### PR TITLE
Fix selected indicator style for left panel

### DIFF
--- a/assets/styles/left/list.sass
+++ b/assets/styles/left/list.sass
@@ -66,11 +66,10 @@
       span
         position: relative
         display: block
-        top: 50%
+        top: 25px
         left: -15px
         width: 20px
         height: 20px
-        margin-top: -11px
         border: 1px solid $color-border-normal
         @include rotate(45deg)
         @include box-shadow($color-border-normal 0 1px 8px 0)


### PR DESCRIPTION
I think it will be better to fix position of selected project indicator in left panel.
So when you toggle project info it doesn't jump around, and info separator doesn't detach right border. 

Here is some screenshots.
Before: http://cl.ly/image/3v3L2w0K3S1K
After:  http://cl.ly/image/200o3i1l1b3b 
