### PR TITLE
Fixes Slow Scrolling on Pages with Gigantic Logs

### DIFF
--- a/assets/styles/main/log.sass
+++ b/assets/styles/main/log.sass
@@ -19,7 +19,6 @@ pre#log
   overflow-x: scroll
 
   p
-    position: relative
     padding: 0 15px 0 50px
     margin: 0
     min-height: 16px
@@ -28,8 +27,8 @@ pre#log
     &.highlight
       background-color: $color-bg-log-highlight
     a
-      position: absolute
       margin-left: -40px
+      margin-right: 10px
       cursor: pointer
 
   .fold


### PR DESCRIPTION
I've only tested this on Chrome for the Mac. 

The logs appear identical, but layout much quicker due to not using position relative / fixed.
