### PR TITLE
Don't hide overflow on #main.

### DIFF
--- a/assets/styles/layout.sass
+++ b/assets/styles/layout.sass
@@ -54,7 +54,6 @@ html, body
   -moz-box-flex: 4
   -webkit-box-flex: 4
   position: relative
-  overflow: hidden
   min-width: 630px
   padding: 20px 40px 80px 30px
 


### PR DESCRIPTION
This fixes https://github.com/travis-ci/travis-ci/issues/750 for me. Tested on Linux with Chrome 22 and Firefox 16.0.1.
