### PR TITLE
Fix info icon overlapping tabs (in Firefox).

### DIFF
--- a/assets/scripts/app/templates/repos/list.hbs
+++ b/assets/scripts/app/templates/repos/list.hbs
@@ -4,8 +4,6 @@
 
 {{view Travis.ReposListTabsView}}
 
-<a {{action toggleInfo target="view"}} class="toggle-info"></a>
-
 <div class="tab">
   {{#collection Travis.ReposListView contentBinding="controller"}}
     {{#with view.repo}}

--- a/assets/scripts/app/templates/repos/list/tabs.hbs
+++ b/assets/scripts/app/templates/repos/list/tabs.hbs
@@ -8,5 +8,6 @@
   <li id="tab_search" {{bindAttr class="view.classSearch"}}>
     <h5><a name="search" {{action activate target="view"}}>{{t layouts.application.search}}</a></h5>
   </li>
-</ul>
 
+  <a {{action toggleInfo target="view"}} class="toggle-info"></a>
+</ul>

--- a/assets/scripts/app/views/repo/list.coffee
+++ b/assets/scripts/app/views/repo/list.coffee
@@ -2,9 +2,6 @@
   ReposView: Travis.View.extend
     templateName: 'repos/list'
 
-    toggleInfo: (event) ->
-      $('#repos').toggleClass('open')
-
   ReposListView: Em.CollectionView.extend
     elementId: 'repos'
     tagName: 'ul'
@@ -51,3 +48,6 @@
     classSearch: (->
       'active' if @get('tab') == 'search'
     ).property('tab')
+
+    toggleInfo: (event) ->
+      $('#repos').toggleClass('open')

--- a/assets/styles/left.sass
+++ b/assets/styles/left.sass
@@ -12,7 +12,7 @@
       padding: 0 0 0 10px
       color: $color-text
       font-size: $font-size-small
-      box-sizing: border-box
+      @include box-sizing(border-box)
       border: 1px solid $color-border-light
       @include border-radius(4px)
       background: $color-bg-input inline-image('ui/search.png') no-repeat right 8px
@@ -26,10 +26,9 @@
       display: inline-block
 
   .toggle-info
-    position: absolute
-    right: 20px
-    margin-top: -22px
-    display: block
+    margin: 8px 20px 0 20px
+    display: inline-block
+    float: right
     width: 14px
     height: 14px
     background-image: inline-image('ui/info.png')


### PR DESCRIPTION
These are two minor fixes for Firefox: 
1. Info icon is overlapping tabs if left panel width is two small.
2. FF supports `-moz-box-sizing`, but not `box-sizing`, so we need to use SASS `box-sizing` mixin.

Before:

![Before](https://www.evernote.com/shard/s87/sh/1f5f0c78-ab13-41a9-9c71-7f2270a098b9/fc853ecfdb569cc10d4f8a839a94fd77/res/5ee5fa4b-56f6-45f8-8888-27252ddb80ac/skitch.png?resizeSmall&width=832)

After:

![After](https://www.evernote.com/shard/s87/sh/537946ff-2461-412d-830d-c0ea2433d8b1/7e99a7513ea74d382f3ba975a027ae3e/res/86f7c0b0-38a9-4b68-bdbd-75f1a4add56e/skitch.png?resizeSmall&width=832)

As far as I can tell, Chrome renders everything as it did before.

Btw, Firefox acts very aggressive about left panel's `min-width` and always tries to keep it as narrow as possible. As the result, left panel is resized almost every time user switches tabs, runs search, or reveals repos' descriptions. It's quite annoying, but, unfortunately, I wasn't able to fix it ;( If someone has any advice, I'd be very happy to hear it.
