### PR TITLE
Updated links to GitHub hooks page

### DIFF
--- a/assets/scripts/app/helpers/urls.coffee
+++ b/assets/scripts/app/helpers/urls.coffee
@@ -30,7 +30,7 @@
     "http://github.com/#{slug}/network"
 
   githubAdmin: (slug) ->
-    "http://github.com/#{slug}/admin/hooks#travis_minibucket"
+    "http://github.com/#{slug}/settings/hooks#travis_minibucket"
 
   statusImage: (slug, branch) ->
     "#{location.protocol}//#{location.host}/#{slug}.png" + if branch then "?branch=#{branch}" else ''

--- a/assets/scripts/app/models/hook.coffee
+++ b/assets/scripts/app/models/hook.coffee
@@ -19,7 +19,7 @@ require 'travis/model'
   ).property()
 
   urlGithubAdmin: (->
-    "http://github.com/#{@get('slug')}/admin/hooks#travis_minibucket"
+    "http://github.com/#{@get('slug')}/settings/hooks#travis_minibucket"
   ).property()
 
   toggle: ->


### PR DESCRIPTION
Hey,

I tried to setup a new Travis testing for my project and noticed that the link to GitHub hooks page gives 404.

The problem is that the GitHub URL changed from  `/admin/hooks` to `/settings/hooks`. 

This pull request fixes that.
