### PR TITLE
WIP! Added first level instrumentation for travis-web

### DIFF
--- a/assets/scripts/app/app.coffee
+++ b/assets/scripts/app/app.coffee
@@ -13,6 +13,7 @@ require 'views'
 require 'config/locales'
 require 'data/sponsors'
 
+require 'travis/instrumentation'
 # $.mockjaxSettings.log = false
 # Ember.LOG_BINDINGS = true
 # Ember.ENV.RAISE_ON_DEPRECATION = true

--- a/assets/scripts/lib/travis/instrumentation.coffee
+++ b/assets/scripts/lib/travis/instrumentation.coffee
@@ -1,0 +1,8 @@
+Travis.Instrumentation = {
+  subscribe: (event) ->
+    Em.subscribe event,
+      before:(name, timestamp, payload) ->
+        timestamp
+      after: (name, timestamp, payload, start_timestamp) ->
+        console.log(name, payload, timestamp - start_timestamp)
+}


### PR DESCRIPTION
This is not enabled by default. You need to run:

Travis.Instrumentation.subscribe('render.view')

To start capturing info
