### PR TITLE
Select current branch in status images popup.

### DIFF
--- a/assets/scripts/app/templates/repos/show/tools.hbs
+++ b/assets/scripts/app/templates/repos/show/tools.hbs
@@ -44,7 +44,7 @@
   </p>
   <p>
     <label>{{t repositories.image_url}}:</label>
-    <input type="text" class="url" {{bindAttr value="view.urlStatusImage"}}></input>
+    <input type="text" class="url" {{bindAttr value="view.statusImageUrl"}}></input>
   </p>
   <p>
     <label>{{t repositories.markdown}}:</label>

--- a/assets/scripts/app/views/repo/show.coffee
+++ b/assets/scripts/app/views/repo/show.coffee
@@ -184,22 +184,22 @@
       'https://' + location.host + Travis.Urls.repo(@get('repo.slug'))
     ).property('repo.slug')
 
-    urlStatusImage: (->
+    statusImageUrl: (->
       Travis.Urls.statusImage(@get('repo.slug'), @get('statusImageBranch.commit.branch'))
     ).property('repo.slug', 'statusImageBranch')
 
     markdownStatusImage: (->
-      "[![Build Status](#{@get('urlStatusImage')})](#{@get('urlRepo')})"
-    ).property('urlStatusImage')
+      "[![Build Status](#{@get('statusImageUrl')})](#{@get('urlRepo')})"
+    ).property('statusImageUrl')
 
     textileStatusImage: (->
-      "!#{@get('urlStatusImage')}!:#{@get('urlRepo')}"
-    ).property('urlStatusImage')
+      "!#{@get('statusImageUrl')}!:#{@get('urlRepo')}"
+    ).property('statusImageUrl')
 
     rdocStatusImage: (->
-      "{<img src=\"#{@get('urlStatusImage')}\" alt=\"Build Status\" />}[#{@get('urlRepo')}]"
-    ).property('urlStatusImage')
+      "{<img src=\"#{@get('statusImageUrl')}\" alt=\"Build Status\" />}[#{@get('urlRepo')}]"
+    ).property('statusImageUrl')
 
     asciidocStatusImage: (->
-      "image:#{@get('urlStatusImage')}[\"Build Status\", link=\"#{@get('urlRepo')}\"]"
-    ).property('urlStatusImage')
+      "image:#{@get('statusImageUrl')}[\"Build Status\", link=\"#{@get('urlRepo')}\"]"
+    ).property('statusImageUrl')


### PR DESCRIPTION
This is an attempt to implement #53 feature request: select current build's branch in the status images popup by default. It doesn't reset selected branch each time the popup is open, so until you switch to a different build, popup will 'remember' selected branch.

I tried to use view's `'branches'` property instead of `'repo.branches'`, but for some reason the resulting behavior was pretty weird. Probably because of this `if @get('active')` condition in the `'branches'` property definition.
