### PR TITLE
Slit out #main content sponsor Sass

### DIFF
--- a/assets/styles/main/log.sass
+++ b/assets/styles/main/log.sass
@@ -105,18 +105,3 @@ pre#log
 
   &.active .status
     background-color: #6b0
-
-#main
-  .sponsor
-    float: left
-    margin-top: 0
-    color: #999
-  .to-top
-    float: right
-    margin-right: 2px
-    padding-right: 16px
-    color: #999
-    background: inline-image('ui/to-top.png') no-repeat right 6px
-
-
-

--- a/assets/styles/main/sponsors.sass
+++ b/assets/styles/main/sponsors.sass
@@ -1,0 +1,11 @@
+#main
+  .sponsor
+    float: left
+    margin-top: 0
+    color: #999
+  .to-top
+    float: right
+    margin-right: 2px
+    padding-right: 16px
+    color: #999
+    background: inline-image('ui/to-top.png') no-repeat right 6px


### PR DESCRIPTION
These classes aren't part of the log, so they should be separated out like the rest
