### PR TITLE
Better align of build numbers in right column

### DIFF
--- a/assets/styles/right/lists.sass
+++ b/assets/styles/right/lists.sass
@@ -38,6 +38,7 @@
     .name,
     .slug
       display: inline-block
+      display: -moz-inline-stack
       overflow: hidden
       white-space: nowrap
       text-overflow: ellipsis


### PR DESCRIPTION
This is only fix for FF, checked on chrome few last versions,
safari 5.1 and 6, FF above 15.

P.S. You must merge this. I took "I work for travis" sticker on some conference and I hadn't noticed that it is "I work..." not "I love..." or something like that. So it was on my macbook pretty and shining but I was living in a lie. So then my macbook crashed (ok, I helped it a little bit) and I am quite sure that it was some of Travis' black magic. I saw Sven's long hair on some photo so it had to be black magic... I like my new macbook so you know...
