### PR TITLE
Correct spelling in translation key

### DIFF
--- a/assets/scripts/app/templates/sponsors/decks.hbs
+++ b/assets/scripts/app/templates/sponsors/decks.hbs
@@ -1,4 +1,4 @@
-<h4>{{t layouts.application.sponsers}}</h4>
+<h4>{{t layouts.application.sponsors}}</h4>
 
 <ul class="sponsors top">
   {{#each deck in controller}}

--- a/assets/scripts/app/templates/sponsors/links.hbs
+++ b/assets/scripts/app/templates/sponsors/links.hbs
@@ -1,5 +1,5 @@
 <div class="box">
-  <h4>{{t layouts.application.sponsers}}</h4>
+  <h4>{{t layouts.application.sponsors}}</h4>
 
   <ul class="sponsors bottom">
     {{#each controller}}

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -70,7 +70,7 @@ en:
       my_repositories: My Repositories
       recent: Recent
       search: Search
-      sponsers: Sponsors
+      sponsors: Sponsors
       sponsors_link: See all of our amazing sponsors &rarr;
     mobile:
       author: Author

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -70,7 +70,7 @@ es:
       my_repositories: Mis Repositorios
       recent: Reciente
       search: Buscar
-      sponsers: Patrocinadores
+      sponsors: Patrocinadores
       sponsors_link: Ver todos nuestros patrocinadores &rarr;
     mobile:
       author: Autor

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -70,7 +70,7 @@ fr:
       my_repositories: Mes dépôts
       recent: Récent
       search: Chercher
-      sponsers: Sponsors
+      sponsors: Sponsors
       sponsors_link: Voir tous nos extraordinaire sponsors &rarr;
     mobile:
       author: Auteur

--- a/locales/ja.yml
+++ b/locales/ja.yml
@@ -64,7 +64,7 @@ ja:
       my_repositories: マイリポジトリ
       recent: 最近
       search: 検索
-      sponsers: スポンサー
+      sponsors: スポンサー
       sponsors_link: スポンサーをもっと見る &rarr;
     mobile:
       author: 制作者

--- a/locales/nb.yml
+++ b/locales/nb.yml
@@ -70,7 +70,7 @@ nb:
       my_repositories: Mine kodelagre
       recent: Nylig
       search: Søk
-      sponsers: Sponsorer
+      sponsors: Sponsorer
       sponsors_link: Se alle de flotte sponsorene våre &rarr;
     mobile:
       author: Forfatter

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -70,7 +70,7 @@ nl:
       my_repositories: Mijn repositories
       recent: Recent
       search: Zoeken
-      sponsers: Sponsors
+      sponsors: Sponsors
       sponsors_link: Bekijk al onze geweldige sponsors &rarr;
     mobile:
       author: Auteur

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -73,7 +73,7 @@ pl:
       my_repositories: Moje Repozytoria
       recent: Ostatnie
       search: Wyniki
-      sponsers: Sponsorzy
+      sponsors: Sponsorzy
       sponsors_link: Zobacz naszych wszystkich wspaniałych sponsorów &rarr;
     mobile:
       author: Autor

--- a/locales/pt-BR.yml
+++ b/locales/pt-BR.yml
@@ -70,7 +70,7 @@ pt-BR:
       my_repositories: Meus Repositórios
       recent: Recentes
       search: Buscar
-      sponsers: Patrocinadores
+      sponsors: Patrocinadores
       sponsors_link: Conheça todos os nossos patrocinadores &rarr;
     mobile:
       author: Autor

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -76,7 +76,7 @@ ru:
       my_repositories: Мои репозитории
       recent: Недавние
       search: Поиск
-      sponsers: Спонсоры
+      sponsors: Спонсоры
       sponsors_link: Список всех наших замечательных спонсоров &rarr;
     mobile:
       author: Автор


### PR DESCRIPTION
Sponsors was misspelled as sponsers in one of the translation keys.
