### PR TITLE
Adding missed documentation link in profile

### DIFF
--- a/locales/de.yml
+++ b/locales/de.yml
@@ -118,7 +118,7 @@ de:
       locale: Sprache
       message:
         config: Wie du eigene Build-Optionen konfigurieren kannst
-        your_repos: Lege die Schalter unten um, um den Travis Dienst-Hook für deine Projekte zu aktivieren, dann pushe zu GitHub.<br />\n  Um gegen mehrere Rubine zu testen, sehe
+        your_repos: Lege die Schalter unten um, um den Travis Dienst-Hook für deine Projekte zu aktivieren, dann pushe zu GitHub.<br />\n  Um gegen mehrere Rubies zu testen, siehe <a href=\\"http://about.travis-ci.org/docs/user/languages/ruby/#Choosing-Ruby-versions-implementations-to-test-against\\">hier.</a>
       messages:
         notice: Bitte lese dir unser <a href=\\"http://about.travis-ci.org/docs/user/getting-started/\\">Getting Started-Handbuch</a> durch, um loszulegen.\\n  <small>Es dauert nur ein paar Minuten.</small>
       token: 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -118,7 +118,7 @@ en:
       locale: locale
       message:
         config: how to configure custom build options
-        your_repos: ! "  Flick the switches below to turn on the Travis service hook for your projects, then push to GitHub.<br />\n  To test against multiple rubies, see"
+        your_repos: ! "  Flick the switches below to turn on the Travis service hook for your projects, then push to GitHub.<br />\n  To test against multiple rubies, see <a href=\"http://about.travis-ci.org/docs/user/languages/ruby/#Choosing-Ruby-versions-implementations-to-test-against\">here.</a>"
       messages:
         notice: ! "To get started, please read our <a href=\"http://about.travis-ci.org/docs/user/getting-started/\">Getting Started guide</a>.\n  <small>It will only take a couple of minutes.</small>"
       token: Token


### PR DESCRIPTION
At the Travis Pro profile page the sentence
"Flick the switches below to turn on the Travis service hook for your projects, then push to GitHub. To test against multiple rubies, see" is missing the link.

I added it for EN an DE.

Greetz and keep on the good work! 
SweeD
