### PR TITLE
Make 'My Repos' come before 'Recent' in sidebar

### DIFF
--- a/assets/scripts/app/controllers/repos.coffee
+++ b/assets/scripts/app/controllers/repos.coffee
@@ -1,7 +1,7 @@
 require 'travis/limited_array'
 
 Travis.ReposController = Ember.ArrayController.extend
-  defaultTab: 'recent'
+  defaultTab: 'owned'
   isLoadedBinding: 'content.isLoaded'
   needs: ['currentUser', 'repo']
   currentUserBinding: 'controllers.currentUser'

--- a/assets/scripts/app/templates/repos/list/tabs.hbs
+++ b/assets/scripts/app/templates/repos/list/tabs.hbs
@@ -1,10 +1,12 @@
 <ul class="tabs">
-  <li id="tab_recent" {{bindAttr class="view.classRecent"}}>
-    <h5><a {{action activate "recent" target="view"}}>{{t layouts.application.recent}}</a></h5>
-  </li>
   <li id="tab_owned" {{bindAttr class="view.classOwned"}}>
     <h5><a {{action activate "owned" target="view"}}>{{t layouts.application.my_repositories}}</a></h5>
   </li>
+
+  <li id="tab_recent" {{bindAttr class="view.classRecent"}}>
+    <h5><a {{action activate "recent" target="view"}}>{{t layouts.application.recent}}</a></h5>
+  </li>
+
   <li id="tab_search" {{bindAttr class="view.classSearch"}}>
     <h5><a {{action activate "search" target="view"}}>{{t layouts.application.search}}</a></h5>
   </li>


### PR DESCRIPTION
I would like to suggest a small change to the design of the sidebar. The sidebar has two tabs - 'My Repos' and 'Recent Builds' - and currently, Recent Builds is the default tab. I think we should change it to default to My Repos, since this information would be more important to users who are coming to the site to check up on the status of their projects.
