### PR TITLE
Add GitHub mark to GitHub links

### DIFF
--- a/assets/styles/main/repository.sass
+++ b/assets/styles/main/repository.sass
@@ -60,5 +60,5 @@
     a[href^="http://www.github.com"]
       &:hover
         background: transparent url(/images/icons/github.png) center right no-repeat
-        background-size: 10px
-      padding-right: 18px
+        background-size: 12px
+      padding-right: 16px


### PR DESCRIPTION
This was requested in #95.

Adds a little 10x10px GitHub mark to every GitHub link in the main
frame.

![screen shot 2013-05-06 at 5 35 48 am](https://f.cloud.github.com/assets/24421/465607/74b18a58-b639-11e2-9366-8328fb870c27.png)
