### PR TITLE
Remove conditional ga HTTPS loading

### DIFF
--- a/assets/scripts/vendor/ga.js
+++ b/assets/scripts/vendor/ga.js
@@ -3,7 +3,10 @@ var setupGoogleAnalytics = function() {
   _gaq.push(['_setAccount', Travis.config.ga_code]);
   _gaq.push(['_trackPageview']);
 
-  var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-  ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-  var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+  var ga = document.createElement('script');
+  ga.type = 'text/javascript';
+  ga.async = true;
+  ga.src = 'https://ssl.google-analytics.com/ga.js';
+  var s = document.getElementsByTagName('script')[0];
+  s.parentNode.insertBefore(ga, s);
 }


### PR DESCRIPTION
Shortcut since site is always secure.
Fixes gh-137
