### PR TITLE
remove the (i) from the top right of the tabs

### DIFF
--- a/assets/scripts/app/templates/repos/list.hbs
+++ b/assets/scripts/app/templates/repos/list.hbs
@@ -27,12 +27,6 @@
       </p>
 
       <div class="indicator"><span></span></div>
-
-      {{#if description}}
-        <div class="info">
-          <p class="description">{{description}}</p>
-        </div>
-      {{/if}}
     {{/with}}
   {{else}}
     <p class="empty"></p>

--- a/assets/scripts/app/templates/repos/list/tabs.hbs
+++ b/assets/scripts/app/templates/repos/list/tabs.hbs
@@ -10,6 +10,4 @@
   <li id="tab_search" {{bindAttr class="view.classSearch"}}>
     <h5><a {{action activate "search" target="view"}}>{{t layouts.application.search}}</a></h5>
   </li>
-
-  <a {{action toggleInfo target="view"}} class="toggle-info"></a>
 </ul>

--- a/assets/scripts/app/views/repo/list.coffee
+++ b/assets/scripts/app/views/repo/list.coffee
@@ -43,6 +43,3 @@
     classSearch: (->
       'active' if @get('tab') == 'search'
     ).property('tab')
-
-    toggleInfo: ->
-      $('#repos').toggleClass('open')

--- a/assets/styles/left.sass
+++ b/assets/styles/left.sass
@@ -17,12 +17,3 @@
       @include border-radius(4px)
       background: $color-bg-input inline-image('ui/search.png') no-repeat right 8px
 
-  .toggle-info
-    margin: 8px 20px 0 20px
-    display: inline-block
-    float: right
-    width: 14px
-    height: 14px
-    background-image: inline-image('ui/info.png')
-    cursor: pointer
-


### PR DESCRIPTION
the (i) is a miscommunication as it looks like it is to give information about the tabs instead of pop down descriptions underneath each of the repos in the recent and 'my repos' lists.
