### PR TITLE
Only run Saucelabs test with secure variables

### DIFF
--- a/script/ci
+++ b/script/ci
@@ -6,7 +6,7 @@ elif [ "$TEST_SUITE" == "phantomjs" ]; then
   bundle exec rackup -s puma -p 5000 -D
   sleep 3
   ./run_jasmine.coffee http://localhost:5000/spec.html
-elif [ "$TEST_SUITE" == "saucelabs" ]; then
+elif [ "$TRAVIS_SECURE_ENV_VARS" == "true" && "$TEST_SUITE" == "saucelabs" ]; then
   bundle exec rackup -s puma -p 5000 -D
   sleep 3
   curl https://gist.github.com/santiycr/5139565/raw/sauce_connect_setup.sh | bash


### PR DESCRIPTION
This is intended to short circut PRs so that they don't get marked as failed when they don't have access to the Sauce vars.
