### PR TITLE
Get rid of 'controllerFor' deprecation warnings

### DIFF
--- a/assets/scripts/app/controllers/repo.coffee
+++ b/assets/scripts/app/controllers/repo.coffee
@@ -51,7 +51,7 @@ Travis.RepoController = Travis.Controller.extend
 
   lastBuildDidChange: ->
     build = @get('repo.lastBuild')
-    @controllerFor('build').set('build', build)
+    @set('build', build)
 
   stopObservingLastBuild: ->
     @removeObserver('repo.lastBuild', this, 'lastBuildDidChange')


### PR DESCRIPTION
`RepoController` already declares `needs` but `lastBuildDidChange` still uses `controllerFor`.
