### PR TITLE
Line numbers and log content should be aligned

### DIFF
--- a/assets/styles/main/log.sass
+++ b/assets/styles/main/log.sass
@@ -32,8 +32,9 @@ pre#log
       a
         color: white
     a
-      // display: inline-block
-      // min-width: 30px
+      display: inline-block
+      text-align: right
+      min-width: 40px
       margin-left: -33px
       cursor: pointer
       text-decoration: none
@@ -42,7 +43,6 @@ pre#log
         content: counter(line-numbering)
         counter-increment: line-numbering
         padding-right: 1em
-        text-align: right
 
   .fold
     height: 16px


### PR DESCRIPTION
This is a really small cosmetic issue, but notice it every time :eyes: 

![travis ci - free hosted continuous integration platform for the open source community 2013-11-20 12-11-20](https://f.cloud.github.com/assets/43297/1581372/7b3f459a-51d4-11e3-9027-f945f7939150.png)

There's a way around it by making `pre#log p a` `display: inline-block` and set a `width` or `min-width`, but I guess the clean way would be to do it like GitHub: change the template to use tables so the line number can share the same size.

What do you think? I'd be interested in sending a PR for either of those solutions.

Edit: Looks like someone had the same idea already: it's commented in the current code :) https://github.com/gregkare/travis-web/blob/d4ae21251eb69dc068162db25c33dc254964d5ac/assets/styles/main/log.sass#L35-L36
