### PR TITLE
Fluid scrolling buttons

### DIFF
--- a/assets/scripts/app/tailing.coffee
+++ b/assets/scripts/app/tailing.coffee
@@ -45,8 +45,9 @@ $.extend Travis.Tailing.prototype,
     offset = $(window).scrollTop() - $('#log').offset().top
     max = $('#log').height() - $('#tail').height() + 5
     offset = max if offset > max
+
     if offset > 0
-      tail.css(top: offset - 2)
+      tail.css(position: 'fixed', right: 32)
     else
-      tail.css(top: 0)
+      tail.css(position: 'absolute', right: 2)
 

--- a/assets/scripts/app/templates/jobs/pre.hbs
+++ b/assets/scripts/app/templates/jobs/pre.hbs
@@ -1,7 +1,14 @@
 <div id="log-container">
   <a href="#" id="tail" {{action "toggleTailing" target="view"}}>
     <span class="status"></span>
-    <label>Follow logs</label>
+
+    <label>
+      {{#if view.job.isFinished}}
+        Scroll to end of logs
+      {{else}}
+        Follow logs
+      {{/if}}
+    </label>
   </a>
   <pre id="log" class="ansi"></pre>
 

--- a/assets/scripts/app/views/log.coffee
+++ b/assets/scripts/app/views/log.coffee
@@ -97,8 +97,9 @@ Travis.reopen
       window.history.pushState({ path: path }, null, path);
       @set('controller.lineNumber', number)
 
-    toTop: () ->
-      $(window).scrollTop(0)
+    actions:
+      toTop: () ->
+        $(window).scrollTop(0)
 
     noop: -> # TODO required?
 

--- a/assets/styles/main/log.sass
+++ b/assets/styles/main/log.sass
@@ -86,44 +86,58 @@ pre#log
 #log-container
   position: relative
 
-#log-container #tail
-  z-index: 99
-  position: absolute
-  display: block
-  top: 0
-  right: 2px
-  margin: 13px 10px 0 0
-  padding: 0 2px 0 3px
-  color: #666
-  text-shadow: 0px 1px 0px #fff
-  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif
-  font-size: $font-size-tiny
-  line-height: 14px
-  text-decoration: none
-  white-space: nowrap
-  border: 1px solid #bbb
-  border-top-color: #ddd
-  border-bottom-color: #bbb
-  @include border-radius(8px)
-  @include background(linear-gradient(#fff, #e0e0e0))
+#log-container
+  #tail
+    z-index: 99
+    position: absolute
+    display: block
+    top: 0
+    right: 2px
+    margin: 13px 10px 0 0
+    padding: 0 2px 0 3px
+    color: #666
+    text-shadow: 0px 1px 0px #fff
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif
+    font-size: $font-size-tiny
+    line-height: 14px
+    text-decoration: none
+    white-space: nowrap
+    border: 1px solid #bbb
+    border-top-color: #ddd
+    border-bottom-color: #bbb
+    @include border-radius(8px)
+    @include background(linear-gradient(#fff, #e0e0e0))
 
-  label
-    display: none
-    cursor: pointer
-
-  &:hover
-    padding: 1px 4px 1px 6px
     label
-      display: inline
+      display: none
+      cursor: pointer
 
-  .status
+    &:hover
+      padding: 1px 4px 1px 6px
+      label
+        display: inline
+
+    .status
+      display: inline-block
+      margin-right: 1px
+      width: 8px
+      height: 8px
+      background-color: #aaa
+      @include border-radius(4px)
+      @include box-shadow(white 1px 1px 2px)
+
+    &.active .status
+      background-color: #6b0
+
+  .to-top
+    position: fixed
     display: inline-block
-    margin-right: 1px
-    width: 8px
-    height: 8px
-    background-color: #aaa
-    @include border-radius(4px)
-    @include box-shadow(white 1px 1px 2px)
-
-  &.active .status
-    background-color: #6b0
+    bottom: 5px
+    right: 35px
+    width: 50px
+    float: right
+    margin-right: 2px
+    padding-right: 16px
+    text-align: right
+    color: #999
+    background: inline-image('ui/to-top.png') no-repeat right 6px

--- a/assets/styles/main/sponsors.sass
+++ b/assets/styles/main/sponsors.sass
@@ -3,12 +3,3 @@
     // float: left
     margin-top: 0
     color: #999
-  .to-top
-    display: inline-block
-    width: 50px
-    float: right
-    margin-right: 2px
-    padding-right: 16px
-    text-align: right
-    color: #999
-    background: inline-image('ui/to-top.png') no-repeat right 6px


### PR DESCRIPTION
This fluidifies the positionning of the follow the logs button.
We're relying on the browser to define it's position instead of setting the top at each scroll.

Also, as suggest by @joshk in #89, if the build has finished running, it renames the button content to "Scroll to end of logs".

Finally, as per #89, it makes the "back to top" button follow the scroll too.
This button now looks like the following:
![screen shot 2013-12-05 at 16 05 45](https://f.cloud.github.com/assets/9347/1683510/c5fcc440-5dbe-11e3-88a1-62e8fa0a1d29.png)

As a side note, this back to top button might need a bit of redesign, since it now might look weird if the log has a full length.
![screen shot 2013-12-05 at 16 06 18](https://f.cloud.github.com/assets/9347/1683519/f210142e-5dbe-11e3-8a9f-08335ab350aa.png)
