### PR TITLE
Do not githubify sign-off messages

### DIFF
--- a/assets/scripts/app/helpers/helpers.coffee
+++ b/assets/scripts/app/helpers/helpers.coffee
@@ -84,7 +84,7 @@ require 'config/emoij'
 
   _githubReferenceRegexp: new RegExp("([\\w-]+)?\\/?([\\w-]+)?(?:#|gh-)(\\d+)", 'g')
 
-  _githubUserRegexp: new RegExp("@([\\w-]+)", 'g')
+  _githubUserRegexp: new RegExp("^|\\B@([\\w-]+)", 'g')
 
   _githubUserLink: (reference, username) ->
     "<a href=\"http://github.com/#{username}\">#{reference}</a>"

--- a/assets/scripts/spec/unit/helpers_spec.coffee
+++ b/assets/scripts/spec/unit/helpers_spec.coffee
@@ -52,3 +52,9 @@ test 'replaces @user with github user link', ->
   expected = 'It is for you <a href="http://github.com/tender_love1">@tender_love1</a>'
 
   equal(result, expected, "@user should be converted to a link")
+
+test 'does not replace @user if it is a sign-off', ->
+  message = 'Signed-off-by: GitHub User <user@example.com>'
+  result = Travis.Helpers.githubify(message, 'travis-ci', 'travis-web')
+
+  equal(result, message, "@user should not be converted to a link if it matches an email")


### PR DESCRIPTION
Don't successfully `githubify` strings prepended with an `@` symbol if
what's matched actually resembles an email address. @mentions should
only be githubified if there is a word boundary before it.

This fixes travis-ci/travis-ci#1591

Signed-off-by: David Celis me@davidcel.is
