### PR TITLE
Preliminary Multi-OS support

### DIFF
--- a/assets/scripts/travis.coffee
+++ b/assets/scripts/travis.coffee
@@ -82,7 +82,7 @@ $.extend Travis,
     code_climate: $('meta[name="travis.code_climate"]').attr('value')
     code_climate_url: $('meta[name="travis.code_climate_url"]').attr('value')
 
-  CONFIG_KEYS: ['go', 'rvm', 'gemfile', 'env', 'jdk', 'otp_release', 'php', 'node_js', 'perl', 'python', 'scala', 'compiler', 'ghc']
+  CONFIG_KEYS: ['go', 'rvm', 'gemfile', 'env', 'jdk', 'otp_release', 'php', 'node_js', 'perl', 'python', 'scala', 'compiler', 'ghc', 'os']
 
   QUEUES: [
     { name: 'linux',   display: 'Linux' }


### PR DESCRIPTION
Include `os` in the Matrix table. This makes travis-ci/travis-core#306 much more pleasant to look at.
