### PR TITLE
Build Matrix keys should be more flexible than just being camelized

### DIFF
--- a/assets/scripts/app/helpers/helpers.coffee
+++ b/assets/scripts/app/helpers/helpers.coffee
@@ -26,12 +26,12 @@ require 'config/emoij'
     (sha || '').substr(0, 7)
 
   formatConfig: (config) ->
-    config = $.only config, Travis.CONFIG_KEYS
+    config = $.only config, Object.keys(Travis.CONFIG_KEYS_MAP)
     values = $.map config, (value, key) ->
       value = (if value && value.join then value.join(', ') else value) || ''
       if key == 'rvm' && "#{value}".match(/^\d+$/)
         value = "#{value}.0"
-      '%@: %@'.fmt $.camelize(key), value
+      '%@: %@'.fmt Travis.CONFIG_KEYS_MAP[key], value
     if values.length == 0 then '-' else values.join(', ')
 
   formatMessage: (message, options) ->
@@ -116,4 +116,4 @@ require 'config/emoij'
 
   configKeys: (config) ->
     return [] unless config
-    $.intersect($.keys(config), Travis.CONFIG_KEYS)
+    $.intersect($.keys(config), Object.keys(Travis.CONFIG_KEYS_MAP))

--- a/assets/scripts/app/models/build.coffee
+++ b/assets/scripts/app/models/build.coffee
@@ -57,7 +57,7 @@ require 'travis/model'
   configKeys: (->
     keys = @get('rawConfigKeys')
     headers = (I18n.t(key) for key in ['build.job', 'build.duration', 'build.finished_at'])
-    $.map(headers.concat(keys), (key) -> return $.camelize(key))
+    $.map(headers.concat(keys), (key) -> if Travis.CONFIG_KEYS_MAP.hasOwnProperty(key) then Travis.CONFIG_KEYS_MAP[key] else key)
   ).property('rawConfigKeys.length')
 
   canCancel: (->

--- a/assets/scripts/spec/integration/build_spec.coffee
+++ b/assets/scripts/spec/integration/build_spec.coffee
@@ -34,7 +34,7 @@ test "displaying information on build page", ->
 
     listsJobs
       table: '#jobs'
-      headers: ['Job', 'Duration', 'Finished', 'Rvm']
+      headers: ['Job', 'Duration', 'Finished', 'Ruby']
       jobs: [
         { color: 'green', id: 1, number: '1.1', repo: 'travis-ci/travis-core', finishedAt: '3 minutes ago', duration: '30 sec', rvm: 'rbx' }
         { color: 'red',   id: 2, number: '1.2', repo: 'travis-ci/travis-core', finishedAt: '2 minutes ago', duration: '40 sec', rvm: '1.9.3' }
@@ -42,7 +42,7 @@ test "displaying information on build page", ->
 
     listsJobs
       table: '#allowed_failure_jobs'
-      headers: ['Job', 'Duration', 'Finished', 'Rvm']
+      headers: ['Job', 'Duration', 'Finished', 'Ruby']
       jobs: [
         { color: '', id: 3, number: '1.3', repo: 'travis-ci/travis-core', finishedAt: '-', duration: '-', rvm: 'jruby' }
       ]

--- a/assets/scripts/spec/integration/current_spec.coffee
+++ b/assets/scripts/spec/integration/current_spec.coffee
@@ -34,7 +34,7 @@ test "displaying information on repo page", ->
 
     listsJobs
       table: '#jobs'
-      headers: ['Job', 'Duration', 'Finished', 'Rvm']
+      headers: ['Job', 'Duration', 'Finished', 'Ruby']
       jobs: [
         { id: 1, color: 'green', number: '1.1', repo: 'travis-ci/travis-core', finishedAt: '3 minutes ago', duration: '30 sec', rvm: 'rbx' }
         { id: 2, color: 'red',   number: '1.2', repo: 'travis-ci/travis-core', finishedAt: '2 minutes ago', duration: '40 sec', rvm: '1.9.3' }
@@ -42,7 +42,7 @@ test "displaying information on repo page", ->
 
     listsJobs
       table: '#allowed_failure_jobs'
-      headers: ['Job', 'Duration', 'Finished', 'Rvm']
+      headers: ['Job', 'Duration', 'Finished', 'Ruby']
       jobs: [
         { id: 3, color: '', number: '1.3', repo: 'travis-ci/travis-core', finishedAt: '-', duration: '-', rvm: 'jruby' }
       ]

--- a/assets/scripts/spec/integration/index_spec.coffee
+++ b/assets/scripts/spec/integration/index_spec.coffee
@@ -34,7 +34,7 @@ test "displaying information on index page", ->
 
     listsJobs
       table: '#jobs'
-      headers: ['Job', 'Duration', 'Finished', 'Rvm']
+      headers: ['Job', 'Duration', 'Finished', 'Ruby']
       jobs: [
         { color: 'green', id: 1, number: '1.1', repo: 'travis-ci/travis-core', finishedAt: '3 minutes ago', duration: '30 sec', rvm: 'rbx' }
         { color: 'red',   id: 2, number: '1.2', repo: 'travis-ci/travis-core', finishedAt: '2 minutes ago', duration: '40 sec', rvm: '1.9.3' }
@@ -42,7 +42,7 @@ test "displaying information on index page", ->
 
     listsJobs
       table: '#allowed_failure_jobs'
-      headers: ['Job', 'Duration', 'Finished', 'Rvm']
+      headers: ['Job', 'Duration', 'Finished', 'Ruby']
       jobs: [
         { color: '', id: 3, number: '1.3', repo: 'travis-ci/travis-core', finishedAt: '-', duration: '-', rvm: 'jruby' }
       ]

--- a/assets/scripts/spec/unit/build_spec.coffee
+++ b/assets/scripts/spec/unit/build_spec.coffee
@@ -54,4 +54,4 @@ test 'it takes into account all the jobs when getting config keys', ->
     configKeys = build.get('configKeys')
 
   deepEqual(rawConfigKeys, ['rvm', 'env', 'gemfile', 'jdk' ])
-  deepEqual(configKeys, [ 'Job', 'Duration', 'Finished', 'Rvm', 'Env', 'Gemfile', 'Jdk' ])
+  deepEqual(configKeys, [ 'Job', 'Duration', 'Finished', 'Ruby', 'ENV', 'Gemfile', 'JDK' ])

--- a/assets/scripts/travis.coffee
+++ b/assets/scripts/travis.coffee
@@ -82,7 +82,22 @@ $.extend Travis,
     code_climate: $('meta[name="travis.code_climate"]').attr('value')
     code_climate_url: $('meta[name="travis.code_climate_url"]').attr('value')
 
-  CONFIG_KEYS: ['go', 'rvm', 'gemfile', 'env', 'jdk', 'otp_release', 'php', 'node_js', 'perl', 'python', 'scala', 'compiler', 'ghc', 'os']
+  CONFIG_KEYS_MAP: {
+    go:          'Go'
+    rvm:         'Ruby'
+    gemfile:     'Gemfile'
+    env:         'ENV'
+    jdk:         'JDK'
+    otp_release: 'OTP Release'
+    php:         'PHP'
+    node_js:     'Node.js'
+    perl:        'Perl'
+    python:      'Python'
+    scala:       'Scala'
+    compiler:    'Compiler'
+    ghc:         'GHC'
+    os:          'OS'
+  }
 
   QUEUES: [
     { name: 'linux',   display: 'Linux' }


### PR DESCRIPTION
So that we have `PHP` and `RVM`, instead of `Php` and `Rvm`.
