### PR TITLE
feat(repo-tools): show status image popup to everyone

### DIFF
--- a/assets/scripts/app/templates/repos/show/tools.hbs
+++ b/assets/scripts/app/templates/repos/show/tools.hbs
@@ -12,13 +12,9 @@
       </li>
     {{/if}}
   </ul>
-  {{#if view.displayStatusImages}}
   <a href="#" id="status-image-popup" name="status-images" class="open-popup" {{action "statusImages" target="view"}}>
     <img {{bind-attr src="view.statusImageUrl"}} title="Build Status Images"/>
   </a>
-  {{/if}}
-
-
 </div>
 
 <div id="regenerate-key" class="popup">

--- a/assets/scripts/app/views/repo/show.coffee
+++ b/assets/scripts/app/views/repo/show.coffee
@@ -124,10 +124,6 @@ Travis.reopen
       Travis.Urls.statusImage(@get('slug'))
     ).property('slug')
 
-    displayStatusImages: (->
-      @get('hasPermission')
-    ).property('hasPermission')
-
     statusImages: ->
       @popupCloseAll()
       view = Travis.StatusImagesView.create(toolsView: this)


### PR DESCRIPTION
If you can see the repository, then you should also be able to see the status
of said repository (and status image), so you should also be able to copy the
link to a status image.

Close travis-ci/travis-ci#1881.
