### PR TITLE
fix(models): update the endpoint used to restart jobs and builds

### DIFF
--- a/assets/scripts/app/models/build.coffee
+++ b/assets/scripts/app/models/build.coffee
@@ -69,7 +69,7 @@ require 'travis/model'
   )
 
   requeue: ->
-    Travis.ajax.post '/requests', build_id: @get('id')
+    Travis.ajax.post "/builds/#{@get('id')}/restart"
 
   isPropertyLoaded: (key) ->
     if ['_duration', 'finishedAt'].contains(key) && !@get('isFinished')

--- a/assets/scripts/app/models/job.coffee
+++ b/assets/scripts/app/models/job.coffee
@@ -70,7 +70,7 @@ require 'travis/model'
   )
 
   requeue: ->
-    Travis.ajax.post '/requests', job_id: @get('id')
+    Travis.ajax.post "/jobs/#{@get('id')}/restart"
 
   appendLog: (part) ->
     @get('log').append part


### PR DESCRIPTION
`/requests` is deprecated
