### PR TITLE
Build logs open in a new tab

### DIFF
--- a/assets/scripts/app/templates/repos/show/actions.hbs
+++ b/assets/scripts/app/templates/repos/show/actions.hbs
@@ -28,7 +28,7 @@
              does not refresh 'if' properly, need further investigation}}
     {{#if view.jobIdForLog}}
       <li class="icon" title="Download Log">
-        <a class="download-log" {{bind-attr href="view.plainTextLogUrl"}}><img class="icon" src="/images/icons/align-justify.png" width="20"/></a>
+        <a class="download-log" target="travcilogs" {{bind-attr href="view.plainTextLogUrl"}}><img class="icon" src="/images/icons/align-justify.png" width="20"/></a>
       </li>
     {{/if}}
     {{#if view.displayCodeClimate}}


### PR DESCRIPTION
In my use of travis-ci, which I love, I've discovered that it would be beneficial for build logs to open in a new tab so that I can keep my travis-web tab open and synchronized.

The pr introduces a simple target to the anchor that spawns the build log.

Thanks you for your consideration.

Sam
