### PR TITLE
fix(api-redirect): update regex used for determining when to redirect

### DIFF
--- a/lib/travis/web/api_redirect.rb
+++ b/lib/travis/web/api_redirect.rb
@@ -18,7 +18,7 @@ class Travis::Web::ApiRedirect < Sinatra::Base
     end
   end
 
-  get NotPublicImages.new(%r{^/([^/]+)/([^/]+).png}, %r{^/images/}) do
+  get NotPublicImages.new(%r{^/([^/]+)/([^/]+)\.png$}, %r{^/images/}) do
     redirect!
   end
 

--- a/spec/api_redirect_spec.rb
+++ b/spec/api_redirect_spec.rb
@@ -10,4 +10,8 @@ describe Travis::Web::ApiRedirect do
   it 'redirects /:owner/:repo.png' do
     get('/foo/bar.png').should be_redirect
   end
+
+  it 'does not redirect /owner/some-png-repo' do
+    get('/owner/some-png-repo').should_not be_redirect
+  end
 end


### PR DESCRIPTION
With the old redirect, repositories with "png" in the name got redirected as well as images.
