### PR TITLE
Style the "underline" class.

### DIFF
--- a/assets/styles/ansi.sass
+++ b/assets/styles/ansi.sass
@@ -6,8 +6,8 @@
     font-weight: bold
   .italic
     font-style: italic
-  .underscore
-    // monochrome displays only according to http://ascii-table.com/ansi-escape-sequences.php
+  .underline
+    text-decoration: underline
   .black
     color: $ansi-black
   .black.bold


### PR DESCRIPTION
(refs travis-ci/travis-ci#2047)

On me removing the `ansi.underscore` class: it didn't do anything; I couldn’t find any reference to it elsewhere in travis-ci/travis-web or travis-ci/travis-web-log; and I think "underline" is a more appropriate name.

While the reference linked in the comment (http://ascii-table.com/ansi-escape-sequences.php) appears to say that "underscore" should work only on monochrome displays, this [other reference](http://ascii-table.com/ansi-escape-sequences-vt-100.php) doesn’t say that "underline" should be so limited--and I don't think there's any reason to be a stickler anyway: Travis currently supports italic text, which isn't described in either of those references.
