### PR TITLE
Update jobs summary to new format.

### DIFF
--- a/assets/scripts/app/templates/jobs/show.hbs
+++ b/assets/scripts/app/templates/jobs/show.hbs
@@ -29,12 +29,14 @@
 
       <div class="footer">
         <div class="author">
-          {{#if commit.authorName}}
-            <img src="https://travis-ci.org/images/mailer/mascot-avatar-40px.png"/>{{commit.authorName}} authored
+          {{#if job.commit.authorName}}
+            <div class="authored"><img {{bind-attr src="view.urlAuthorGravatarImage"}}/>{{job.commit.authorName}} authored{{#if job.commit.authorIsCommitter}} and committed{{/if}}</div>
           {{/if}}
-          {{#if commit.committerName}}
-            <img src="https://travis-ci.org/images/mailer/mascot-avatar-40px.png"/>{{commit.committerName}} committed
-          {{/if}}
+          {{#unless job.commit.authorIsCommitter}}
+            {{#if job.commit.committerName}}
+              <div class="committed"><img {{bind-attr src="view.urlCommitterGravatarImage"}}/>{{job.commit.committerName}} committed</div>
+            {{/if}}
+          {{/unless}}
         </div>
 
         <div class="commit-changes">

--- a/assets/scripts/app/views/job.coffee
+++ b/assets/scripts/app/views/job.coffee
@@ -30,3 +30,11 @@ Travis.reopen
     urlGithubCommit: (->
       Travis.Urls.githubCommit(@get('repo.slug'), @get('commit.sha'))
     ).property('repo.slug', 'commit.sha')
+
+    urlCommitterGravatarImage: (->
+      Travis.Urls.gravatarImage(@get('commit.committerEmail'), 40)
+    ).property('commit.committerEmail')
+
+    urlAuthorGravatarImage: (->
+      Travis.Urls.gravatarImage(@get('commit.authorEmail'), 40)
+    ).property('commit.authorEmail')


### PR DESCRIPTION
I missed, that summary is not DRY'ed. You can see still old ungravatared summary in the job detail (for example https://travis-ci.org/travis-ci/travis-web/jobs/24764226).

This is just a quickfix to keep it consistent.

I'll try to introduce proper (respecting DRY principle) solution later.
