### PR TITLE
Pesky Scrollbars

### DIFF
--- a/assets/styles/main/log.sass
+++ b/assets/styles/main/log.sass
@@ -15,7 +15,6 @@ pre#log
   word-wrap: break-word
   background-color: $color-bg-log
   border: 1px solid $color-border-log
-  overflow-x: scroll
   counter-reset: line-numbering
 
   .cut


### PR DESCRIPTION
This fixes the pesky scrollbars that show up at the bottom of the build logs unnecessarly.

Before:
![before](https://cloud.githubusercontent.com/assets/3277097/2964631/c0c751e6-dae8-11e3-829e-d85e6b4b1017.png)

After:
![image](https://cloud.githubusercontent.com/assets/3277097/2964653/fea76992-dae8-11e3-959c-9dc5c428c52a.png)
