### PR TITLE
Changed job.commit.body to render on iPhone

### DIFF
--- a/assets/scripts/app/templates/builds/show.hbs
+++ b/assets/scripts/app/templates/builds/show.hbs
@@ -8,14 +8,14 @@
       </div>
 
       <div class="runtime">
-           {{#if build.isFinished}}ran{{else}}running{{/if}} for {{formatDuration build.duration}} 
+           {{#if build.isFinished}}ran{{else}}running{{/if}} for {{formatDuration build.duration}}
       </div>
 
       <div class="finished">
         {{formatTime build.finishedAt}}
       </div>
     </div>
- 
+
     <div class="branch" {{bind-attr title="build.commit.branch"}}>
       {{build.commit.branch}}
     </div>
@@ -24,9 +24,9 @@
     - {{formatMessage build.commit.subject repoBinding=build.repo}}
     </div>
 
-    <pre class="body">
-{{formatMessage build.commit.body repoBinding=build.repo pre=true}}
-    </pre>
+    <p class="body">
+{{formatMessage build.commit.body repoBinding=build.repo pre=false}}
+    </p>
 
     <div class="footer">
       <div class="author">

--- a/assets/scripts/app/templates/jobs/show.hbs
+++ b/assets/scripts/app/templates/jobs/show.hbs
@@ -7,14 +7,14 @@
         </div>
 
         <div class="runtime">
-           {{#if job.isFinished}}ran{{else}}running{{/if}} for {{formatDuration job.duration}} 
+           {{#if job.isFinished}}ran{{else}}running{{/if}} for {{formatDuration job.duration}}
         </div>
 
         <div class="finished">
           {{formatTime job.finishedAt}}
         </div>
       </div>
-   
+
       <div class="branch" {{bind-attr title="job.commit.branch"}}>
         {{job.commit.branch}}
       </div>
@@ -23,9 +23,9 @@
         - {{formatMessage job.commit.subject repoBinding=job.repo}}
       </div>
 
-      <pre class="body">
-{{formatMessage job.commit.body repoBinding=job.repo pre=true}}
-      </pre>
+      <p class="body">
+{{formatMessage job.commit.body repoBinding=job.repo pre=false}}
+      </p>
 
       <div class="footer">
         <div class="author">

--- a/assets/styles/main/summary.sass
+++ b/assets/styles/main/summary.sass
@@ -39,7 +39,6 @@
     line-height: 20px
 
   .body
-    min-width: 500px
     display: block
     min-height: 30px
     font-size: 12px
@@ -50,7 +49,7 @@
 
     a
       text-decoration: underline
-  
+
   .build-status
     @include border-radius(4px)
     float: right
@@ -161,7 +160,7 @@
   .message
     white-space: normal
     min-width: 0
-  
+
     pre
       font-size: 12px
       display: inline-block


### PR DESCRIPTION
The job.config.body element was a pre element and that did not allow it
to wrap on small screens. Also the min-width was greater than the
containing element width.

Fixes: https://github.com/travis-ci/travis-web/issues/285

I do not know the design that lead to using pre in the job.commit.body, so I may well
be breaking some design guidelines here.
