### PR TITLE
Fixed the display of the state icon in the request page

### DIFF
--- a/assets/styles/requests.sass
+++ b/assets/styles/requests.sass
@@ -5,6 +5,7 @@
     font-size: 120%
     padding-left: 15px
     background-position: 0px 6px
+    background-repeat: no-repeat
   &.accepted
     h3
       background-image: inline-image('icons/state-passed.svg')


### PR DESCRIPTION
Before
![travis_request_icon_before](https://cloud.githubusercontent.com/assets/439401/3915009/946686ea-2353-11e4-96ad-ba72f4e049c0.PNG)

After
![travis_request_icon_after](https://cloud.githubusercontent.com/assets/439401/3915012/9c817a10-2353-11e4-9d8f-b357e9e4d320.PNG)
