### PR TITLE
Pass test suite.

### DIFF
--- a/assets/scripts/lib/travis/log_chunks.coffee
+++ b/assets/scripts/lib/travis/log_chunks.coffee
@@ -76,6 +76,7 @@ Travis.LogChunks = Em.ArrayProxy.extend
         if part.final
           @notifyPropertyChange('final')
 
-      Ember.run.once this, ->
-        @tryFinalizing()
-        @resetTimeout()
+      Ember.run this, ->
+        Ember.run.once this, ->
+          @tryFinalizing()
+          @resetTimeout()

--- a/assets/scripts/spec/unit/log_chunks_spec.coffee
+++ b/assets/scripts/spec/unit/log_chunks_spec.coffee
@@ -40,7 +40,7 @@ test "it triggers downloading missing parts if there is a missing part, even tho
   , 40
 
 test "it triggers downloading next parts if there is no final part", ->
-  expect(2)
+  expect(4)
   stop()
 
   callback = (missingNumbers, after) ->
@@ -58,7 +58,7 @@ test "it triggers downloading next parts if there is no final part", ->
   , 35
 
 test "it triggers downloading all available parts if there is no parts yet", ->
-  expect(1)
+  expect(2)
   stop()
 
   callback = (missingNumbers, after) ->

--- a/public/spec.html
+++ b/public/spec.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <meta rel="travis.api_endpoint" href="">
+    <meta rel="travis.source_endpoint" href="https://github.com">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Travis CI - Free Hosted Continuous Integration Platform for the Open Source Community</title>
     <link rel="icon" type="image/png" href="/favicon.ico">


### PR DESCRIPTION
- Add `travis.source_endpoint` meta (fixes many tests with hard expectations on `http://github.com` being in URL paths).
- Wrap `Ember.run.once` in a `Ember.run` (prevents test auto-run assertion).
- Fix expect counts for a couple tests.
