### PR TITLE
Rename 'Concurrent builds' setting to 'Concurrent jobs'

### DIFF
--- a/assets/scripts/app/templates/settings/index.hbs
+++ b/assets/scripts/app/templates/settings/index.hbs
@@ -19,7 +19,7 @@
       {{input value=settings.maximum_number_of_builds size="4" pattern='/^[0-9]+$/'}}
     </p>
     <label>
-      Concurrent builds
+      Concurrent jobs
     </label>
   </p>
 </form>


### PR DESCRIPTION
My understanding is that this setting is actually a value used to control job concurrency, not build concurrency, so this clarifies that by referring to jobs instead of builds.

I realise there are other places this is used, such as `maximum_number_of_builds` in the CLI and elsewhere, but this change was more within my grasp. :)