### PR TITLE
Don't save data from pusher that won't likely be used

### DIFF
--- a/app/routes/main/recent.coffee
+++ b/app/routes/main/recent.coffee
@@ -5,6 +5,9 @@ Route = MainTabRoute.extend
   reposTabName: 'recent'
 
   activate: ->
-    @store.set('recentReposOpened', true)
+    @store.set('recentReposTabIsOpened', true)
+
+  deactivate: ->
+    @store.set('recentReposTabIsOpened', true)
 
 `export default Route`

--- a/app/routes/main/recent.coffee
+++ b/app/routes/main/recent.coffee
@@ -4,4 +4,7 @@
 Route = MainTabRoute.extend
   reposTabName: 'recent'
 
+  activate: ->
+    @store.set('recentReposOpened', true)
+
 `export default Route`

--- a/app/store.coffee
+++ b/app/store.coffee
@@ -9,7 +9,7 @@ Store = DS.Store.extend
     [name, type] = event.split(':')
 
     auth = @container.lookup('auth:main')
-    if !@get('recentReposOpened') && event != 'job:log' && auth.get('signedIn') &&
+    if !@get('recentReposTabIsOpened') && event != 'job:log' && auth.get('signedIn') &&
         !config.pro && !config.enterprise
       # if recent repos hasn't been opened yet, we can safely
       # drop any events that doesn't belong to repos owned by

--- a/app/store.coffee
+++ b/app/store.coffee
@@ -1,4 +1,5 @@
 `import DS from 'ember-data'`
+`import config from 'travis/config/environment'`
 
 Store = DS.Store.extend
   defaultAdapter: 'application'
@@ -6,6 +7,22 @@ Store = DS.Store.extend
 
   receivePusherEvent: (event, data) ->
     [name, type] = event.split(':')
+
+    auth = @container.lookup('auth:main')
+    if !@get('recentReposOpened') && event != 'job:log' && auth.get('signedIn') &&
+        !config.pro && !config.enterprise
+      # if recent repos hasn't been opened yet, we can safely
+      # drop any events that doesn't belong to repos owned by
+      # the logged in user and that aren't related to any
+      # repositories that are already opened
+
+      permissions = auth.get('permissions')
+      if name == 'job'
+        id = data.job.repository_id
+      else if name == 'build'
+        id = data.repository.id
+
+      return if !@hasRecordForId('repo', id) && !permissions.contains(id)
 
     if name == 'job' && data.job?.commit
       @pushPayload(commits: [data.job.commit])

--- a/app/utils/auth.coffee
+++ b/app/utils/auth.coffee
@@ -144,4 +144,6 @@ Auth = Ember.Object.extend
     "#{location.protocol}//www.gravatar.com/avatar/#{@get('currentUser.gravatarId')}?s=48&d=mm"
   ).property('currentUser.gravatarId')
 
+  permissions: Ember.computed.alias('currentUser.permissions')
+
 `export default Auth`

--- a/testem.json
+++ b/testem.json
@@ -8,7 +8,8 @@
   ],
   "launch_in_dev": [
     "PhantomJS",
-    "Chrome"
+    "Chrome",
+    "Firefox"
   ],
   "launchers": {
     "SL_chrome": {


### PR DESCRIPTION
If user is logged in and doesn't keep 'recent repositories' tab opened, most of
the pusher events from 'common' channel are useless.

This commit introduces a logic to reject pusher events if:

  * recent tab hasn't been opened
  * user is signed in
  * Travis CI for open source is used
  * repository for a given event is not yet in store
  * repository for a given event is not part of current user's repositories