### PR TITLE
Fix a small spelling mistake: committed (on build listing pages)

### DIFF
--- a/app/templates/builds.hbs
+++ b/app/templates/builds.hbs
@@ -20,7 +20,7 @@
             {{/link-to}}
           {{/if}}
         </h2>
-        <p class="tile-author"><img {{bind-attr src="build.urlAuthorGravatarImage"}} alt="">{{build.commit.committerName}} commited</p>
+        <p class="tile-author"><img {{bind-attr src="build.urlAuthorGravatarImage"}} alt="">{{build.commit.committerName}} committed</p>
       </div>
       <div class="column tile-additional medium-6 end">
         <div class="column small-6">


### PR DESCRIPTION
![screen shot 2015-03-13 at 3 58 34 pm](https://cloud.githubusercontent.com/assets/19339/6646315/0c7a968e-c99a-11e4-9b3c-fbb386977d06.png)

It's correct when you navigate to the individual build:

![screen shot 2015-03-13 at 3 59 43 pm](https://cloud.githubusercontent.com/assets/19339/6646310/064c64f4-c99a-11e4-9a8e-2b5648bc4bf2.png)
