### PR TITLE
Add eventType as an attribute, include api builds to the history

### DIFF
--- a/app/models/build.coffee
+++ b/app/models/build.coffee
@@ -17,6 +17,7 @@ Build = Model.extend DurationCalculations,
   pullRequest:       DS.attr('boolean')
   pullRequestTitle:  DS.attr()
   pullRequestNumber: DS.attr('number')
+  eventType:         DS.attr('string')
 
   repo:   DS.belongsTo('repo', async: true)
   commit: DS.belongsTo('commit', async: true)
@@ -32,11 +33,6 @@ Build = Model.extend DurationCalculations,
 
       @reload()
   ).property('_config')
-
-  # TODO add eventType to the api for api build requests
-  eventType: (->
-    if @get('pullRequest') then 'pull_request' else 'push'
-  ).property('pullRequest')
 
   isPullRequest: (->
     @get('eventType') == 'pull_request' || @get('pullRequest')

--- a/app/models/repo.coffee
+++ b/app/models/repo.coffee
@@ -50,8 +50,8 @@ Repo = Model.extend
 
   builds: (->
     id = @get('id')
-    builds = @store.filter('build', event_type: 'push', repository_id: id, (b) ->
-      b.get('repo.id') == id && b.get('eventType') == 'push'
+    builds = @store.filter('build', event_type: ['push', 'api'], repository_id: id, (b) ->
+      b.get('repo.id') == id && (b.get('eventType') == 'push' || b.get('eventType') == 'api')
     )
 
     # TODO: move to controller


### PR DESCRIPTION
So that builds triggered via API can be found on the build history for the time being.

/cc @drogus @rkh 