### PR TITLE
remove link to stack overflow in help menu

### DIFF
--- a/app/templates/top.hbs
+++ b/app/templates/top.hbs
@@ -15,7 +15,6 @@
         </p>
         <ul class="navigation-nested">
           <li><a href="http://docs.travis-ci.com">Docs</a></li>
-          <li><a href="http://stackoverflow.com/questions/ask?tags=travis-ci">Ask a Question</a></li>
           <li><a href="http://docs.travis-ci.com/imprint.html" alt="Imprint">Imprint</a></li>
         </ul>
       </li>


### PR DESCRIPTION
Simply deleted the list item in the drop down menu