### PR TITLE
Fix Xcode typo on landing page

### DIFF
--- a/app/templates/home-pro.hbs
+++ b/app/templates/home-pro.hbs
@@ -71,7 +71,7 @@
         <li><a href="http://docs.travis-ci.com/user/languages/clojure/"><img alt="Clojure logo" src="../images/pro-landing/lang-clojure.svg" class="language-clojure">Clojure</a></li>
         <li><a href="http://docs.travis-ci.com/user/languages/javascript-with-nodejs/"><img alt="NodeJS logo" src="../images/pro-landing/lang-nodejs.svg" class="language-node">Node</a></li>
         <li><a href="http://docs.travis-ci.com/user/languages/php/"><img alt="PHP logo" src="../images/pro-landing/lang-php.svg" class="language-php">PHP</a></li>
-        <li><a href="http://docs.travis-ci.com/user/languages/objective-c/"><img alt="Xcode logo" src="../images/pro-landing/lang-xcode.svg" class="language-xcode">XCode</a></li>
+        <li><a href="http://docs.travis-ci.com/user/languages/objective-c/"><img alt="Xcode logo" src="../images/pro-landing/lang-xcode.svg" class="language-xcode">Xcode</a></li>
         <li><a href="http://docs.travis-ci.com/user/languages/ruby/"><img alt="Ruby logo" src="../images/pro-landing/lang-ruby.svg" class="language-ruby">Ruby</a></li>
         <li><a href="http://docs.travis-ci.com/user/languages/python/"><img alt="Python logo" src="../images/pro-landing/lang-python.svg" class="language-python">Python</a></li>
         <li><a href="http://docs.travis-ci.com/user/languages/java/"><img alt="Java logo" src="../images/pro-landing/lang-java.svg" class="language-java">Java</a></li>


### PR DESCRIPTION
It's normally written as Xcode and not XCode.