### PR TITLE
Author/Committer Avatar Bug in Build List

### DIFF
--- a/app/components/branch-row.coffee
+++ b/app/components/branch-row.coffee
@@ -1,5 +1,4 @@
 `import Ember from 'ember'`
-`import { gravatarImage } from 'travis/utils/urls'`
 `import { githubCommit as githubCommitUrl } from 'travis/utils/urls'`
 `import TravisRoute from 'travis/routes/basic'`
 `import config from 'travis/config/environment'`

--- a/app/components/build-header.coffee
+++ b/app/components/build-header.coffee
@@ -1,5 +1,4 @@
 `import Ember from 'ember'`
-`import { gravatarImage } from 'travis/utils/urls'`
 `import GithubUrlPropertievs from 'travis/mixins/github-url-properties'`
 `import { durationFrom, safe } from 'travis/utils/helpers'`
 `import { githubCommit } from 'travis/utils/urls'`
@@ -9,22 +8,6 @@ BuildHeaderComponent = Ember.Component.extend
   tagName: 'section'
   classNames: ['build-header']
   classNameBindings: ['item.state']
-
-  committerAvatarUrl: (->
-    if url = @get('commit.committerAvatarUrl')
-      url
-    else
-      email = @get('commit.committerEmail')
-      gravatarImage(email, 40)
-  ).property('commit.committerEmail', 'commit.committerAvatarUrl')
-
-  authorAvatarUrl: (->
-    if url = @get('commit.authorAvatarUrl')
-      url
-    else
-      email = @get('commit.authorEmail')
-      gravatarImage(email, 40)
-  ).property('commit.authorEmail', 'commit.authorAvatarUrl')
 
   isJob: (->
     if @get('item.build') then true else false

--- a/app/components/builds-item.coffee
+++ b/app/components/builds-item.coffee
@@ -1,19 +1,10 @@
 `import Ember from 'ember'`
-`import { gravatarImage } from 'travis/utils/urls'`
 `import { githubCommit as githubCommitUrl } from 'travis/utils/urls'`
 
 BuildsItemComponent = Ember.Component.extend
   tagName: 'li'
   classNameBindings: ['build.state']
   classNames: ['row-li', 'pr-row']
-
-  authorAvatarUrl: (->
-    if url = @get('build.commit.authorAvatarUrl')
-      url
-    else
-      email = @get('build.commit.authorEmail')
-      gravatarImage(email, 40)
-  ).property('build.commit.authorEmail', 'build.commit.authorAvatarUrl')
 
   urlGithubCommit: (->
     githubCommitUrl(@get('build.repo.slug'), @get('build.commit.sha'))

--- a/app/controllers/branches.coffee
+++ b/app/controllers/branches.coffee
@@ -1,5 +1,4 @@
 `import Ember from 'ember'`
-`import { gravatarImage } from 'travis/utils/urls'`
 `import GithubUrlPropertievs from 'travis/mixins/github-url-properties'`
 
 BranchesController = Ember.Controller.extend

--- a/app/controllers/build.coffee
+++ b/app/controllers/build.coffee
@@ -1,5 +1,4 @@
 `import Ember from 'ember'`
-`import { gravatarImage } from 'travis/utils/urls'`
 `import GithubUrlPropertievs from 'travis/mixins/github-url-properties'`
 
 Controller = Ember.Controller.extend GithubUrlPropertievs,

--- a/app/models/commit.coffee
+++ b/app/models/commit.coffee
@@ -1,6 +1,7 @@
 `import Ember from 'ember'`
 `import Model from 'travis/models/model'`
 `import Build from 'travis/models/build'`
+`import { gravatarImage } from 'travis/utils/urls'`
 
 Commit = Model.extend
   sha:               DS.attr()
@@ -33,5 +34,21 @@ Commit = Model.extend
     @get('authorName') == @get('committerName') and
       @get('authorEmail') == @get('committerEmail')
   ).property('authorName', 'authorEmail', 'committerName', 'committerEmail')
+
+  authorAvatarUrlOrGravatar: (->
+    if url = @get('authorAvatarUrl')
+      url
+    else
+      email = @get('authorEmail')
+      gravatarImage(email, 40)
+  ).property('authorEmail', 'authorAvatarUrl')
+
+  committerAvatarUrlOrGravatar: (->
+    if url = @get('committerAvatarUrl')
+      url
+    else
+      email = @get('committerEmail')
+      gravatarImage(email, 40)
+  ).property('committerEmail', 'committerAvatarUrl')
 
 `export default Commit`

--- a/app/templates/components/build-header.hbs
+++ b/app/templates/components/build-header.hbs
@@ -38,11 +38,11 @@
     </ul>
     <p class="commit-author">
       {{#if commit.authorName}}
-        <img src={{authorAvatarUrl}} alt="comitter avatar" aria-hidden="true"><span class="label-align">{{commit.authorName}} authored{{#if commit.authorIsCommitter}} and committed{{/if}}</span>
+        <img src={{commit.authorAvatarUrlOrGravatar}} alt="author avatar" aria-hidden="true"><span class="label-align">{{commit.authorName}} authored{{#if commit.authorIsCommitter}} and committed{{/if}}</span>
       {{/if}}
       {{#unless commit.authorIsCommitter}}
         {{#if commit.committerName}}
-          <img src={{committerAvatarUrl}} alt="comitter avatar" aria-hidden="true"><span class="label-align">{{commit.committerName}} committed</span>
+          <img src={{commit.committerAvatarUrlOrGravatar}} alt="comitter avatar" aria-hidden="true"><span class="label-align">{{commit.committerName}} committed</span>
         {{/if}}
       {{/unless}}
     </p>

--- a/app/templates/components/builds-item.hbs
+++ b/app/templates/components/builds-item.hbs
@@ -20,7 +20,7 @@
     {{/unless}}
   </div>
   <div class="row-item row-committer">
-    <img class="avatar" src={{authorAvatarUrl}} alt="{{build.commit.committerName}} avatar">
+    <img class="avatar" src={{build.commit.authorAvatarUrlOrGravatar}} alt="{{build.commit.authorName}} avatar">
     <span class="label-align">{{build.commit.committerName}}</span>
   </div>
 </div>

--- a/app/templates/components/builds-item.hbs
+++ b/app/templates/components/builds-item.hbs
@@ -21,7 +21,13 @@
   </div>
   <div class="row-item row-committer">
     <img class="avatar" src={{build.commit.authorAvatarUrlOrGravatar}} alt="{{build.commit.authorName}} avatar">
-    <span class="label-align">{{build.commit.committerName}}</span>
+    <span class="label-align">{{build.commit.authorName}}</span>
+    {{#unless build.commit.authorIsCommitter}}
+      {{#if build.commit.committerName}}
+        <img class="avatar" src={{build.commit.committerAvatarUrlOrGravatar}} alt="{{build.commit.commiterName}}">
+        <span class="label-align">{{build.commit.committerName}}</span>
+      {{/if}}
+    {{/unless}}
   </div>
 </div>
 

--- a/app/views/job.coffee
+++ b/app/views/job.coffee
@@ -1,6 +1,6 @@
 `import Ember from 'ember'`
 `import { colorForState } from 'travis/utils/helpers'`
-`import { githubCommit, gravatarImage } from 'travis/utils/urls'`
+`import { githubCommit } from 'travis/utils/urls'`
 `import Polling from 'travis/mixins/polling'`
 
 View = Ember.View.extend Polling,
@@ -19,13 +19,5 @@ View = Ember.View.extend Polling,
   urlGithubCommit: (->
     githubCommit(@get('repo.slug'), @get('commit.sha'))
   ).property('repo.slug', 'commit.sha')
-
-  urlCommitterGravatarImage: (->
-    gravatarImage(@get('commit.committerEmail'), 40)
-  ).property('commit.committerEmail')
-
-  urlAuthorGravatarImage: (->
-    gravatarImage(@get('commit.authorEmail'), 40)
-  ).property('commit.authorEmail')
 
 `export default View`

--- a/tests/unit/components/builds-item-test.coffee
+++ b/tests/unit/components/builds-item-test.coffee
@@ -32,5 +32,4 @@ test 'it renders', (assert) ->
 
   ok component.$().hasClass('passed'), 'component has right status class'
   equal component.$('.row-branch a').text().trim(), 'foobarbranch', 'component renders branch if event is push'
-  equal component.$('.avatar').attr('src'), 'https://www.gravatar.com/avatar/5c1e6d6e64e12aca17657581a48005d1?s=40&d=https%3A%2F%2Ftravis-ci.org%2Fimages%2Fui%2Fdefault-avatar.png', 'component renders right gravatar image'
   equal component.$('a[title="See the commit on GitHub"]').attr('href'), 'https://github.com/foo/bar/commit/a5e8093098f9c0fb46856b753fb8943c7fbf26f3', 'component generates right commit link'

--- a/tests/unit/models/commit-test.coffee
+++ b/tests/unit/models/commit-test.coffee
@@ -1,0 +1,25 @@
+`import { moduleForModel, test } from 'ember-qunit'`
+
+moduleForModel 'commit', 'Unit | Model | commit', needs: ['model:build']
+
+test 'calculation of avatar urls via Gravatar', ->
+  model = @subject()
+  Ember.run ->
+    model.setProperties
+      authorEmail: 'author@example.com'
+      committerEmail: 'author@example.com'
+      authorAvatarUrl: null
+      committerAvatarUrl: null
+  equal model.get('authorAvatarUrlOrGravatar'), 'https://www.gravatar.com/avatar/5c1e6d6e64e12aca17657581a48005d1?s=40&d=https%3A%2F%2Ftravis-ci.org%2Fimages%2Fui%2Fdefault-avatar.png', 'correctly sets gravatar image'
+  equal model.get('committerAvatarUrlOrGravatar'), 'https://www.gravatar.com/avatar/5c1e6d6e64e12aca17657581a48005d1?s=40&d=https%3A%2F%2Ftravis-ci.org%2Fimages%2Fui%2Fdefault-avatar.png', 'correctly sets gravatar image'
+
+test 'calculation of avatar urls via overriding parameter', ->
+  model = @subject()
+  Ember.run ->
+    model.setProperties
+      authorEmail: 'author@example.com'
+      committerEmail: 'author@example.com'
+      authorAvatarUrl: 'http://example.com/test.jpg'
+      committerAvatarUrl: 'http://example.com/test2.jpg'
+  equal model.get('authorAvatarUrlOrGravatar'), 'http://example.com/test.jpg', 'correctly sets avatar'
+  equal model.get('committerAvatarUrlOrGravatar'), 'http://example.com/test2.jpg', 'correctly sets avatar'


### PR DESCRIPTION
When commits have an author different from the committer, the association between avatar and name in the builds list is wrong ("authored" by Josh Kalderimis, committed by me):

![old-state](https://cloud.githubusercontent.com/assets/768913/12071464/b678b37c-b0ae-11e5-80d8-280c3b4b3436.jpg)

For reference, this build can be found here: [/thriqon/travis-demo-rep/builds](https://travis-ci.org/thriqon/travis-demo-rep/builds).

This only occurs in the build list, not in the build detail view.

With this PR, the calculation is moved to the model and reused in both instances. The third commit additionally drops some unneeded imports of `gravatarImage` which I found while scanning for more avatar calculations. After the change, the build overview looks like this:

![new-state](https://cloud.githubusercontent.com/assets/768913/12071470/47704bba-b0af-11e5-9c4f-c809879bb5e2.jpg)