### PR TITLE
Leverage <time> element

### DIFF
--- a/app/templates/components/build-header.hbs
+++ b/app/templates/components/build-header.hbs
@@ -67,17 +67,17 @@
   <ul class="list-icon">
     <li title="{{format-duration elapsedTime}}" class="commit-stopwatch">
       <span class="icon-stopwatch" aria-hidden="true"></span>
-      <span class="label-align">Elapsed time {{format-duration elapsedTime}}</span></li>
+      <span class="label-align">Elapsed time <time datetime="PT{{elapsedTime}}S">{{format-duration elapsedTime}}</time></span></li>
     {{#unless isJob}}
       {{#if item.isMatrix}}
         <li title="{{format-duration item.duration}}" class="commit-clock">
           <span class="icon-clock" aria-hidden="true"></span>
-          <span class="label-align">{{#if item.isFinished}}Total time{{else}}Running for{{/if}} {{format-duration item.duration}}</span></li>
+          <span class="label-align">{{#if item.isFinished}}Total time{{else}}Running for{{/if}} <time datetime="PT{{item.duration}}S">{{format-duration item.duration}}</time></span></li>
       {{/if}}
     {{/unless}}
     <li title="{{pretty-date item.finishedAt}}" class="commit-calendar">
       <span class="icon-calendar" aria-hidden="true"></span>
-      <span class="label-align">{{format-time item.finishedAt}}</span></li>
+      <time class="label-align" datetime={{item.finishedAt}}>{{format-time item.finishedAt}}</time></li>
   </ul>
 </div>
 <div class="build-tools">

--- a/app/templates/components/builds-item.hbs
+++ b/app/templates/components/builds-item.hbs
@@ -46,13 +46,13 @@
   <div class="row-item">
     <div title="{{format-duration build.duration}}">
       <span class="icon-clock"></span>
-      <span class="label-align">{{format-duration build.duration}}</span>
+      <time class="label-align" datetime="PT{{build.duration}}S">{{format-duration build.duration}}</time>
     </div>
   </div>
   <div class="row-item">
     <div title="{{pretty-date build.formattedFinishedAt}}">
       <span class="icon-calendar"></span>
-      <span class="label-align">{{format-time build.finishedAt}}</span>
+      <time class="label-align" datetime={{build.finishedAt}}>{{format-time build.finishedAt}}</time>
     </div>
   </div>
 </div>

--- a/app/templates/components/jobs-item.hbs
+++ b/app/templates/components/jobs-item.hbs
@@ -34,6 +34,6 @@
 
   <div class="job-duration" title="Started {{pretty-date job.startedAt}}">
     <span class="icon-clock" aria-hidden="true"></span>
-    <span class="label-align" aria-label="Job duration">{{format-duration job.duration}}</span>
+    <time class="label-align" aria-label="Job duration" datetime="PT{{job.duration}}S">{{format-duration job.duration}}</time>
   </div>
 {{/link-to}}

--- a/app/templates/components/landing-row.hbs
+++ b/app/templates/components/landing-row.hbs
@@ -52,8 +52,8 @@
           </g>
         </svg>
       </span>
-      <span class="label-align">
-        {{landing-page-last-build-time repo.lastBuildFinishedAt}}</span>
+      <time class="label-align" datetime="{{repo.lastBuildFinishedAt}}">
+        {{landing-page-last-build-time repo.lastBuildFinishedAt}}</time>
     </div>
   </div>
 </div>

--- a/app/templates/components/repos-list-item.hbs
+++ b/app/templates/components/repos-list-item.hbs
@@ -21,15 +21,15 @@
 
   <p>
     <span class="icon-clock"></span>
-    <span class="label-align">Duration: 
-    <time class="duration" datetime={{repo.lastBuildStartedAt}} title={{repo.lastBuildStartedAt}}>
+    <span class="label-align">Duration:
+    <time class="duration" datetime="PT{{repo.lastBuildDuration}}S" title={{repo.lastBuildStartedAt}}>
       {{format-duration repo.lastBuildDuration}}
     </time></span>
   </p>
 
   <p>
     <span class="icon-calendar"></span>
-    <span class="label-align">Finished: 
+    <span class="label-align">Finished:
     <time class="finished_at timeago" datetime={{repo.lastBuildFinishedAt}} title={{repo.lastBuildFinishedAt}}>
       {{format-time repo.lastBuildFinishedAt}}
     </time></span>

--- a/app/templates/components/repos-list-item.hbs
+++ b/app/templates/components/repos-list-item.hbs
@@ -22,16 +22,16 @@
   <p>
     <span class="icon-clock"></span>
     <span class="label-align">Duration: 
-    <abbr class="duration" title={{repo.lastBuildStartedAt}}>
+    <time class="duration" datetime={{repo.lastBuildStartedAt}} title={{repo.lastBuildStartedAt}}>
       {{format-duration repo.lastBuildDuration}}
-    </abbr></span>
+    </time></span>
   </p>
 
   <p>
     <span class="icon-calendar"></span>
     <span class="label-align">Finished: 
-    <abbr class="finished_at timeago" title={{repo.lastBuildFinishedAt}}>
+    <time class="finished_at timeago" datetime={{repo.lastBuildFinishedAt}} title={{repo.lastBuildFinishedAt}}>
       {{format-time repo.lastBuildFinishedAt}}
-    </abbr></span>
+    </time></span>
   </p>
 </div>

--- a/app/templates/components/running-jobs.hbs
+++ b/app/templates/components/running-jobs.hbs
@@ -41,9 +41,9 @@
           </span>
           <span class="label-align">
             Duration:
-            <abbr class="duration" title={{job.startedAt}}>
+            <time class="duration" datetime={{job.startedAt}} title={{job.startedAt}}>
               {{format-duration job.duration}}
-            </abbr>
+            </time>
           </span>
         </p>
 


### PR DESCRIPTION
Sample of using the `time` element instead of `abbr` for displaying timestamps.

The `time` element can also represent durations. So the sample used here is suboptimal. Rather than the duration time lising the `lastBuildStartedAt` time in the `datetime` attribute, it ought to be a [valid `duration` value](https://www.w3.org/html/wg/drafts/html/master/infrastructure.html#valid-duration-string). However, I didn't see any existing helpers for formatting according to a machine-readable duration value.

Ideally, the `time` element would be used in other areas where times/durations are displayed. This pr is meant as a starting point for discussion.