### PR TITLE
Fix grammatical error for finished job duration

### DIFF
--- a/app/templates/components/build-header.hbs
+++ b/app/templates/components/build-header.hbs
@@ -67,7 +67,7 @@
       {{#if item.isMatrix}}
         <li title="{{format-duration item.duration}}" class="commit-clock">
           <span class="icon-clock" aria-hidden="true"></span>
-          <span class="label-align">{{#if item.isFinished}}Total time{{else}}Running{{/if}} for {{format-duration item.duration}}</span></li>
+          <span class="label-align">{{#if item.isFinished}}Total time{{else}}Running for{{/if}} {{format-duration item.duration}}</span></li>
       {{/if}}
     {{/unless}}
     <li title="{{pretty-date item.finishedAt}}" class="commit-calendar">


### PR DESCRIPTION
While a job is running, on the job status view, the duration is labeled: "Running for x sec". When the job finishes, 'Running' is swapped for 'Total time'. But "Total time for x sec" doesn't make any sense. the " for" should be part of the conditional with "Running"