### PR TITLE
remove "Legacy" from "Precise builds" in log-content message

### DIFF
--- a/app/templates/components/log-content.hbs
+++ b/app/templates/components/log-content.hbs
@@ -16,7 +16,7 @@
     {{#if job.displayGceNotice}}
       {{#if job.isFinished}}
         <p class="notice--blue"><span class="icon-flag"></span>
-        <span class="label-align">This job ran on our new platform for Legacy Precise builds. Please read <a href="https://blog.travis-ci.com/2015-11-27-moving-to-a-more-elastic-future" title="Blog post on infrastructure migration">our blog post for more information</a>.</span></p>
+        <span class="label-align">This job ran on our new platform for Precise builds. Please read <a href="https://blog.travis-ci.com/2015-11-27-moving-to-a-more-elastic-future" title="Blog post on infrastructure migration">our blog post for more information</a>.</span></p>
       {{else}}
         <p class="notice--blue"><span class="icon-flag"></span>
         <span class="label-align">This job is running on our new platform for Legacy Precise builds. Please read <a href="https://blog.travis-ci.com/2015-11-27-moving-to-a-more-elastic-future" title="Blog post on infrastructure migration">our blog post for more information</a>.</span></p>


### PR DESCRIPTION
Very minor change - tested on staging, all is good.