### PR TITLE
Remove autoprexifer deprecations

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ember-ajax": "0.7.1",
     "ember-cli": "2.2.0-beta.6",
     "ember-cli-app-version": "^1.0.0",
-    "ember-cli-autoprefixer": "^0.3.0",
+    "ember-cli-autoprefixer": "^0.5.0",
     "ember-cli-babel": "5.1.5",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-deprecation-workflow": "0.1.5",


### PR DESCRIPTION
Upgading ember-cli-autoprefixer to 0.5.0 removes the deprecation
messages from the build output (these were targeted for removal
in 0.4.0).

There are no noticable side effects, but this version does package
the most recent version of postcss/autoprefixer. The release notes
for that version can be found
[here](https://github.com/postcss/autoprefixer/releases/tag/6.0.0).