### PR TITLE
Adding some more "about us" info to /about

### DIFF
--- a/app/templates/team.hbs
+++ b/app/templates/team.hbs
@@ -12,7 +12,20 @@
           {{team-member member=member}}
         {{/each}}
       </ul>
-    </div>
+      <header class="section--center team-header">
+        <h1 class="h1--green">Travis CI is:</h1>
+        <p class="text-big">A continuous integration platform.</p>
+        <p class="text-big">We run people's tests, deploy their code and help them be confident about their work.</p>
+        <p class="text-big">We have strong roots in open source, both in our community and how Travis CI was built. We continue to support the open source community where  ver we can.</p>
+        <p class="text-big">Travis CI is run as a hosted service, free for open source, and a paid product for private code. It's also available as an on-premises version   (Travis CI Enterprise).</p>
+        <p class="text-big">We're a small, bootstrapped business from Berlin, Germany with a team distributed across the globe. Our goal is to help people build better so  ftware. Travis CI is profitable, and we're building a sustainable business for the long run.</p>
+        <p class="text-big">Our team values working at a healthy pace and a normal working day over working long hours late at night. We'd prefer you go take a walk or sp  end time with your family than try to work through just one more support ticket.</p>
+        <p class="text-big">Empathy is one of our core values as a team and company, towards each other, and our customers.</p>
+        <p class="text-big">We foster a culture of continuous improvement and learning. If something's worth fixing or improving, it should be fixed or improved. Making m  istakes is part of what we do, and we make sure we have each other's backs and learn from them.</p>
+        <p class="text-big">At Travis CI, we value diversity in all aspects of our team. We value everyone's questions, insights and feedback.</p>
+        <p class="text-big">We devote time to help our customers, the open source community, diversity in software development and to help our local communities. Most importantly, we strive to help and support each other.</p>
+     </header>
+     </div>
   </section>
 </div>
 {{/travis-layout}}


### PR DESCRIPTION
I got a DM from a friend interested in the job asking if we had
an "about page" that was more than just the headshots, which he
thought were super cool. I took the language from what we've been
including in jobs ads, as a start. I thought I'd submit it for
tweaking and review by those with more design sense than me ;)