### PR TITLE
Remove click handler overriding default link behavior

### DIFF
--- a/app/components/repos-list-item.js
+++ b/app/components/repos-list-item.js
@@ -23,10 +23,5 @@ export default Ember.Component.extend(Polling, {
         scrollTop: 0
       }, 200);
     }
-  },
-
-  click() {
-    this.scrollTop();
-    return this.get('routing').transitionTo('repo', this.get('repo.slug').split('/'));
   }
 });

--- a/app/mixins/scroll-reset.js
+++ b/app/mixins/scroll-reset.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+
+export default Ember.Mixin.create({
+  activate: function() {
+    this._super(...arguments);
+    window.scrollTo(0,0);
+  }
+});

--- a/app/routes/repo.js
+++ b/app/routes/repo.js
@@ -1,8 +1,9 @@
 import TravisRoute from 'travis/routes/basic';
 import Repo from 'travis/models/repo';
+import ScrollResetMixin from 'travis/mixins/scroll-reset';
 import Ember from 'ember';
 
-export default TravisRoute.extend({
+export default TravisRoute.extend(ScrollResetMixin, {
   store: Ember.inject.service(),
 
   titleToken(model) {


### PR DESCRIPTION
An [issue](https://github.com/travis-ci/travis-ci/issues/5181) was reported in
which the repository sidebar links were not functioning as expected. I've
tracked it down to the fact that a click handler was registered and
automatically performing a redirect to the repo route.

As reported, this breaks CMD+Click behavior (as the click handler was still
called and navigating when the user did not expect it). It also breaks normal link
behavior as it would take the user to a URL they did not intend to visit.

This commit simply removes that click handler. I checked the previous
coffee version of the file to gain more context on why it was initially
added, but unfortunately, it was simply added when the original
component was created, so I'm not sure what its use was.

If there is known behavior that this would break, we should probably add some
additional test coverage around it, and I could take another crack at a fix.