### PR TITLE
Remove legacy binding deprecation warnings

### DIFF
--- a/app/templates/components/builds-item.hbs
+++ b/app/templates/components/builds-item.hbs
@@ -5,7 +5,7 @@
       {{#if build.isPullRequest}}
         {{#link-to "build" build.repo build}}
           <small>PR #{{build.pullRequestNumber}}</small>
-          {{{format-message build.pullRequestTitle short="true" repoBinding=build.repo}}}
+          {{{format-message build.pullRequestTitle short="true" repo=build.repo}}}
         {{/link-to}}
       {{else}}
         {{#link-to "build" build.repo build}}
@@ -15,7 +15,7 @@
     </h2>
     {{#unless build.isPullRequest}}
       <div class="row-message">
-        {{{format-message build.commit.message short="true" repoBinding=build.repo}}}
+        {{{format-message build.commit.message short="true" repo=build.repo}}}
       </div>
     {{/unless}}
   </div>

--- a/app/templates/components/requests-item.hbs
+++ b/app/templates/components/requests-item.hbs
@@ -19,7 +19,7 @@
   <span class="label-align">{{format-time request.created_at}}</span></div>
 
 <div class="row-item fade-out">
-  {{{format-message request.commit.message short="true" repoBinding=request.build.repo}}}
+  {{{format-message request.commit.message short="true" repo=request.build.repo}}}
 </div>
 
 <div class="row-item">


### PR DESCRIPTION
This removes the warnings and should clean up the test output (especially in CI) quite a bit.