### PR TITLE
Add R language key for matrix column

### DIFF
--- a/app/utils/keys-map.js
+++ b/app/utils/keys-map.js
@@ -30,7 +30,8 @@ languageConfigKeys = {
   lein: 'Lein',
   compiler: 'Compiler',
   crystal: 'Crystal',
-  osx_image: 'Xcode'
+  osx_image: 'Xcode',
+  r: 'R'
 };
 
 configKeys = {


### PR DESCRIPTION
I believe this should fix the "no language set" message seen at https://travis-ci.org/jimhester/travis-test/builds/109884131

Let me know if there is something else which needs to be done