### PR TITLE
[Refactor] Remove *Binding properties, inject user into relevant components

### DIFF
--- a/app/components/build-repo-actions.js
+++ b/app/components/build-repo-actions.js
@@ -1,7 +1,9 @@
 import Ember from 'ember';
 import RepoActionsItemComponentMixin from 'travis/mixins/repo-actions-item-component-mixin';
 
+const { alias } = Ember.computed;
+
 export default Ember.Component.extend(RepoActionsItemComponentMixin, {
-  item: Ember.computed.alias('build'),
+  item: alias('build'),
   type: 'build'
 });

--- a/app/components/flash-display.js
+++ b/app/components/flash-display.js
@@ -1,12 +1,13 @@
 import Ember from 'ember';
 
+const { alias } = Ember.computed;
 const { service } = Ember.inject;
 
 export default Ember.Component.extend({
   flashes: service(),
   classNames: ['flash'],
   tagName: 'ul',
-  messagesBinding: 'flashes.messages',
+  messages: alias('flashes.messages'),
 
   actions: {
     closeMessage(msg) {

--- a/app/components/hook-switch.js
+++ b/app/components/hook-switch.js
@@ -1,14 +1,15 @@
 import Ember from 'ember';
 
+const { alias } = Ember.computed;
+
 export default Ember.Component.extend({
   tagName: 'a',
   classNames: ['switch--icon'],
   classNameBindings: ['active'],
-  activeBinding: "hook.active",
+  active: alias('hook.active'),
   click() {
-    var hook;
     this.sendAction('onToggle');
-    hook = this.get('hook');
+    let hook = this.get('hook');
     return hook.toggle().then((function() {}), () => {
       this.toggleProperty('hook.active');
       return this.sendAction('onToggleError', hook);

--- a/app/components/job-log.js
+++ b/app/components/job-log.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
 
+const { alias } = Ember.computed;
+
 export default Ember.Component.extend({
   logBinding: 'job.log',
   classNames: ['job-log'],

--- a/app/components/job-repo-actions.js
+++ b/app/components/job-repo-actions.js
@@ -1,7 +1,9 @@
 import Ember from 'ember';
 import RepoActionsItemComponentMixin from 'travis/mixins/repo-actions-item-component-mixin';
 
+const { alias } = Ember.computed;
+
 export default Ember.Component.extend(RepoActionsItemComponentMixin, {
-  item: Ember.computed.alias('job'),
+  item: alias('job'),
   type: 'job'
 });

--- a/app/components/job-wrapper.js
+++ b/app/components/job-wrapper.js
@@ -5,8 +5,6 @@ import Polling from 'travis/mixins/polling';
 
 export default Ember.Component.extend({
   pollModels: 'job.build',
-  commitBinding: 'job.commit',
-  currentItemBinding: 'job',
 
   color: function() {
     return colorForState(this.get('job.state'));

--- a/app/components/log-content.js
+++ b/app/components/log-content.js
@@ -4,6 +4,9 @@ import LogFolder from 'travis/utils/log-folder';
 import config from 'travis/config/environment';
 import { plainTextLog as plainTextLogUrl } from 'travis/utils/urls';
 
+const { service } = Ember.inject;
+const { alias } = Ember.computed;
+
 Log.DEBUG = false;
 
 Log.LIMIT = 10000;
@@ -58,15 +61,14 @@ Object.defineProperty(Log.Limit.prototype, 'limited', {
   }
 });
 
-const { service } = Ember.inject;
-
 export default Ember.Component.extend({
+  auth: service(),
   popup: service(),
   permissions: service(),
-
   classNameBindings: ['logIsVisible:is-open'],
   logIsVisible: false,
-  currentUserBinding: 'auth.currentUser',
+
+  currentUser: alias('auth.currentUser'),
 
   didInsertElement() {
     if (Log.DEBUG) {

--- a/app/components/not-active.js
+++ b/app/components/not-active.js
@@ -2,9 +2,13 @@ import Ember from 'ember';
 import config from 'travis/config/environment';
 
 const { service } = Ember.inject;
+const { alias } = Ember.computed;
 
 export default Ember.Component.extend({
+  auth: service(),
   flashes: service(),
+
+  user: alias('auth.currentUser'),
 
   canActivate: function() {
     let user = this.get('user');
@@ -13,6 +17,8 @@ export default Ember.Component.extend({
           repoId = parseInt(this.get('repo.id'));
 
       return permissions.contains(repoId);
+    } else {
+      return false;
     }
   }.property('user.pushPermissions.[]', 'repo'),
 

--- a/app/components/org-item.js
+++ b/app/components/org-item.js
@@ -1,11 +1,13 @@
 import Ember from 'ember';
 
+const { alias } = Ember.computed;
+
 export default Ember.Component.extend({
   classNames: ['media', 'account'],
   tagName: 'li',
   classNameBindings: ['type', 'selected'],
-  typeBinding: 'account.type',
-  selectedBinding: 'account.selected',
+  type: alias('account.type'),
+  selected: alias('account.selected'),
   tokenIsVisible: false,
 
   name: function() {

--- a/app/components/repo-show-tools.js
+++ b/app/components/repo-show-tools.js
@@ -2,14 +2,18 @@ import Ember from 'ember';
 import config from 'travis/config/environment';
 
 const { service } = Ember.inject;
+const { alias } = Ember.computed;
 
 export default Ember.Component.extend({
+  auth: service(),
   popup: service(),
   permissions: service(),
 
   classNames: ['option-button'],
   classNameBindings: ['isOpen:display'],
   isOpen: false,
+
+  currentUser: alias('auth.currentUser'),
 
   click(event) {
     if ($(event.target).is('a') && $(event.target).parents('.settings-dropdown').length) {
@@ -37,5 +41,4 @@ export default Ember.Component.extend({
   displayStatusImages: function() {
     return this.get('permissions').hasPermission(this.get('repo'));
   }.property('permissions.all', 'repo'),
-
 });

--- a/app/components/repos-list-tabs.js
+++ b/app/components/repos-list-tabs.js
@@ -1,11 +1,12 @@
 import Ember from 'ember';
 
 const { service } = Ember.inject;
+const { alias } = Ember.computed;
 
 export default Ember.Component.extend({
   auth: service(),
 
-  currentUserBinding: 'auth.currentUser',
+  currentUser: alias('auth.currentUser'),
 
   classRecent: function() {
     if (this.get('tab') === 'recent') {

--- a/app/components/show-more-button.js
+++ b/app/components/show-more-button.js
@@ -1,12 +1,14 @@
 import Ember from 'ember';
 
+const { alias } = Ember.computed;
+
 export default Ember.Component.extend({
   tagName: 'button',
   classNames: ['showmore-button'],
   classNameBindings: ['isLoading', 'showMore'],
   showMore: true,
   attributeBindings: ['disabled'],
-  disabledBinding: 'isLoading',
+  disabled: alias('isLoading'),
 
   buttonLabel: function() {
     if (this.get('isLoading')) {

--- a/app/components/status-images.js
+++ b/app/components/status-images.js
@@ -3,11 +3,13 @@ import { format as formatStatusImage } from 'travis/utils/status-image-formats';
 import Config from 'travis/config/environment';
 
 const { service } = Ember.inject;
+const { alias } = Ember.computed;
 
 export default Ember.Component.extend({
   popup: service(),
   auth: service(),
-  popupNameBinding: 'popup.popupName',
+
+  popupName: alias('popup.popupName'),
 
   id: 'status-images',
   attributeBindings: ['id'],

--- a/app/components/sync-button.js
+++ b/app/components/sync-button.js
@@ -1,6 +1,11 @@
 import Ember from 'ember';
 
+const { service } = Ember.inject;
+const { alias } = Ember.computed;
+
 export default Ember.Component.extend({
+  auth: service(),
+  user: alias('auth.currentUser'),
   classNames: ["sync-button"],
   actions: {
     sync() {

--- a/app/controllers/account.js
+++ b/app/controllers/account.js
@@ -1,8 +1,12 @@
 import Ember from 'ember';
 
+const { service } = Ember.inject;
+const { alias } = Ember.computed;
+
 export default Ember.Controller.extend({
+  auth: service(),
   allHooks: [],
-  userBinding: 'auth.currentUser',
+  user: alias('auth.currentUser'),
 
   init() {
     var self;

--- a/app/controllers/accounts/info.js
+++ b/app/controllers/accounts/info.js
@@ -1,8 +1,11 @@
 import Ember from 'ember';
 
-const { controller } = Ember.inject;
+const { alias } = Ember.computed;
+const { controller, service } = Ember.inject;
 
 export default Ember.Controller.extend({
+  auth: service(),
   repos: controller(),
-  userBinding: 'auth.currentUser'
+
+  user: alias('auth.currentUser'),
 });

--- a/app/controllers/build.js
+++ b/app/controllers/build.js
@@ -1,16 +1,17 @@
 import Ember from 'ember';
 import GithubUrlProperties from 'travis/mixins/github-url-properties';
 
-const { controller } = Ember.inject;
+const { service, controller } = Ember.inject;
+const { alias } = Ember.computed;
 
 export default Ember.Controller.extend(GithubUrlProperties, {
+  auth: service(),
   repoController: controller('repo'),
-  repoBinding: 'repoController.repo',
-  commitBinding: 'build.commit',
-  currentUserBinding: 'auth.currentUser',
-  tabBinding: 'repoController.tab',
+
+  repo: alias('repoController.repo'),
+  currentUser: alias('auth.currentUser'),
+  tab: alias('repoController.tab'),
   sendFaviconStateChanges: true,
-  currentItemBinding: 'build',
 
   jobsLoaded: function() {
     var jobs;

--- a/app/controllers/builds.js
+++ b/app/controllers/builds.js
@@ -1,15 +1,16 @@
 import Ember from 'ember';
 
 const { controller } = Ember.inject;
+const { alias } = Ember.computed;
 
 export default Ember.Controller.extend({
   buildsSorting: ['number:desc'],
   builds: Ember.computed.sort('model', 'buildsSorting'),
   repoController: controller('repo'),
-  repoBinding: 'repoController.repo',
-  tabBinding: 'repoController.tab',
-  isLoadedBinding: 'model.isLoaded',
-  isLoadingBinding: 'model.isLoading',
+  repo: alias('repoController.repo'),
+  tab: alias('repoController.tab'),
+  isLoaded: alias('model.isLoaded'),
+  isLoading: alias('model.isLoading'),
 
   showMore() {
     var id, number, type;

--- a/app/controllers/job.js
+++ b/app/controllers/job.js
@@ -1,15 +1,15 @@
 import Ember from 'ember';
 import { githubCommit } from 'travis/utils/urls';
 
-const { controller } = Ember.inject;
+const { service, controller } = Ember.inject;
+const { alias } = Ember.computed;
 
 export default Ember.Controller.extend({
+  auth: service(),
   repoController: controller('repo'),
-  repoBinding: 'repoController.repo',
-  commitBinding: 'job.commit',
-  currentUserBinding: 'auth.currentUser',
-  tabBinding: 'repoController.tab',
-  currentItemBinding: 'job',
+  repo: alias('repoController.repo'),
+  currentUser: alias('auth.currentUser'),
+  tab: alias('repoController.tab'),
 
   urlGithubCommit: function() {
     return githubCommit(this.get('repo.slug'), this.get('commit.sha'));

--- a/app/controllers/profile.js
+++ b/app/controllers/profile.js
@@ -1,13 +1,16 @@
 import Ember from 'ember';
 
-const { controller } = Ember.inject;
+const { service, controller } = Ember.inject;
+const { alias } = Ember.computed;
 
 export default Ember.Controller.extend({
   name: 'profile',
+  auth: service(),
   accountController: controller('account'),
   accountsController: controller('accounts'),
-  userBinding: 'auth.currentUser',
-  accountBinding: 'accountController.model',
+
+  user: alias('auth.currentUser'),
+  account: alias('accountController.model'),
 
   activate(action, params) {
     return this[("view_" + action).camelize()]();

--- a/app/controllers/repo.js
+++ b/app/controllers/repo.js
@@ -3,8 +3,8 @@ import { githubRepo, statusImage } from 'travis/utils/urls';
 import config from 'travis/config/environment';
 import eventually from 'travis/utils/eventually';
 
-
-const { controller, service } = Ember.inject;
+const { service, controller } = Ember.inject;
+const { alias } = Ember.computed;
 
 export default Ember.Controller.extend({
   updateTimesService: service('updateTimes'),
@@ -14,8 +14,8 @@ export default Ember.Controller.extend({
   buildController: controller('build'),
   buildsController: controller('builds'),
   reposController: controller('repos'),
-  reposBinding: 'reposController.repos',
-  currentUserBinding: 'auth.currentUser',
+  repos: alias('reposController.repos'),
+  currentUser: alias('auth.currentUser'),
 
   classNames: ['repo'],
 

--- a/app/controllers/repos.js
+++ b/app/controllers/repos.js
@@ -2,6 +2,9 @@ import Ember from 'ember';
 import Repo from 'travis/models/repo';
 import Config from 'travis/config/environment';
 
+const { service, controller } = Ember.inject;
+const { alias } = Ember.computed;
+
 var sortCallback = function(repo1, repo2) {
   // this function could be made simpler, but I think it's clearer this way
   // what're we really trying to achieve
@@ -47,11 +50,8 @@ var sortCallback = function(repo1, repo2) {
   throw "should not happen";
 };
 
-
-
-const { controller, service } = Ember.inject;
-
 var Controller = Ember.Controller.extend({
+  auth: service(),
   ajax: service(),
   updateTimesService: service('updateTimes'),
 
@@ -85,7 +85,7 @@ var Controller = Ember.Controller.extend({
 
   isLoaded: false,
   repoController: controller('repo'),
-  currentUserBinding: 'auth.currentUser',
+  currentUser: alias('auth.currentUser'),
 
   selectedRepo: function() {
     return this.get('repoController.repo.content') || this.get('repoController.repo');

--- a/app/controllers/top.js
+++ b/app/controllers/top.js
@@ -1,13 +1,15 @@
 import Ember from 'ember';
 import config from 'travis/config/environment';
 
+const { alias } = Ember.computed;
 const { service } = Ember.inject;
 
 export default Ember.Controller.extend({
-  userBinding: 'auth.currentUser',
+  auth: service(),
   store: service(),
   storage: service(),
-  currentUserBinding: 'auth.currentUser',
+
+  user: alias('auth.currentUser'),
 
   userName: function() {
     return this.get('user.name') || this.get('user.login');

--- a/app/mixins/repo-actions-item-component-mixin.js
+++ b/app/mixins/repo-actions-item-component-mixin.js
@@ -2,9 +2,13 @@ import Ember from 'ember';
 import eventually from 'travis/utils/eventually';
 
 const { service } = Ember.inject;
+const { alias } = Ember.computed;
 
 export default Ember.Mixin.create({
   flashes: service(),
+  auth: service(),
+
+  user: alias('auth.currentUser'),
 
   restarting: false,
   cancelling: false,

--- a/app/models/account.js
+++ b/app/models/account.js
@@ -2,6 +2,8 @@ import Ember from 'ember';
 import attr from 'ember-data/attr';
 import Model from 'travis/models/model';
 
+const { alias } = Ember.computed;
+
 export default Model.extend({
   name: attr(),
   type: attr(),
@@ -9,5 +11,5 @@ export default Model.extend({
   reposCount: attr('number'),
   subscribed: attr('boolean'),
   education: attr('boolean'),
-  loginBinding: 'id'
+  login: alias('id')
 });

--- a/app/services/flashes.js
+++ b/app/services/flashes.js
@@ -1,8 +1,13 @@
 import Ember from 'ember';
 import LimitedArray from 'travis/utils/limited-array';
 
+const { service } = Ember.inject;
+const { alias } = Ember.computed;
+
 export default Ember.Service.extend({
-  currentUserBinding: 'auth.currentUser',
+  auth: service(),
+  store: service(),
+  currentUser: alias('auth.currentUser'),
 
   init() {
     this._super(...arguments);

--- a/app/templates/account.hbs
+++ b/app/templates/account.hbs
@@ -21,7 +21,7 @@
       <h1>{{accountName}}</h1>
     </div>
 
-    {{sync-button user=auth.currentUser}}
+    {{sync-button}}
 
     {{#unless config.enterprise}}
       {{#if config.pro}}

--- a/app/templates/build.hbs
+++ b/app/templates/build.hbs
@@ -3,7 +3,7 @@
   {{loading-indicator}}
 {{else}}
 
-  {{build-header item=build user=auth.currentUser commit=commit repo=repo}}
+  {{build-header item=build commit=build.commit repo=repo}}
 
   {{#if build.isMatrix}}
     {{#if jobsLoaded}}

--- a/app/templates/components/build-header.hbs
+++ b/app/templates/components/build-header.hbs
@@ -82,8 +82,8 @@
 </div>
 <div class="build-tools">
   {{#if isJob}}
-    {{repo-actions job=item repo=item.repo user=auth.currentUser}}
+    {{repo-actions job=item repo=item.repo}}
   {{else}}
-    {{repo-actions build=item repo=item.repo user=user}}
+    {{repo-actions build=item repo=item.repo}}
   {{/if}}
 </div>

--- a/app/templates/components/repo-actions.hbs
+++ b/app/templates/components/repo-actions.hbs
@@ -1,7 +1,7 @@
 {{! TODO: when `component` helper is available we could just use
 with a component name based on type that is passed here }}
 {{#if job}}
-  {{job-repo-actions job=job user=user repo=repo}}
+  {{job-repo-actions job=job repo=repo}}
 {{else}}
-  {{build-repo-actions build=build user=user repo=repo}}
+  {{build-repo-actions build=build repo=repo}}
 {{/if}}

--- a/app/templates/dashboard/repositories.hbs
+++ b/app/templates/dashboard/repositories.hbs
@@ -1,7 +1,7 @@
 <div class="inner">
   <div class="dashboard-header">
     {{orgs-filter orgs=orgs selected=selectedOrg action="selectOrg"}}
-    {{sync-button user=auth.currentUser}}
+    {{sync-button}}
   </div>
 
   <div class="dashboard-repos">

--- a/app/templates/job.hbs
+++ b/app/templates/job.hbs
@@ -1,7 +1,7 @@
 {{#job-wrapper repo=repo job=job}}
 {{#if job.isLoaded}}
 
-  {{build-header item=job user=auth.currentUser commit=job.commit repo=repo}}
+  {{build-header item=job commit=job.commit repo=repo}}
 
   {{job-log job=job}}
 

--- a/app/templates/repo.hbs
+++ b/app/templates/repo.hbs
@@ -18,7 +18,7 @@
       </header>
       <main class="repo-main">
         <div class="repo-navigation">
-          {{repo-show-tools repo=repo build=build job=job tab=tab currentUser=auth.currentUser}}
+          {{repo-show-tools repo=repo build=build job=job tab=tab}}
 
           {{repo-show-tabs repo=repo tab=tab build=build job=job}}
         </div>

--- a/app/templates/repo/not-active.hbs
+++ b/app/templates/repo/not-active.hbs
@@ -1,1 +1,1 @@
-{{not-active user=auth.currentUser repo=repo}}
+{{not-active repo=repo}}

--- a/app/utils/limited-array.js
+++ b/app/utils/limited-array.js
@@ -1,9 +1,11 @@
 import Ember from 'ember';
 import limit from 'travis/utils/computed-limit';
 
+const { alias } = Ember.computed;
+
 export default Ember.ArrayProxy.extend({
   limit: 10,
-  isLoadedBinding: 'content.isLoaded',
+  isLoaded: alias('content.isLoaded'),
   arrangedContent: limit('content', 'limit'),
 
   totalLength: function() {

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -87,6 +87,10 @@ export default function() {
     return {jobs: schema.job.all()};
   });
 
+  this.get('/builds', function(schema, request) {
+    return {builds: schema.build.all()};
+  });
+
   this.get('/builds/:id', function(schema, request) {
     let build = schema.build.find(request.params.id).attrs;
     let jobs = schema.job.where({build_id: build.id}).map(job => job.attrs);

--- a/tests/acceptance/builds/restart-test.js
+++ b/tests/acceptance/builds/restart-test.js
@@ -17,6 +17,7 @@ test('restarting build', function(assert) {
   let job = server.create('job', {number: '1234.1', repository_id: repo.id, state: 'passed', build_id: build.id, commit_id: commit.id});
   let log = server.create('log', { id: job.id });
   let repoId = parseInt(repo.id);
+
   server.create('permissions', {
     admin: [repoId],
     push: [repoId],

--- a/tests/unit/components/build-repo-actions-test.js
+++ b/tests/unit/components/build-repo-actions-test.js
@@ -1,7 +1,25 @@
 import { test, moduleForComponent } from 'ember-qunit';
 import Ember from 'ember';
+
+let userStub = Ember.Object.extend({
+  hasAccessToRepo: function(repo) {
+    ok(repo.get('id', 44));
+    ok(true, 'hasAccessToRepo was called');
+    return false;
+  }
+}).create();
+
+// stub auth service
+const authStub = Ember.Service.extend({
+  currentUser: userStub
+});
+
 moduleForComponent('build-repo-actions', 'BuildRepoActionsComponent', {
-  unit: true
+  unit: true,
+  beforeEach() {
+    this.register('service:auth', authStub);
+    this.inject.service('auth');
+  }
 });
 
 test('it shows cancel button if canCancel is true', function() {
@@ -62,15 +80,7 @@ test('it properly checks for user permissions for a repo', function() {
   repo = Ember.Object.create({
     id: 44
   });
-  user = Ember.Object.extend({
-    hasAccessToRepo: function(repo) {
-      ok(repo.get('id', 44));
-      ok(true, 'hasAccessToRepo was called');
-      return false;
-    }
-  }).create();
   component = this.subject({
-    user: user,
     repo: repo
   });
   return ok(!component.get('userHasPermissionForRepo'), 'user should not have access to a repo');

--- a/tests/unit/components/job-repo-actions-test.js
+++ b/tests/unit/components/job-repo-actions-test.js
@@ -1,8 +1,24 @@
 import { test, moduleForComponent } from 'ember-qunit';
 import Ember from 'ember';
 
+let userStub = Ember.Object.extend({
+  hasAccessToRepo: function(repo) {
+    ok(repo.get('id', 44));
+    ok(true, 'hasAccessToRepo was called');
+    return false;
+  }
+}).create();
+
+// stub auth service
+const authStub = Ember.Service.extend({
+  currentUser: userStub
+});
+
 moduleForComponent('job-repo-actions', 'JobRepoActionsComponent', {
-  unit: true
+  unit: true,
+  beforeEach() {
+    this.register('service:auth', authStub);
+  }
 });
 
 test('it shows cancel button if canCancel is true', function() {
@@ -63,15 +79,7 @@ test('it properly checks for user permissions for a repo', function() {
   repo = Ember.Object.create({
     id: 44
   });
-  user = Ember.Object.extend({
-    hasAccessToRepo: function(repo) {
-      ok(repo.get('id', 44));
-      ok(true, 'hasAccessToRepo was called');
-      return false;
-    }
-  }).create();
   component = this.subject({
-    user: user,
     repo: repo
   });
   return ok(!component.get('userHasPermissionForRepo'), 'user should not have access to a repo');

--- a/tests/unit/components/not-active-test.js
+++ b/tests/unit/components/not-active-test.js
@@ -1,23 +1,24 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import Ember from 'ember';
 
+const authServiceStub = Ember.Service.extend({
+  currentUser: Ember.Object.create({ pushPermissions: [1] })
+});
+
 moduleForComponent('not-active', 'Unit | Component | not active', {
-  // Specify the other units that are required for this test
-  // needs: ['component:foo', 'helper:bar'],
-  unit: true
+  unit: true,
+  beforeEach() {
+    this.register('service:auth', authServiceStub);
+    this.inject.service('auth', { as: 'auth' });
+  }
 });
 
 test('canActivate returns true if a user has access to a repo', function(assert) {
   let component = this.subject();
-
-  let user = Ember.Object.create({ pushPermissions: [1] });
   let repo = Ember.Object.create({ id: 1 });
 
-  component.set('user', user);
   component.set('repo', repo);
 
-  //this.render();
-  //assert.equal(this.$().text().trim(), '');
   assert.ok(component.get('canActivate'));
 });
 
@@ -30,10 +31,8 @@ test("canActivate returns false if user doesn't exist", function(assert) {
 test("canActivate returns false if user doesn't push access to the repo", function(assert) {
   let component = this.subject();
 
-  let user = Ember.Object.create({ pushPermissions: [2] });
-  let repo = Ember.Object.create({ id: 1 });
+  let repo = Ember.Object.create({ id: 2 });
 
-  component.set('user', user);
   component.set('repo', repo);
 
   assert.ok(!component.get('canActivate'));


### PR DESCRIPTION
These bindings can be replaced wholesale with the more idiomatic
alternative: aliases.

In addition, avoid passing in user to components where it can be injected directly.

One of the perceived downsides of dependency injection can be
that it can make debugging feel more difficult because it's not
immediately clear where the value is coming from, which the explicit
variant we previously used does not suffer from.

While explicitness is often a virtue, it comes at the cost of increased
noise that pervades multiple layers of components. I'd argue this makes
the parent components more difficult to understand, given they are
littered with unnecessary references to data they themselves do not
need.

My only concern with this PR is that, without acceptance tests in place, that I may
have inadvertently broken something. I've done extensive smoke testing to try and
compensate for that, but it's possible I've overlooked something.