### PR TITLE
Don't wait for downloading user data when opening the app

### DIFF
--- a/app/components/branch-row.js
+++ b/app/components/branch-row.js
@@ -7,6 +7,8 @@ const { service } = Ember.inject;
 
 export default Ember.Component.extend({
   routing: service('-routing'),
+  permissions: service(),
+
   tagName: 'li',
   classNameBindings: ['branch.last_build.state'],
   classNames: ['branch-row', 'row-li'],
@@ -56,18 +58,8 @@ export default Ember.Component.extend({
   }.property(),
 
   canTrigger: function() {
-    var permissions;
-    if (!this.get('auth.signedIn')) {
-      return false;
-    } else {
-      permissions = this.get('auth.currentUser.permissions');
-      if (permissions.contains(parseInt(this.get('branch.repository.id')))) {
-        return true;
-      } else {
-        return false;
-      }
-    }
-  }.property(),
+    return this.get('permissions').hasPermission(this.get('branch.repository'));
+  }.property('permissions.all', 'build.repository'),
 
   triggerBuild: function() {
     var apiEndpoint, options, repoId;

--- a/app/components/dashboard-row.js
+++ b/app/components/dashboard-row.js
@@ -3,7 +3,11 @@ import { githubCommit as githubCommitUrl } from 'travis/utils/urls';
 import config from 'travis/config/environment';
 import { hasAdminPermission, hasPushPermission } from 'travis/utils/permission';
 
+const { service } = Ember.inject;
+
 export default Ember.Component.extend({
+  permissions: service(),
+
   tagName: 'li',
   classNameBindings: ['repo.default_branch.last_build.state'],
   classNames: ['rows', 'rows--dashboard'],
@@ -16,13 +20,13 @@ export default Ember.Component.extend({
     return githubCommitUrl(this.get('repo.slug'), this.get('repo.default_branch.last_build.commit.sha'));
   }.property('repo'),
 
-  displayMenuTofu: function() {
-    return hasPushPermission(this.get('currentUser'), this.get('repo.id'));
-  },
+  displayMenuTofu: Ember.computed('permissions.all', 'repo', function() {
+    return this.get('permissions').hasPushPermission(this.get('repo'));
+  }),
 
-  displayActivateLink: function() {
-    return hasAdminPermission(this.get('currentUser'), this.get('repo.id'));
-  },
+  displayActivateLink: Ember.computed('permissions.all', 'repo', function() {
+    return this.get('permissions').hasAdminPermission(this.get('repo'));
+  }),
 
   actions: {
     tiggerBuild(branch) {

--- a/app/components/log-content.js
+++ b/app/components/log-content.js
@@ -62,6 +62,8 @@ const { service } = Ember.inject;
 
 export default Ember.Component.extend({
   popup: service(),
+  permissions: service(),
+
   classNameBindings: ['logIsVisible:is-open'],
   logIsVisible: false,
   currentUserBinding: 'auth.currentUser',
@@ -192,11 +194,8 @@ export default Ember.Component.extend({
   }.property('job.log.id', 'job.log.token'),
 
   hasPermission: function() {
-    var permissions;
-    if (permissions = this.get('currentUser.permissions')) {
-      return permissions.contains(parseInt(this.get('job.repo.id')));
-    }
-  }.property('currentUser.permissions.length', 'job.repo.id'),
+    return this.get('permissions').hasPermission(this.get('job.repo'));
+  }.property('permissions.all', 'job.repo'),
 
   canRemoveLog: function() {
     var job;

--- a/app/components/not-active.js
+++ b/app/components/not-active.js
@@ -1,8 +1,10 @@
 import Ember from 'ember';
 import config from 'travis/config/environment';
 
+const { service } = Ember.inject;
+
 export default Ember.Component.extend({
-  flashes: Ember.inject.service(),
+  flashes: service(),
 
   canActivate: function() {
     let user = this.get('user');

--- a/app/components/repo-show-tools.js
+++ b/app/components/repo-show-tools.js
@@ -1,11 +1,12 @@
 import Ember from 'ember';
 import config from 'travis/config/environment';
-import { hasPermission, hasPushPermission } from 'travis/utils/permission';
 
 const { service } = Ember.inject;
 
 export default Ember.Component.extend({
   popup: service(),
+  permissions: service(),
+
   classNames: ['option-button'],
   classNameBindings: ['isOpen:display'],
   isOpen: false,
@@ -26,15 +27,15 @@ export default Ember.Component.extend({
     }
   },
   displaySettingsLink: function() {
-    return hasPushPermission(this.get('currentUser'), this.get('repo.id'));
-  }.property('currentUser.pushPermissions.length', 'repo'),
+    return this.get('permissions').hasPushPermission(this.get('repo'));
+  }.property('permissions.all', 'repo'),
 
   displayCachesLink: function() {
-    return hasPushPermission(this.get('currentUser'), this.get('repo.id')) && config.endpoints.caches;
-  }.property('currentUser.pushPermissions.length', 'repo'),
+    return this.get('permissions').hasPushPermission(this.get('repo')) && config.endpoints.caches;
+  }.property('permissions.all', 'repo'),
 
   displayStatusImages: function() {
-    return hasPermission(this.get('currentUser'), this.get('repo.id'));
-  }.property('currentUser.permissions.length', 'repo.id')
+    return this.get('permissions').hasPermission(this.get('repo'));
+  }.property('permissions.all', 'repo'),
 
 });

--- a/app/controllers/repo.js
+++ b/app/controllers/repo.js
@@ -23,6 +23,10 @@ export default Ember.Controller.extend({
   builds: Ember.computed.alias('buildsController.content'),
   job: Ember.computed.alias('jobController.job'),
 
+  reset() {
+    this.set('repo', null);
+  },
+
   isEmpty: function() {
     return this.get('repos.isLoaded') && this.get('repos.length') === 0;
   }.property('repos.isLoaded', 'repos.length'),

--- a/app/services/flashes.js
+++ b/app/services/flashes.js
@@ -62,14 +62,14 @@ export default Ember.Service.extend({
   },
 
   display(type, message) {
-    if(!['error', 'notice', 'warning'].contains(type)) {
-      console.warn("WARNING: <service:flashes> display(type, message) function can only handle 'error', 'notice' and 'warning' types");
+    if(!['error', 'notice', 'success'].contains(type)) {
+      console.warn("WARNING: <service:flashes> display(type, message) function can only handle 'error', 'notice' and 'success' types");
     }
     this.loadFlashes([{ [type]: message }]);
   },
 
-  warning(message) {
-    this.display('warning', message);
+  success(message) {
+    this.display('success', message);
   },
 
   error(message) {

--- a/app/services/flashes.js
+++ b/app/services/flashes.js
@@ -7,6 +7,10 @@ export default Ember.Service.extend({
   init() {
     this._super(...arguments);
 
+    this.setup();
+  },
+
+  setup() {
     this.set('flashes', LimitedArray.create({
       limit: 1,
       content: []
@@ -59,6 +63,10 @@ export default Ember.Service.extend({
 
   close(msg) {
     return this.get('flashes').removeObject(msg);
+  },
+
+  clear() {
+    this.setup();
   },
 
   display(type, message) {

--- a/app/services/permissions.js
+++ b/app/services/permissions.js
@@ -1,0 +1,31 @@
+import Ember from 'ember';
+import { hasPermission, hasPushPermission, hasAdminPermission } from 'travis/utils/permission';
+
+const { service } = Ember.inject;
+
+export default Ember.Service.extend({
+  auth: service(),
+
+  currentUser: Ember.computed.alias('auth.currentUser'),
+  // This is computed property that can be used to allow any properties that
+  // use permissions service to add dependencies easier. So instead of depending
+  // on each of these things separately, we can depend on all
+  all: Ember.computed('currentUser.permissions', 'currentUser.permissions.[]',
+         'currentUser.pushPermissions', 'currentUser.pushPermissions.[]',
+         'currentUser.adminPermissions', 'currentUser.adminPermissions.[]',
+         function() {
+            return;
+         }),
+
+  hasPermission(repo) {
+    return hasPermission(this.get('currentUser'), repo);
+  },
+
+  hasPushPermission(repo) {
+    return hasPushPermission(this.get('currentUser'), repo);
+  },
+
+  hasAdminPermission(repo) {
+    return hasAdminPermission(this.get('currentUser'), repo);
+  }
+});

--- a/app/utils/permission.js
+++ b/app/utils/permission.js
@@ -1,31 +1,22 @@
 
-var hasPermission = function(user, repoId) {
-  var id = parseInt(repoId);
-  var permissions;
-  if (user) {
-    if (permissions = user.get('permissions')) {
-      return permissions.contains(id);
-    }
+var hasPermission = function(user, repo) {
+  let id = isNaN(repo) ? repo.get('id') : parseInt(repo);
+  if(user) {
+    return user.get('permissions').contains(id);
   }
 };
 
-var hasPushPermission = function(user, repoId) {
-  var id = parseInt(repoId);
-  var permissions;
-  if (user) {
-    if (permissions = user.get('pushPermissions')) {
-      return permissions.contains(id);
-    }
+var hasPushPermission = function(user, repo) {
+  let id = isNaN(repo) ? repo.get('id') : parseInt(repo);
+  if(user) {
+    return user.get('pushPermissions').contains(id);
   }
 };
 
-var hasAdminPermission = function(user, repoId) {
-  var id = parseInt(repoId);
-  var permissions;
-  if (user) {
-    if (permissions = user.get('adminPermissions')) {
-      return permissions.contains(id);
-    }
+var hasAdminPermission = function(user, repo) {
+  let id = isNaN(repo) ? repo.get('id') : parseInt(repo);
+  if(user) {
+    return user.get('adminPermissions').contains(id);
   }
 };
 

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -46,9 +46,13 @@ export default function() {
   });
 
   this.get('/users/:id', (schema, request) => {
-    let user = schema.user.find(request.params.id);
-    if (user) {
-      return { user: user.attrs };
+    if(request.requestHeaders.Authorization === 'token testUserToken') {
+      let user = schema.user.find(request.params.id);
+      if (user) {
+        return { user: user.attrs };
+      }
+    } else {
+      return new Mirage.Response(403, {}, {});
     }
   });
 

--- a/tests/acceptance/auth/automatic-sign-out-test.js
+++ b/tests/acceptance/auth/automatic-sign-out-test.js
@@ -1,0 +1,21 @@
+import { test } from 'qunit';
+import moduleForAcceptance from 'travis/tests/helpers/module-for-acceptance';
+import authPage from 'travis/tests/pages/auth';
+
+moduleForAcceptance('Acceptance | automatic sign out', {
+  beforeEach() {
+    const currentUser = server.create('user');
+    signInUser(currentUser);
+  }
+});
+
+test('when token is invalid user should be signed out', function(assert) {
+  window.sessionStorage.setItem('travis.token', 'wrong-token');
+  window.localStorage.setItem('travis.token', 'wrong-token');
+
+  visit('/');
+
+  andThen(function() {
+    assert.equal(authPage.automaticSignOutNotification, "You've been signed out, because your access token has expired.");
+  });
+});

--- a/tests/acceptance/profile-test.js
+++ b/tests/acceptance/profile-test.js
@@ -9,7 +9,7 @@ moduleForAcceptance('Acceptance | profile', {
       login: 'feministkilljoy',
       repos_count: 3
     });
-    
+
     signInUser(currentUser);
 
     const organization = server.create('account', {
@@ -84,7 +84,7 @@ test('view token', function(assert) {
   profilePage.token.show();
 
   andThen(function() {
-    assert.equal(profilePage.token.value, 'abc123');
+    assert.equal(profilePage.token.value, 'testUserToken');
   });
 });
 

--- a/tests/helpers/sign-in-user.js
+++ b/tests/helpers/sign-in-user.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Test.registerAsyncHelper('signInUser', function(app, user) {
   const localStorageUser = JSON.parse(JSON.stringify(user.attrs));
-  localStorageUser.token = "abc123";
+  localStorageUser.token = "testUserToken";
   window.localStorage.setItem('travis.token', 'testUserToken');
   window.localStorage.setItem('travis.user', JSON.stringify(localStorageUser));
 });

--- a/tests/pages/auth.js
+++ b/tests/pages/auth.js
@@ -1,0 +1,11 @@
+import PageObject from 'travis/tests/page-object';
+
+let {
+  clickable,
+  visitable,
+  text
+} = PageObject;
+
+export default PageObject.create({
+  automaticSignOutNotification: text('p.flash-message')
+});

--- a/tests/unit/services/flashes-test.js
+++ b/tests/unit/services/flashes-test.js
@@ -15,23 +15,23 @@ test('it allows to show an error', function(assert) {
   assert.deepEqual(service.get('flashes.firstObject'), { message: 'There was an error!', type: 'error' }, 'there should be an error message in flashes');
 });
 
-test('it allows to show an notice', function(assert) {
+test('it allows to show a notice', function(assert) {
   let service = this.subject();
 
   assert.equal(service.get('flashes.length'), 0, 'precond - flashes initializes with 0 elements');
 
-  service.notice('There was an notice!');
+  service.notice('There was a notice!');
 
-  assert.deepEqual(service.get('flashes.firstObject'), { message: 'There was an notice!', type: 'notice' }, 'there should be an notice message in flashes');
+  assert.deepEqual(service.get('flashes.firstObject'), { message: 'There was a notice!', type: 'notice' }, 'there should be a notice message in flashes');
 });
 
-test('it allows to show an warning', function(assert) {
+test('it allows to show a success', function(assert) {
   let service = this.subject();
 
   assert.equal(service.get('flashes.length'), 0, 'precond - flashes initializes with 0 elements');
 
-  service.warning('There was an warning!');
+  service.success('There was a success!');
 
-  assert.deepEqual(service.get('flashes.firstObject'), { message: 'There was an warning!', type: 'warning' }, 'there should be an warning message in flashes');
+  assert.deepEqual(service.get('flashes.firstObject'), { message: 'There was a success!', type: 'success' }, 'there should be a notice message in flashes');
 });
 

--- a/tests/unit/services/permissions-test.js
+++ b/tests/unit/services/permissions-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('service:permissions', 'Unit | Service | permissions', {
+  // Specify the other units that are required for this test.
+  // needs: ['service:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let service = this.subject();
+  assert.ok(service);
+});

--- a/tests/unit/utils/permission-test.js
+++ b/tests/unit/utils/permission-test.js
@@ -6,21 +6,51 @@ module('Unit | Utility | permission');
 
 test('it checks permissions', function(assert) {
   let user = Ember.Object.create({permissions: [1]});
+
   assert.ok(hasPermission(user, 1));
   assert.ok(!hasPermission(user, 2));
   assert.ok(!hasPermission(null, 1));
 });
 
+test('it checks permissions if a repo object is given', function(assert) {
+  let repo1 = Ember.Object.create({ id: 1 }),
+      repo2 = Ember.Object.create({ id: 2 }),
+      user  = Ember.Object.create({permissions: [1]});
+
+  assert.ok(hasPermission(user, repo1));
+  assert.ok(!hasPermission(user, repo2));
+});
+
 test('it checks push permissions', function(assert) {
   let user = Ember.Object.create({pushPermissions: [1]});
+
   assert.ok(hasPushPermission(user, 1));
   assert.ok(!hasPushPermission(user, 2));
   assert.ok(!hasPushPermission(null, 1));
 });
 
+test('it checks push permissions if a repo object is given', function(assert) {
+  let repo1 = Ember.Object.create({ id: 1 }),
+      repo2 = Ember.Object.create({ id: 2 }),
+      user  = Ember.Object.create({pushPermissions: [1]});
+
+  assert.ok(hasPushPermission(user, repo1));
+  assert.ok(!hasPushPermission(user, repo2));
+});
+
 test('it checks admin permissions', function(assert) {
   let user = Ember.Object.create({adminPermissions: [1]});
+
   assert.ok(hasAdminPermission(user, 1));
   assert.ok(!hasAdminPermission(user, 2));
   assert.ok(!hasAdminPermission(null, 1));
+});
+
+test('it checks admin permissions if a repo object is given', function(assert) {
+  let repo1 = Ember.Object.create({ id: 1 }),
+      repo2 = Ember.Object.create({ id: 2 }),
+      user  = Ember.Object.create({adminPermissions: [1]});
+
+  assert.ok(hasAdminPermission(user, repo1));
+  assert.ok(!hasAdminPermission(user, repo2));
 });


### PR DESCRIPTION
This is still WIP, but I wanted to create a PR already.

This is meant to fix the problem with long page when fetching user data takes longer. Originally we didn't check user data when page was loaded. Instead, we were relying on user data set in local storage. If user's token was invalid, some of the requests would fail and we would log user out. This led to some problems and recently I changed the strategy to always check user data when the app starts. The problem is that if loading user data takes long time, a user will see a blank page. We could of course put a spinner there, but I think that we could also get back to the old strategy and load user data in background. This will require a few tweaks in the code to handle some situations better, but it will allow people to use the site quicker.