### PR TITLE
fix image format for POD

### DIFF
--- a/app/utils/status-image-formats.js
+++ b/app/utils/status-image-formats.js
@@ -27,7 +27,7 @@ rstStatusImage = (function(url, slug, branch) {
 });
 
 podStatusImage = (function(url, slug, branch) {
-  return "=for HTML <a href=\"" + url + "\"><img src=\"" + (statusImageUrl(slug, branch)) + "\"></a>";
+  return "=for html <a href=\"" + url + "\"><img src=\"" + (statusImageUrl(slug, branch)) + "\"></a>";
 });
 
 ccxmlStatusUrl = (function(slug, branch) {


### PR DESCRIPTION
Some POD parsers recognize only lowercase format names.

For e.g., pod2markdown fails to generate a markdown file with the status image if the format is 'HTML'