### PR TITLE
pass through Env.pusher.channelPrefix for enterprise

### DIFF
--- a/waiter/config.ru
+++ b/waiter/config.ru
@@ -59,6 +59,7 @@ run Travis::Web::App.build(
   pusher_key:      ENV['PUSHER_KEY'],
   pusher_host:     ENV['PUSHER_HOST'] || 'ws.pusherapp.com',
   pusher_path:     ENV['PUSHER_PATH'],
+  pusher_channel_prefix: ENV['PUSHER_CHANNEL_PREFIX'],
   ga_code:         ENV['GA_CODE'],
   root:            File.expand_path('../../dist', __FILE__),
   server_start:    Time.now,

--- a/waiter/lib/travis/web/app.rb
+++ b/waiter/lib/travis/web/app.rb
@@ -141,7 +141,7 @@ class Travis::Web::App
 
     def expires(file)
       if fingerprinted?(file)
-        (server_start + age).httpdate 
+        (server_start + age).httpdate
       else
         '0'
       end
@@ -189,6 +189,7 @@ class Travis::Web::App
       pusher['key'] = options[:pusher_key] if options[:pusher_key]
       pusher['host'] = options[:pusher_host] if options[:pusher_host]
       pusher['path'] = options[:pusher_path] if options[:pusher_path]
+      pusher['channel_prefix'] = options[:pusher_channel_prefix] if options[:pusher_channel_prefix]
       config['pusher'] = pusher
 
       config['ember-cli-pendo'] = { apiKey: options[:pendo_key] }


### PR DESCRIPTION
this fixes live log updates on enterprise (also, removes one trailing space, ha!)