### PR TITLE
Remove moment deprecation on builds page

### DIFF
--- a/app/helpers/pretty-date.js
+++ b/app/helpers/pretty-date.js
@@ -2,5 +2,6 @@ import { timeAgoInWords, safe } from 'travis/utils/helpers';
 import Ember from "ember";
 
 export default Ember.Helper.helper(function(params) {
-  return safe(moment(params[0]).format('MMMM D, YYYY H:mm:ss') || '-');
+  let date = new Date(params[0]);
+  return safe(moment(date).format('MMMM D, YYYY H:mm:ss') || '-');
 });


### PR DESCRIPTION
See https://github.com/moment/moment/issues/1407 for more details. All that was needed was to manually instantiate a new Date() object