### PR TITLE
show smalltalk config matrix expansion key

### DIFF
--- a/app/utils/keys-map.js
+++ b/app/utils/keys-map.js
@@ -11,6 +11,7 @@ languageConfigKeys = {
   python: 'Python',
   scala: 'Scala',
   smalltalk: 'Smalltalk',
+  smalltalk_config: 'Config',
   ruby: 'Ruby',
   d: 'D',
   julia: 'Julia',


### PR DESCRIPTION
display the `smalltalk_config` key (which is expanded to a matrix) in the web, so you can distinguish the builds
see https://github.com/travis-ci/travis-build/pull/689
fix https://github.com/hpi-swa/smalltalkCI/issues/128
cc @fniephaus