### PR TITLE
Fix ember-try deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ install:
   - bower install
 
 script:
-  - ember try $EMBER_VERSION
+  - ember try:one $EMBER_VERSION
 
 notifications:
   campfire:


### PR DESCRIPTION
See the logs here:
https://travis-ci.org/travis-ci/travis-web/jobs/124193154

> DEPRECATION: tryCmd command is deprecated in favor of `ember try:one`.
> Example: `ember try default-scenario serve --port 4201`, becomes:
> `ember try:one default-scenario --- ember serve --port 4201`

This deprecation came along with @clekstro’s recent package updates. Harder to see because it’s only a CLI thing.