### PR TITLE
Disable Sauce Connect

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,9 @@ matrix:
 
   fast_finish: true
 
-addons:
-  sauce_connect: true
+# TODO restore Sauce Connect when it’s actually being used
+# addons:
+#   sauce_connect: true
 
 sudo: false
 


### PR DESCRIPTION
It’s not currently being used and it’s limiting the number of concurrent builds, so this disables it until we want to start using it again.