### PR TITLE
Move debugging logging behind feature flag

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -46,7 +46,7 @@ export default ActiveModelAdapter.extend({
 
   handleResponse(status, headers, payload) {
     if (status > 299) {
-      if (this.features.isEnabled('debugging')) {
+      if (this.features.debugging) {
         console.log("[ERROR] API responded with an error (" + status + "): " + (JSON.stringify(payload)));
       }
     }

--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -5,6 +5,7 @@ import ActiveModelAdapter from 'active-model-adapter';
 const { service } = Ember.inject;
 
 export default ActiveModelAdapter.extend({
+  features: service(),
   auth: service(),
   host: config.apiEndpoint,
   coalesceFindRequests: true,
@@ -45,7 +46,9 @@ export default ActiveModelAdapter.extend({
 
   handleResponse(status, headers, payload) {
     if (status > 299) {
-      console.log("[ERROR] API responded with an error (" + status + "): " + (JSON.stringify(payload)));
+      if (this.features.isEnabled('debugging')) {
+        console.log("[ERROR] API responded with an error (" + status + "): " + (JSON.stringify(payload)));
+      }
     }
 
     return this._super(...arguments);

--- a/app/app.js
+++ b/app/app.js
@@ -10,11 +10,6 @@ Ember.LinkComponent.reopen({
 });
 
 var App = Ember.Application.extend(Ember.Evented, {
-  LOG_TRANSITIONS: true,
-  LOG_TRANSITIONS_INTERNAL: true,
-  LOG_ACTIVE_GENERATION: true,
-  LOG_MODULE_RESOLVER: true,
-  LOG_VIEW_LOOKUPS: true,
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
   Resolver: Resolver,

--- a/app/components/log-content.js
+++ b/app/components/log-content.js
@@ -67,7 +67,7 @@ export default Ember.Component.extend({
   currentUserBinding: 'auth.currentUser',
 
   didInsertElement() {
-    if (this.features.isEnabled('debugging')) {
+    if (this.features.debugging) {
       console.log('log view: did insert');
     }
     this._super(...arguments);
@@ -161,7 +161,7 @@ export default Ember.Component.extend({
   partsDidChange(parts, start, _, added) {
     Ember.run.schedule('afterRender', this, function() {
       var i, j, len, part, ref, ref1, ref2, results;
-      if (this.features.isEnabled('debugging')) {
+      if (this.features.debugging) {
         console.log('log view: parts did change');
       }
       if (this.get('_state') !== 'inDOM') {

--- a/app/components/log-content.js
+++ b/app/components/log-content.js
@@ -67,7 +67,7 @@ export default Ember.Component.extend({
   currentUserBinding: 'auth.currentUser',
 
   didInsertElement() {
-    if (Log.DEBUG) {
+    if (this.features.isEnabled('debugging')) {
       console.log('log view: did insert');
     }
     this._super(...arguments);
@@ -161,7 +161,7 @@ export default Ember.Component.extend({
   partsDidChange(parts, start, _, added) {
     Ember.run.schedule('afterRender', this, function() {
       var i, j, len, part, ref, ref1, ref2, results;
-      if (Log.DEBUG) {
+      if (this.features.isEnabled('debugging')) {
         console.log('log view: parts did change');
       }
       if (this.get('_state') !== 'inDOM') {

--- a/app/models/log.js
+++ b/app/models/log.js
@@ -113,7 +113,7 @@ var LogModel = Ember.Object.extend({
 
   fetch() {
     var handlers, id;
-    if (this.features.isEnabled('debugging')) {
+    if (this.features.debugging) {
       console.log('log model: fetching log');
     }
     this.clearParts();
@@ -167,7 +167,7 @@ var LogModel = Ember.Object.extend({
 
   loadParts(parts) {
     var i, len, part;
-    if (this.features.isEnabled('debugging')) {
+    if (this.features.debugging) {
       console.log('log model: load parts');
     }
     for (i = 0, len = parts.length; i < len; i++) {

--- a/app/models/log.js
+++ b/app/models/log.js
@@ -3,6 +3,8 @@ import Job from 'travis/models/job';
 import Ember from 'ember';
 import config from 'travis/config/environment';
 
+const { service } = Ember.inject;
+
 var Request = Ember.Object.extend({
   HEADERS: {
     accept: 'application/json; chunked=true; version=2, text/plain; version=2'
@@ -55,6 +57,7 @@ var Request = Ember.Object.extend({
 });
 
 var LogModel = Ember.Object.extend({
+  features: service(),
   version: 0,
   isLoaded: false,
   length: 0,
@@ -110,7 +113,7 @@ var LogModel = Ember.Object.extend({
 
   fetch() {
     var handlers, id;
-    if (Log.DEBUG) {
+    if (this.features.isEnabled('debugging')) {
       console.log('log model: fetching log');
     }
     this.clearParts();
@@ -164,7 +167,9 @@ var LogModel = Ember.Object.extend({
 
   loadParts(parts) {
     var i, len, part;
-    console.log('log model: load parts');
+    if (this.features.isEnabled('debugging')) {
+      console.log('log model: load parts');
+    }
     for (i = 0, len = parts.length; i < len; i++) {
       part = parts[i];
       this.append(part);

--- a/app/services/ajax.js
+++ b/app/services/ajax.js
@@ -70,7 +70,7 @@ export default Ember.Service.extend({
     };
     error = options.error || function() {};
     options.error = (data, status, xhr) => {
-      if (this.features.isEnabled('debugging')) {
+      if (this.features.debugging) {
         console.log("[ERROR] API responded with an error (" + status + "): " + (JSON.stringify(data)));
       }
       return error.call(this, data, status, xhr);

--- a/app/services/ajax.js
+++ b/app/services/ajax.js
@@ -13,6 +13,7 @@ default_options = {
 const { service } = Ember.inject;
 
 export default Ember.Service.extend({
+  features: service(),
   auth: service(),
 
   get(url, callback, errorCallback) {
@@ -69,7 +70,9 @@ export default Ember.Service.extend({
     };
     error = options.error || function() {};
     options.error = (data, status, xhr) => {
-      console.log("[ERROR] API responded with an error (" + status + "): " + (JSON.stringify(data)));
+      if (this.features.isEnabled('debugging')) {
+        console.log("[ERROR] API responded with an error (" + status + "): " + (JSON.stringify(data)));
+      }
       return error.call(this, data, status, xhr);
     };
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -36,6 +36,10 @@ module.exports = function(environment) {
     ajaxPolling: false
   };
 
+  ENV.featureFlags = {
+    debugging: false
+  };
+
   if (typeof process !== 'undefined') {
     if (process.env.TRAVIS_PRO && !process.env.TRAVIS_ENTERPRISE) {
       // set defaults for pro if it's used
@@ -72,11 +76,15 @@ module.exports = function(environment) {
   }
 
   if (environment === 'development') {
-    // ENV.APP.LOG_RESOLVER = true;
-    // ENV.APP.LOG_ACTIVE_GENERATION = true;
-    // ENV.APP.LOG_TRANSITIONS = true;
-    // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
-    // ENV.APP.LOG_VIEW_LOOKUPS = true;
+    ENV.featureFlags = {
+      debugging: true
+    };
+
+    ENV.APP.LOG_ACTIVE_GENERATION = true;
+    ENV.APP.LOG_TRANSITIONS = true;
+    ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
+    ENV.APP.LOG_VIEW_LOOKUPS = true;
+
     ENV['ember-cli-mirage'] = {
       enabled: false
     };
@@ -86,10 +94,6 @@ module.exports = function(environment) {
     // Testem prefers this...
     ENV.baseURL = '/';
     ENV.locationType = 'none';
-
-    // keep test console output quieter
-    ENV.APP.LOG_ACTIVE_GENERATION = false;
-    ENV.APP.LOG_VIEW_LOOKUPS = false;
 
     ENV.APP.rootElement = '#ember-testing';
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -105,6 +105,10 @@ module.exports = function(environment) {
     ENV['ember-cli-mirage'] = {
       enabled: false
     };
+
+    ENV.featureFlags = {
+      debugging: true
+    };
   }
 
   // TODO: I insert values from ENV here, but in production

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "ember-data-filter": "1.13.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.5",
+    "ember-feature-flags": "clekstro/ember-feature-flags#inject_into_adapters",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "ember-try": "0.2.2",


### PR DESCRIPTION
This removes the console clutter we have in our tests (as well as
production). The development environment would continue to contain the logged
information.

My plan for production was to create a debug button in the future that we could
activate at will to debug an issue, so we only have the logging as
needed.