### PR TITLE
Avoid building phantom.js from source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,12 +28,9 @@ cache:
     - node_modules
 
 before_install:
+  - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
   - "npm config set spin false"
   - "npm install -g npm@^2"
-  - mkdir travis-phantomjs
-  - wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
-  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -C $PWD/travis-phantomjs
-  - export PATH=$PWD/travis-phantomjs:$PATH
 
 install:
   - npm install -g bower


### PR DESCRIPTION
This doesn't appear to be necessary in other projects I've encountered
recently, so removing it to see if it makes any difference. If nothing
breaks, it shortens our build config at the very least.