### PR TITLE
Use dot reporter within CI for shorter logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
   - bower install
 
 script:
-  - ember try:one $EMBER_VERSION
+  - ember try:one $EMBER_VERSION --- ember test --reporter dot
 
 notifications:
   campfire:


### PR DESCRIPTION
This will still show a failure/stacktrace at the end of our builds, meaning it simply cuts down on the noise
of our passing tests