### PR TITLE
Add sentry integration

### DIFF
--- a/app/components/builds-item.js
+++ b/app/components/builds-item.js
@@ -6,6 +6,11 @@ export default Ember.Component.extend({
   classNameBindings: ['build.state'],
   classNames: ['row-li', 'pr-row'],
 
+  didInsertElement() {
+    this._super(...arguments);
+    throw new Error("Error");
+  },
+
   urlGithubCommit: function() {
     return githubCommitUrl(this.get('build.repo.slug'), this.get('build.commit.sha'));
   }.property('build.commit.sha')

--- a/app/services/raven.js
+++ b/app/services/raven.js
@@ -1,0 +1,26 @@
+import RavenLogger from 'ember-cli-sentry/services/raven';
+
+export default RavenLogger.extend({
+
+  unhandledPromiseErrorMessage: '',
+
+  captureException(/* error */) {
+    this._super(...arguments);
+  },
+
+  captureMessage(/* message */) {
+    return this._super(...arguments);
+  },
+
+  enableGlobalErrorCatching() {
+    return this._super(...arguments);
+  },
+
+  ignoreError() {
+    return this._super();
+  },
+
+  callRaven(/* methodName, ...optional */) {
+    return this._super(...arguments);
+  }
+});

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,8 @@
     "pretender": "~0.12.0",
     "lodash": "~3.7.0",
     "Faker": "~3.0.0",
-    "ceibo": "1.1.0"
+    "ceibo": "1.1.0",
+    "raven-js": "~2.1"
   },
   "resolutions": {
     "ember": "2.4.5"

--- a/config/environment.js
+++ b/config/environment.js
@@ -36,6 +36,11 @@ module.exports = function(environment) {
     ajaxPolling: false
   };
 
+
+  ENV.sentry = {
+    dsn: 'https://e775f26d043843bdb7ae391dc0f2487a@app.getsentry.com/75334'
+  }
+
   if (typeof process !== 'undefined') {
     if (process.env.TRAVIS_PRO && !process.env.TRAVIS_ENTERPRISE) {
       // set defaults for pro if it's used
@@ -80,6 +85,8 @@ module.exports = function(environment) {
     ENV['ember-cli-mirage'] = {
       enabled: false
     };
+
+    ENV.sentry.development = true;
   }
 
   if (environment === 'test') {
@@ -112,8 +119,8 @@ module.exports = function(environment) {
     'default-src': "'none'",
     'script-src': "'self'",
     'font-src': "'self' https://fonts.googleapis.com/css https://fonts.gstatic.com",
-    'connect-src': "'self' " + ENV.apiEndpoint + " ws://ws.pusherapp.com wss://ws.pusherapp.com http://sockjs.pusher.com https://s3.amazonaws.com/archive.travis-ci.com/ https://s3.amazonaws.com/archive.travis-ci.org/",
-    'img-src': "'self' data: https://www.gravatar.com http://www.gravatar.com",
+    'connect-src': "'self' " + ENV.apiEndpoint + " ws://ws.pusherapp.com wss://ws.pusherapp.com http://sockjs.pusher.com https://s3.amazonaws.com/archive.travis-ci.com/ https://s3.amazonaws.com/archive.travis-ci.org/ app.getsentry.com",
+    'img-src': "'self' data: https://www.gravatar.com http://www.gravatar.com app.getsentry.com",
     'style-src': "'self' https://fonts.googleapis.com",
     'media-src': "'self'",
     'frame-src': "'self' " + ENV.apiEndpoint

--- a/config/environment.js
+++ b/config/environment.js
@@ -108,6 +108,10 @@ module.exports = function(environment) {
     ENV['ember-cli-mirage'] = {
       enabled: false
     };
+
+    ENV.sourcemaps = {
+      enabled: true
+    }
   }
 
   // TODO: I insert values from ENV here, but in production

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ember-cli-qunit": "^1.4.0",
     "ember-cli-release": "0.2.8",
     "ember-cli-sauce": "^1.1.0",
+    "ember-cli-sentry": "2.3.1",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "^2.3.0",


### PR DESCRIPTION
This will only log to Sentry in production-like environments (staging and PRs *will* log).
In development, we will receive a console error that Sentry *would have* been notified.

In parallel with this, I have integrated Sentry to post to a #production-web-errors room in
Slack. Email notification is currently disabled, as I do not wish to spam the entire org whenever
something is undefined.

In the future, we might consider having different channels for non-production environments, but that can be addressed later.