### PR TITLE
Fix Sass extend problems

### DIFF
--- a/app/styles/app/layouts/log.sass
+++ b/app/styles/app/layouts/log.sass
@@ -76,7 +76,6 @@
   padding: .7em .8em .6em
   text-align: right
   background-color: $log-header-bg
-  @extend %border-top-4px
 
   @media #{$small-only}
     display: flex

--- a/app/styles/app/modules/icons.sass
+++ b/app/styles/app/modules/icons.sass
@@ -110,9 +110,9 @@
   @extend %icon-line-commit
 
 %icon-line-eye
-  background-image:inline-image('stroke-icons/icon-seemore.svg')
+  background-image: inline-image('stroke-icons/icon-seemore.svg')
 %icon-line-eye-white
-  background-image:inline-image('stroke-icons/icon-seemore-white.svg')
+  background-image: inline-image('stroke-icons/icon-seemore-white.svg')
 
 %icon-line-question
   background-image: inline-image('stroke-icons/icon-help.svg')

--- a/app/styles/app/modules/tabs.sass
+++ b/app/styles/app/modules/tabs.sass
@@ -22,7 +22,6 @@
       margin: 0 1.5em 0 0
 
   a
-    @extend %inline-block
     width: 100%
     color: $asphalt-grey
     padding: 3px 0 5px
@@ -46,7 +45,6 @@
   position: relative
   .tabnav-sub
     @include resetul
-    @extend %inline-block
     overflow: visible
     a
       color: $asphalt-grey


### PR DESCRIPTION
A newer version of node-sass was released and it caused build errors related to these `@extend`s. This removes two uses of `@extend` that didn’t actually extend anything that existed. The other change is syntactic: a missing space was causing the parent selector to have nothing defined within it.