### PR TITLE
Extract test session setup and teardown

### DIFF
--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -49,7 +49,8 @@
     "currentRouteName",
     "jQuery",
     "Visibility",
-    "Travis"
+    "Travis",
+    "storeUserSession"
   ],
   "node": false,
   "browser": false,

--- a/tests/acceptance/builds/restart-test.js
+++ b/tests/acceptance/builds/restart-test.js
@@ -5,10 +5,7 @@ import buildPage from 'travis/tests/pages/build';
 moduleForAcceptance('Acceptance | builds/restart', {
   beforeEach() {
     const currentUser = server.create('user');
-    let localStorageUser = JSON.parse(JSON.stringify(currentUser.attrs));
-    localStorageUser.token = "abc123";
-    window.localStorage.setItem('travis.token', 'testUserToken');
-    window.localStorage.setItem('travis.user', JSON.stringify(localStorageUser));
+    storeUserSession(currentUser);
   }
 });
 

--- a/tests/acceptance/builds/restart-test.js
+++ b/tests/acceptance/builds/restart-test.js
@@ -9,11 +9,6 @@ moduleForAcceptance('Acceptance | builds/restart', {
     localStorageUser.token = "abc123";
     window.localStorage.setItem('travis.token', 'testUserToken');
     window.localStorage.setItem('travis.user', JSON.stringify(localStorageUser));
-  },
-
-  afterEach() {
-    window.localStorage.clear();
-    window.sessionStorage.clear();
   }
 });
 

--- a/tests/acceptance/profile-test.js
+++ b/tests/acceptance/profile-test.js
@@ -48,11 +48,6 @@ moduleForAcceptance('Acceptance | profile', {
     localStorageUser.token = "abc123";
     window.localStorage.setItem('travis.token', 'testUserToken');
     window.localStorage.setItem('travis.user', JSON.stringify(localStorageUser));
-  },
-
-  afterEach() {
-    window.localStorage.clear();
-    window.sessionStorage.clear();
   }
 });
 

--- a/tests/acceptance/profile-test.js
+++ b/tests/acceptance/profile-test.js
@@ -9,6 +9,8 @@ moduleForAcceptance('Acceptance | profile', {
       login: 'feministkilljoy',
       repos_count: 3
     });
+    
+    storeUserSession(currentUser);
 
     const organization = server.create('account', {
       name: 'Goldsmiths',
@@ -43,11 +45,6 @@ moduleForAcceptance('Acceptance | profile', {
       owner_name: 'bellhooks',
       active: false
     });
-
-    let localStorageUser = JSON.parse(JSON.stringify(currentUser.attrs));
-    localStorageUser.token = "abc123";
-    window.localStorage.setItem('travis.token', 'testUserToken');
-    window.localStorage.setItem('travis.user', JSON.stringify(localStorageUser));
   }
 });
 

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -18,6 +18,9 @@ export default function(name, options = {}) {
       if (options.afterEach) {
         options.afterEach.apply(this, arguments);
       }
+
+      window.localStorage.clear();
+      window.sessionStorage.clear();
     }
   });
 }

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -2,6 +2,8 @@ import Ember from 'ember';
 import Application from '../../app';
 import config from '../../config/environment';
 
+import './store-user-session';
+
 export default function startApp(attrs) {
   let application;
 

--- a/tests/helpers/store-user-session.js
+++ b/tests/helpers/store-user-session.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+
+export default Ember.Test.registerAsyncHelper('storeUserSession', function(app, user) {
+  const localStorageUser = JSON.parse(JSON.stringify(user.attrs));
+  localStorageUser.token = "abc123";
+  window.localStorage.setItem('travis.token', 'testUserToken');
+  window.localStorage.setItem('travis.user', JSON.stringify(localStorageUser));
+});


### PR DESCRIPTION
In preparation for my next acceptance test, I extracted a `storeUserSession` test helper and added the clearing of `localStorage` to the `afterEach` of all acceptance tests. This will reduce boilerplate.

This is pretty simple so I’ll probably just merge after the tests have passed, but let me know if you’d prefer a name other than `storeUserSession` or anything else?