### PR TITLE
Revert to Node 5.X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 language: node_js
-node_js: stable
+node_js: 5
 
 env:
   - EMBER_VERSION=default


### PR DESCRIPTION
[This build](https://travis-ci.org/travis-ci/travis-web/jobs/126038516) failed with a warning about Node 6 and Ember CLI, so let’s revert to 5.X for now.