### PR TITLE
Limit Sentry error reporting

### DIFF
--- a/tests/unit/services/raven-test.js
+++ b/tests/unit/services/raven-test.js
@@ -1,0 +1,16 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('service:raven', 'Unit | Service | raven', {
+});
+
+test('it filters errors matching whitelist', function(assert) {
+  let service = this.subject();
+  let filteredError = { message: 'foo is an error we should filter' };
+  let unfilteredError = { message: 'throw dat' };
+
+  service.shouldReportError = () => true;
+  service.set('whitelistMessages', ['foo', 'bar', 'baz']);
+
+  assert.ok(service.ignoreError(filteredError), "Service should ignore whitelisted error");
+  assert.notOk(service.ignoreError(unfilteredError), "Service should not ignore non-whitelisted error");
+});


### PR DESCRIPTION
The error reporting was necessary to introduce, but the volume of errors has already become unwieldy.
This does two things:
1) implements a whitelist to swallow exceptions that are not really problems (e.g. transition aborted)
2) only report 10% of errors to reduce the volume (as recommended by Sentry)