### PR TITLE
Move Help Scout beacon to navigation

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -82,6 +82,10 @@ var App = Ember.Application.extend(Ember.Evented, {
 
     if (window.HS) {
       HS.beacon.ready(function() {
+        HS.beacon.config({
+          autoInit: false,
+          modal: true
+        });
         HS.beacon.init();
       });  
     } else {

--- a/app/controllers/top.js
+++ b/app/controllers/top.js
@@ -94,6 +94,12 @@ export default Ember.Controller.extend({
       this.get('broadcasts.content').removeObject(broadcast);
       this.set('broadcasts.lastBroadcastStatus', this.defineTowerColor(this.get('broadcasts.content')));
       return false;
+    },
+
+    help() {
+      if (window.HS) {
+        window.HS.beacon.open();
+      }
     }
   },
   showCta: function() {

--- a/app/styles/app/modules/navigation.sass
+++ b/app/styles/app/modules/navigation.sass
@@ -46,6 +46,14 @@ $nav-line-height: 35px
   @media #{$medium-up}
     line-height: $top-height + 1px // such magic wow
 
+button.navigation-anchor
+  border: none
+  background: none
+
+  font-family: inherit
+  font-size: inherit
+  color: inherit
+
 .navigation-nested
   margin: 0
   padding: 0 0 0 1em

--- a/app/templates/top.hbs
+++ b/app/templates/top.hbs
@@ -41,6 +41,7 @@
             </ul>
           </li>
         {{/unless}}
+        <li><button class="navigation-anchor" onclick={{action "help"}}>Help</button></li>
       {{else}}
         <li><a href="https://blog.travis-ci.com" title="Travis CI Blog" class="navigation-anchor">Blog</a></li>
         <li><a href="https://www.traviscistatus.com/" title="Travis CI Status" class="navigation-anchor">Status</a></li>

--- a/app/templates/top.hbs
+++ b/app/templates/top.hbs
@@ -24,18 +24,6 @@
     <ul>
 
     {{#unless config.enterprise}}
-      {{#unless config.pro}}
-        <li><a href="https://blog.travis-ci.com" title="Travis CI Blog" class="navigation-anchor">Blog</a></li>
-        <li><a href="https://www.traviscistatus.com/" title="Travis CI Status" class="navigation-anchor">Status</a></li>
-        <li>
-          <span class="navigation-anchor">Help</span>
-          <ul class="navigation-nested">
-            <li><a href="https://docs.travis-ci.com">Docs</a></li>
-            <li><a href="https://docs.travis-ci.com/imprint.html" alt="Imprint">Imprint</a></li>
-          </ul>
-        </li>
-      {{/unless}}
-
       {{#if config.pro}}
         {{#unless auth.signedIn}}
           <li><a href="/about" title="Travis CI team" class="navigation-anchor">About Us</a></li>
@@ -53,7 +41,18 @@
             </ul>
           </li>
         {{/unless}}
+      {{else}}
+        <li><a href="https://blog.travis-ci.com" title="Travis CI Blog" class="navigation-anchor">Blog</a></li>
+        <li><a href="https://www.traviscistatus.com/" title="Travis CI Status" class="navigation-anchor">Status</a></li>
+        <li>
+          <span class="navigation-anchor">Help</span>
+          <ul class="navigation-nested">
+            <li><a href="https://docs.travis-ci.com">Docs</a></li>
+            <li><a href="https://docs.travis-ci.com/imprint.html" alt="Imprint">Imprint</a></li>
+          </ul>
+        </li>
       {{/if}}
+
     {{else}}
       {{#if auth.signedIn}}
         <li><a class="navigation-anchor" title="Documentation" href="https://docs.travis-ci.com">Docs</a></li>


### PR DESCRIPTION
People have been complaining about the Help Scout beacon button. This is an experiment to move it to be a link-like button in the top navigation.