### PR TITLE
Sentry app version

### DIFF
--- a/app/instance-initializers/raven-release.js
+++ b/app/instance-initializers/raven-release.js
@@ -1,11 +1,13 @@
 import config from 'travis/config/environment';
 
 export function initialize(appInstance) {
+  let sha;
   if (config.environment === 'production') {
-    let sha = config.release;
+    sha = config.release;
   } else {
-    let sha = appInstance.application.version.slice(6, -1);
+    sha = appInstance.application.version.slice(6, -1);
   }
+
   console.log(sha);
 
   let env = window.location.href;

--- a/app/instance-initializers/raven-release.js
+++ b/app/instance-initializers/raven-release.js
@@ -3,7 +3,7 @@ import config from 'travis/config/environment';
 export function initialize(/* appInstance */) {
   let env = window.location.href;
   let sha = config.APP.version.slice(6, -1);
-  let domain = env === 'https://travis-ci.org' ? 'org' : 'com';
+  let domain = env === 'https://travis-ci.org/' ? 'org' : 'com';
   let release = `${domain}-${sha}`;
 
   window.Raven.setRelease(release);

--- a/app/instance-initializers/raven-release.js
+++ b/app/instance-initializers/raven-release.js
@@ -1,8 +1,6 @@
-import config from 'travis/config/environment';
-
-export function initialize(/* appInstance */) {
+export function initialize(appInstance) {
+  let sha = appInstance.application.version.slice(6, -1);
   let env = window.location.href;
-  let sha = config.APP.version.slice(6, -1);
   let domain = env === 'https://travis-ci.org/' ? 'org' : 'com';
   let release = `${domain}-${sha}`;
 

--- a/app/instance-initializers/raven-release.js
+++ b/app/instance-initializers/raven-release.js
@@ -1,7 +1,13 @@
 import config from 'travis/config/environment';
 
 export function initialize(appInstance) {
-  let sha = config.currentRevision.slice(0,7);
+  if (config.environment === 'production') {
+    let sha = process.env.SOURCE_VERSION || "-"
+  } else {
+    let sha = appInstance.application.version.slice(6, -1);
+  }
+  console.log(sha);
+
   let env = window.location.href;
   let domain = env === 'https://travis-ci.org/' ? 'org' : 'com';
   let release = `${domain}-${sha}`;

--- a/app/instance-initializers/raven-release.js
+++ b/app/instance-initializers/raven-release.js
@@ -2,7 +2,7 @@ import config from 'travis/config/environment';
 
 export function initialize(appInstance) {
   if (config.environment === 'production') {
-    let sha = process.env.SOURCE_VERSION || "-"
+    let sha = config.release;
   } else {
     let sha = appInstance.application.version.slice(6, -1);
   }

--- a/app/instance-initializers/raven-release.js
+++ b/app/instance-initializers/raven-release.js
@@ -1,5 +1,7 @@
+import config from 'travis/config/environment';
+
 export function initialize(appInstance) {
-  let sha = appInstance.application.version.slice(6, -1);
+  let sha = config.currentRevision.slice(0,7);
   let env = window.location.href;
   let domain = env === 'https://travis-ci.org/' ? 'org' : 'com';
   let release = `${domain}-${sha}`;

--- a/config/environment.js
+++ b/config/environment.js
@@ -106,6 +106,7 @@ module.exports = function(environment) {
   }
 
   if (environment === 'production') {
+    ENV.release = process.env.SOURCE_VERSION || "-";
     ENV['ember-cli-mirage'] = {
       enabled: false
     };

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "ember-data-filter": "1.13.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.5",
-    "ember-git-version": "0.1.0",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "ember-try": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "ember-data-filter": "1.13.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.5",
+    "ember-git-version": "0.1.0",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "ember-try": "0.2.2",


### PR DESCRIPTION
We need to set the release version explicitly on the global Raven object to have errors marked correctly. Opening a PR so I can test without impacting staging.