### PR TITLE
Update repo.hbs

### DIFF
--- a/app/templates/repo.hbs
+++ b/app/templates/repo.hbs
@@ -8,7 +8,7 @@
       <header>
         <h1 class="repo-title">{{#link-to "owner" repo.owner}}{{repo.owner}}{{/link-to}} / {{#link-to "repo" repo}}{{repo.name}}{{/link-to}}</h1>
         <div class="repo-gh">
-          <a href="{{urlGithub}}" title="{{repo.name}} on Github">{{repo.name}} on Github</a>
+          <a href="{{urlGithub}}" title="{{repo.name}} on GitHub">{{repo.name}} on Github</a>
         </div>
         <div class="repo-badge">
           <a href="#" id="status-image-popup" title="build status image" name="status-images" class="open-popup" {{action "statusImages"}}>


### PR DESCRIPTION
In every other title GitHub is written with a capital H so why not use this in the repo's title :stuck_out_tongue:

(sorry for the useless build :grin:)