### PR TITLE
Persist repository state when enabling repositories

### DIFF
--- a/app/components/build-header.js
+++ b/app/components/build-header.js
@@ -15,7 +15,8 @@ export default Ember.Component.extend({
       return this.get('item.id');
     } else {
       let ids = [];
-      this.item.get('jobs').forEach(function(item) { ids.push(item.id); });
+      let jobs = this.get('item.jobs') || [];
+      jobs.forEach(function(item) { ids.push(item.id); });
       return ids.join(' ');
     }
   }.property('item'),

--- a/app/components/repos-list.js
+++ b/app/components/repos-list.js
@@ -1,7 +1,8 @@
 import Ember from 'ember';
 
 var ReposListComponent = Ember.Component.extend({
-  tagName: 'ul'
+  tagName: 'ul',
+  classNames: ['repos-list']
 });
 
 export default ReposListComponent;

--- a/app/controllers/repos.js
+++ b/app/controllers/repos.js
@@ -162,8 +162,8 @@ var Controller = Ember.Controller.extend({
   viewOwned() {
     var repos, user;
 
-    if (repos = this.get('ownedRepos')) {
-      return this.set('_repos', repos);
+    if (!Ember.isEmpty(this.get('ownedRepos'))) {
+      return this.set('_repos', this.get('ownedRepos'));
     } else if (!this.get('fetchingOwnedRepos')) {
       this.set('isLoaded', false);
 
@@ -239,6 +239,7 @@ var Controller = Ember.Controller.extend({
   repos: function() {
     var repos = this.get('_repos');
 
+
     if(repos && repos.toArray) {
       repos = repos.toArray();
     }
@@ -246,7 +247,11 @@ var Controller = Ember.Controller.extend({
     if(repos && repos.sort) {
       return repos.sort(sortCallback);
     } else {
-      return [];
+      if (Ember.isArray(repos)) {
+        return repos;
+      } else {
+        return [];
+      }
     }
   }.property('_repos.[]', '_repos.@each.lastBuildFinishedAt',
              '_repos.@each.lastBuildId')

--- a/app/models/hook.js
+++ b/app/models/hook.js
@@ -32,7 +32,31 @@ export default Model.extend({
     if (this.get('isSaving')) {
       return;
     }
-    this.set('active', !this.get('active'));
-    return this.save();
+    this.toggleProperty('active');
+    return this.save().then((record) => {
+      this.updateRepositoryStatus();
+      return record;
+    });
+  },
+
+  updateRepositoryStatus() {
+    Ember.run(this, () => {
+      if (this.get('active')) {
+        return this.get('store').push({
+          data: {
+            id: this.get('id'),
+            type: 'repo',
+            attributes: {
+              active: true
+            }
+          }
+        });
+      } else {
+        let record = this.get('store').peekRecord('repo', this.get('id'));
+        if (record) {
+          return this.get('store').unloadRecord(record);
+        }
+      }
+    });
   }
 });

--- a/app/routes/getting-started.js
+++ b/app/routes/getting-started.js
@@ -2,6 +2,12 @@ import TravisRoute from 'travis/routes/basic';
 import Ember from 'ember';
 
 export default TravisRoute.extend({
+  beforeModel(transition) {
+    if (!Ember.isEmpty(this.store.peekAll('repo'))) {
+      this.transitionTo('/');
+    }
+  },
+
   setupController(controller) {
     return Ember.getOwner(this).lookup('controller:repos').activate('owned');
   }

--- a/app/routes/main.js
+++ b/app/routes/main.js
@@ -12,9 +12,4 @@ export default TravisRoute.extend({
       into: 'main'
     });
   },
-
-  setupController(controller) {
-    // TODO: this is redundant with repositories and recent routes
-    // @container.lookup('controller:repos').activate('owned')
-  }
 });

--- a/app/routes/main/repositories.js
+++ b/app/routes/main/repositories.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import MainTabRoute from 'travis/routes/main-tab';
 
 export default MainTabRoute.extend({
@@ -5,6 +6,8 @@ export default MainTabRoute.extend({
   reposTabName: 'owned',
 
   afterModel() {
-    return this.controllerFor('repos').possiblyRedirectToGettingStartedPage();
+    if (Ember.isEmpty(this.store.peekAll('repo'))) {
+      return this.controllerFor('repos').possiblyRedirectToGettingStartedPage();
+    }
   }
 });

--- a/app/templates/build.hbs
+++ b/app/templates/build.hbs
@@ -3,17 +3,21 @@
   {{loading-indicator}}
 {{else}}
 
-  {{build-header item=build commit=build.commit repo=repo}}
+  {{#if build}}
+    {{build-header item=build commit=build.commit repo=repo}}
 
-  {{#if build.isMatrix}}
-    {{#if jobsLoaded}}
-      {{jobs-list jobs=build.requiredJobs repo=repo required="true"}}
-      {{jobs-list jobs=build.allowedFailureJobs repo=repo}}
+    {{#if build.isMatrix}}
+      {{#if jobsLoaded}}
+        {{jobs-list jobs=build.requiredJobs repo=repo required="true"}}
+        {{jobs-list jobs=build.allowedFailureJobs repo=repo}}
+      {{else}}
+        {{loading-indicator center=true}}
+      {{/if}}
     {{else}}
-      {{loading-indicator center=true}}
+      {{job-log job=build.jobs.firstObject}}
     {{/if}}
   {{else}}
-    {{job-log job=build.jobs.firstObject}}
+    {{no-builds}}
   {{/if}}
 
 {{/if}}

--- a/app/templates/getting-started.hbs
+++ b/app/templates/getting-started.hbs
@@ -9,7 +9,7 @@
       </div>
       <div class="media-body column medium-9">
         <h2>Activate GitHub Repositories</h2>
-        <p>Once you're signed in, and we've initially synchronized your repositories from GitHub, go to your {{#link-to "profile"}}profile{{/link-to}} page for open source or for your private projects.</p>
+        <p>Once you're signed in, and we've initially synchronized your repositories from GitHub, go to your {{#link-to "profile" id="profile-page-link"}}profile{{/link-to}} page for open source or for your private projects.</p>
         <p>You'll see all the organizations you're a member of and all the repositories you have access to. The ones you have administrative access to are the ones you can enable the service hook for.</p>
         <p>Flip the switch to on for all repositories you'd like to enable.</p>
       </div>

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -42,6 +42,7 @@ export default function() {
 
   this.put('/hooks/:id', (schema, request) => {
     const user = schema.hooks.find(request.params.id);
+    server.create('repository', { id: request.params.id });
     return user.update(JSON.parse(request.requestBody).hook);
   });
 

--- a/tests/acceptance/registration/getting-started-test.js
+++ b/tests/acceptance/registration/getting-started-test.js
@@ -1,0 +1,49 @@
+import { test } from 'qunit';
+import moduleForAcceptance from 'travis/tests/helpers/module-for-acceptance';
+import profilePage from 'travis/tests/pages/profile';
+import dashboardPage from 'travis/tests/pages/dashboard';
+import header from 'travis/tests/pages/header';
+
+moduleForAcceptance('Acceptance | registration/getting started', {
+  beforeEach() {
+    const currentUser = server.create('user');
+    signInUser(currentUser);
+  }
+});
+
+test('signed in but without repositories', function(assert) {
+  visit('/');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/getting_started');
+  });
+});
+
+test('added repository while onboarding persists to dashboard', function(assert) {
+  dashboardPage
+    .visit()
+    .navigateToProfilePage();
+
+  andThen(() => {
+    assert.equal(currentURL(), '/profile/testuser');
+  });
+
+  const inactiveHook = server.create('hook', {
+    name: 'test-repo',
+    owner_name: 'testuser',
+    active: false,
+    admin: true
+  });
+
+  profilePage.administerableHooks(0).toggle();
+
+  andThen(() => {
+    assert.ok(server.db.hooks[0].active, 'repo is enabled');
+    header.clickDashboardLink();
+  });
+
+  andThen(() => {
+    assert.notEqual(currentURL(), '/getting_started');
+    assert.equal(dashboardPage.sidebarRepositories(0).name, "travis-ci/travis-web", "Newly enabled repository should display in sidebar");
+  });
+});

--- a/tests/index.html
+++ b/tests/index.html
@@ -18,9 +18,6 @@
         top: 100px;
         right: -620px;
       }
-      #ember-testing-container:hover {
-        right: 0;
-      }
     </style>
 
     {{content-for "head-footer"}}

--- a/tests/pages/dashboard.js
+++ b/tests/pages/dashboard.js
@@ -1,11 +1,18 @@
-import PageObject from 'travis/tests/page-object';
+import {
+  create,
+  visitable,
+  clickable,
+  collection,
+  text
+} from 'ember-cli-page-object';
 
-let {
-  visitable
-} = PageObject;
-
-export default PageObject.create({
-
-
-
+export default create({
+  visit: visitable('/'),
+  navigateToProfilePage: clickable('#profile-page-link'),
+  sidebarRepositories: collection({
+    itemScope: 'ul.repos-list',
+    item: {
+      name: text('.tile h2.tile-title span.label-align')
+    }
+  })
 });

--- a/tests/pages/header.js
+++ b/tests/pages/header.js
@@ -1,0 +1,8 @@
+import {
+  create,
+  clickable
+} from 'ember-cli-page-object';
+
+export default create({
+  clickDashboardLink: clickable('.topbar h1#logo a')
+});


### PR DESCRIPTION
This solves a few issues for new users enabling their first
repositories. Currently, when a user enables their first repository and
subsequently navigates to the dashboard, they do not see any
repositories. This was causing some unexpected errors that made certain
portions of the page unrenderable and led to divergent behavior between
the initial page visit and a refresh (where the data would, of course,
be accurate).

This is because we were missing a link between the state of the store
for repository models and making requests to the /hooks endpoint which
enable them on the backend. To fix this, we now manually inject a
repository model into the store, as the id between a hook and a repo is
shared.  This ensures that code querying the store will get the proper
result.

I think this situation can definitely be improved in the future, perhaps
by merging our concept of hooks with that of repositories.  Were we, for
instance, simply making PATCH requests when toggling a repository's
state (instead of making an RPC-like call to another endpoint), we could
rely on the default behavior of the store to automatically get the
updated state. Given the severity of the issues that new users would
currently encounter, I think we should ship this in its current state
and make improvements later.