### PR TITLE
Settings acceptance test: keys

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -116,6 +116,9 @@ module.exports = function(environment) {
     ENV.sentry = {
       development: true
     };
+    ENV.endpoints = {
+      sshKey: true
+    };
   }
 
   if (environment === 'production') {

--- a/config/environment.js
+++ b/config/environment.js
@@ -115,7 +115,7 @@ module.exports = function(environment) {
 
     ENV.sentry = {
       development: true
-    }
+    };
   }
 
   if (environment === 'production') {

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -116,12 +116,9 @@ export default function() {
   });
 
   this.get('/settings/ssh_key/:repo_id', function(schema, request) {
+    const key = schema.sshKeys.where({repositoryId: request.params.repo_id, type: 'custom'}).models[0];
     return {
-      ssh_key: {
-        id: request.params.repo_id,
-        description: 'testy',
-        fingerprint: 'dd:cc:bb:aa'
-      }
+      ssh_key: key
     };
   });
 
@@ -134,10 +131,11 @@ export default function() {
     return turnIntoV3('branch', schema.branches.all().models);
   });
 
-  this.get('/repos/:id/key', function() {
+  this.get('/repos/:id/key', function(schema, request) {
+    const key = schema.sshKeys.where({repositoryId: request.params.id, type: 'default'}).models[0];
     return {
-      key: 'A PUBLIC KEY!',
-      fingerprint: 'aa:bb:cc:dd'
+      key: key.attrs.key,
+      fingerprint: key.attrs.fingerprint
     };
   });
 

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -115,9 +115,14 @@ export default function() {
     };
   });
 
-  this.get('/settings/ssh_key/:repo_id', function() {
-    // FIXME add tests where these are present
-    return {file: 'not found'};
+  this.get('/settings/ssh_key/:repo_id', function(schema, request) {
+    return {
+      ssh_key: {
+        id: request.params.repo_id,
+        description: 'testy',
+        fingerprint: 'dd:cc:bb:aa'
+      }
+    };
   });
 
   this.get('/v3/repo/:id', function(schema, request) {

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -130,8 +130,10 @@ export default function() {
   });
 
   this.get('/repos/:id/key', function() {
-    // FIXME add tests where these are present
-    return {key: 'hello', fingerprint: 'yes'};
+    return {
+      key: 'A PUBLIC KEY!',
+      fingerprint: 'aa:bb:cc:dd'
+    };
   });
 
   this.get('/jobs/:id', function(schema, request) {

--- a/mirage/factories/ssh-key.js
+++ b/mirage/factories/ssh-key.js
@@ -1,0 +1,4 @@
+import { Factory } from 'ember-cli-mirage';
+
+export default Factory.extend({
+});

--- a/mirage/models/repository.js
+++ b/mirage/models/repository.js
@@ -3,5 +3,8 @@ import { Model, hasMany } from 'ember-cli-mirage';
 export default Model.extend({
   builds: hasMany('build'),
   envVars: hasMany(),
-  settings: hasMany()
+  settings: hasMany(),
+
+  customSshKey: hasMany('ssh-key'),
+  defaultSshKey: hasMany('ssh-key')
 });

--- a/mirage/models/ssh-key.js
+++ b/mirage/models/ssh-key.js
@@ -1,0 +1,4 @@
+import { Model, hasMany } from 'ember-cli-mirage';
+
+export default Model.extend({
+});

--- a/tests/acceptance/repo-settings-test.js
+++ b/tests/acceptance/repo-settings-test.js
@@ -241,9 +241,17 @@ test('delete and create crons', function(assert) {
 test('delete and set SSH keys', function(assert) {
   settingsPage.visit({organization: 'killjoys', repo: 'living-a-feminist-life'});
 
+  const deletedIds = [];
+
+  server.delete('/settings/ssh_key/:id', function(schema, request) {
+    deletedIds.push(request.params.id);
+  });
+
   settingsPage.sshKey.delete();
 
   andThen(function() {
+    assert.equal(deletedIds.pop(), '1', 'expected the server to have received a deletion request for the SSH key');
+
     assert.equal(settingsPage.sshKey.name, 'no custom key set');
     assert.equal(settingsPage.sshKey.fingerprint, 'aa:bb:cc:dd');
     assert.ok(settingsPage.sshKey.cannotBeDeleted, 'expected default SSH key not to be deletable');

--- a/tests/acceptance/repo-settings-test.js
+++ b/tests/acceptance/repo-settings-test.js
@@ -118,8 +118,8 @@ test('view settings', function(assert) {
     assert.ok(settingsPage.crons(1).enqueuingInterval.indexOf('Enqueues each') === 0, 'Shows weekly enqueuing text');
     assert.ok(settingsPage.crons(1).disableByBuildText.indexOf('Only if no new commit') === 0, 'expected cron to run only if no new commit after last build');
 
-    assert.equal(settingsPage.sshKey.name, 'no custom key set');
-    assert.equal(settingsPage.sshKey.fingerprint, 'aa:bb:cc:dd');
+    assert.equal(settingsPage.sshKey.name, 'testy');
+    assert.equal(settingsPage.sshKey.fingerprint, 'dd:cc:bb:aa');
   });
 });
 

--- a/tests/acceptance/repo-settings-test.js
+++ b/tests/acceptance/repo-settings-test.js
@@ -259,9 +259,14 @@ test('delete and set SSH keys', function(assert) {
 
   const requestBodies = [];
 
-  server.patch(`/settings/ssh_key/${this.repository.id}`, function(schema, request) {
-    requestBodies.push(JSON.parse(request.requestBody));
-    return {};
+  server.patch(`/settings/ssh_key/${this.repository.id}`, (schema, request) => {
+    const newKey = JSON.parse(request.requestBody);
+    requestBodies.push(newKey);
+    newKey.id = this.repository.id;
+
+    return {
+      ssh_key: newKey
+    };
   });
 
   settingsPage.sshKeyForm.fillDescription('hey');
@@ -269,12 +274,10 @@ test('delete and set SSH keys', function(assert) {
   settingsPage.sshKeyForm.add();
 
   andThen(() => {
-    assert.deepEqual(requestBodies.pop(), {
-      ssh_key: {
-        id: this.repository.id,
-        description: 'hey',
-        value: 'hello'
-      }
+    assert.deepEqual(requestBodies.pop().ssh_key, {
+      id: this.repository.id,
+      description: 'hey',
+      value: 'hello'
     });
   });
 });

--- a/tests/acceptance/repo-settings-test.js
+++ b/tests/acceptance/repo-settings-test.js
@@ -119,6 +119,9 @@ test('view settings', function(assert) {
     assert.equal(settingsPage.crons(1).interval, 'weekly');
     assert.ok(settingsPage.crons(1).nextEnqueuing.indexOf(':11'), 'expected cron next enqueuing to match');
     assert.ok(settingsPage.crons(1).disableByBuildText.indexOf('Only') === 0, 'expected cron to run only if no new commit after last build');
+
+    assert.equal(settingsPage.sshKey.name, 'no custom key set');
+    assert.equal(settingsPage.sshKey.fingerprint, 'aa:bb:cc:dd');
   });
 });
 

--- a/tests/acceptance/repo-settings-test.js
+++ b/tests/acceptance/repo-settings-test.js
@@ -257,4 +257,24 @@ test('delete and set SSH keys', function(assert) {
     assert.ok(settingsPage.sshKey.cannotBeDeleted, 'expected default SSH key not to be deletable');
   });
 
+  const requestBodies = [];
+
+  server.patch(`/settings/ssh_key/${this.repository.id}`, function(schema, request) {
+    requestBodies.push(JSON.parse(request.requestBody));
+    return {};
+  });
+
+  settingsPage.sshKeyForm.fillDescription('hey');
+  settingsPage.sshKeyForm.fillKey('hello');
+  settingsPage.sshKeyForm.add();
+
+  andThen(() => {
+    assert.deepEqual(requestBodies.pop(), {
+      ssh_key: {
+        id: this.repository.id,
+        description: 'hey',
+        value: 'hello'
+      }
+    });
+  });
 });

--- a/tests/acceptance/repo-settings-test.js
+++ b/tests/acceptance/repo-settings-test.js
@@ -234,6 +234,7 @@ test('delete and set SSH keys', function(assert) {
   andThen(function() {
     assert.equal(settingsPage.sshKey.name, 'no custom key set');
     assert.equal(settingsPage.sshKey.fingerprint, 'aa:bb:cc:dd');
+    assert.ok(settingsPage.sshKey.cannotBeDeleted, 'expected default SSH key not to be deletable');
   });
 
 });

--- a/tests/acceptance/repo-settings-test.js
+++ b/tests/acceptance/repo-settings-test.js
@@ -225,3 +225,15 @@ test('delete and create crons', function(assert) {
     assert.equal(settingsPage.crons().count, 1, 'expected only one cron to remain');
   });
 });
+
+test('delete and set SSH keys', function(assert) {
+  settingsPage.visit({organization: 'killjoys', repo: 'living-a-feminist-life'});
+
+  settingsPage.sshKey.delete();
+
+  andThen(function() {
+    assert.equal(settingsPage.sshKey.name, 'no custom key set');
+    assert.equal(settingsPage.sshKey.fingerprint, 'aa:bb:cc:dd');
+  });
+
+});

--- a/tests/acceptance/repo-settings-test.js
+++ b/tests/acceptance/repo-settings-test.js
@@ -49,6 +49,18 @@ moduleForAcceptance('Acceptance | repo settings', {
       value: null
     });
 
+    repository.createCustomSshKey({
+      description: 'testy',
+      fingerprint: 'dd:cc:bb:aa',
+      type: 'custom'
+    });
+
+    repository.createDefaultSshKey({
+      type: 'default',
+      fingerprint: 'aa:bb:cc:dd',
+      key: 'A PUBLIC KEY!'
+    });
+
     this.repository = repository;
 
     const repoId = parseInt(repository.id);

--- a/tests/acceptance/repo-settings-test.js
+++ b/tests/acceptance/repo-settings-test.js
@@ -249,8 +249,8 @@ test('delete and set SSH keys', function(assert) {
 
   settingsPage.sshKey.delete();
 
-  andThen(function() {
-    assert.equal(deletedIds.pop(), '1', 'expected the server to have received a deletion request for the SSH key');
+  andThen(() => {
+    assert.equal(deletedIds.pop(), this.repository.id, 'expected the server to have received a deletion request for the SSH key');
 
     assert.equal(settingsPage.sshKey.name, 'no custom key set');
     assert.equal(settingsPage.sshKey.fingerprint, 'aa:bb:cc:dd');

--- a/tests/pages/settings.js
+++ b/tests/pages/settings.js
@@ -77,5 +77,11 @@ export default PageObject.create({
 
       delete: clickable('.icon-delete')
     }
-  })
+  }),
+
+  sshKey: {
+    scope: '.settings-sshkey',
+    name: text('.ssh-key-name span:last-child'),
+    fingerprint: text('.ssh-key-value span:last-child')
+  }
 });

--- a/tests/pages/settings.js
+++ b/tests/pages/settings.js
@@ -81,6 +81,8 @@ export default PageObject.create({
   sshKey: {
     scope: '.settings-sshkey',
     name: text('.ssh-key-name span:last-child'),
-    fingerprint: text('.ssh-key-value span:last-child')
+    fingerprint: text('.ssh-key-value span:last-child'),
+
+    delete: clickable('.icon-delete')
   }
 });

--- a/tests/pages/settings.js
+++ b/tests/pages/settings.js
@@ -86,5 +86,13 @@ export default PageObject.create({
 
     delete: clickable('.icon-delete'),
     cannotBeDeleted: isVisible('.icon-delete-disabled')
+  },
+
+  sshKeyForm: {
+    scope: '.form--sshkey',
+
+    fillDescription: fillable('input.ssh-description'),
+    fillKey: fillable('textarea.ssh-value'),
+    add: clickable('input[type=submit]')
   }
 });

--- a/tests/pages/settings.js
+++ b/tests/pages/settings.js
@@ -5,6 +5,7 @@ let {
   collection,
   fillable,
   hasClass,
+  isVisible,
   text,
   value,
   visitable
@@ -83,6 +84,7 @@ export default PageObject.create({
     name: text('.ssh-key-name span:last-child'),
     fingerprint: text('.ssh-key-value span:last-child'),
 
-    delete: clickable('.icon-delete')
+    delete: clickable('.icon-delete'),
+    cannotBeDeleted: isVisible('.icon-delete-disabled')
   }
 });


### PR DESCRIPTION
This is a continuation of my [previous acceptance test](https://github.com/travis-ci/travis-web/pull/540), where I noticed when I wrapping up work on it that I’d missed assertions for SSH keys. It’s still somewhat mysterious to me how all this works and what the two different key endpoints are about, but hopefully I’ll learn that during this exercise.