### PR TITLE
dropdown menu only lists cron-free branches

### DIFF
--- a/app/controllers/settings.js
+++ b/app/controllers/settings.js
@@ -9,7 +9,7 @@ export default Ember.Controller.extend({
         return branch.get('name') === cron.get('branch').get('name');
       });
     });
-  }.property('model.cronJobs','cronJobs','this.model.cronJobs'),
+  }.property('model.cronJobs.jobs.@each'),
 
   freeSortedBranches: Ember.computed.sort('freeBranches', function(a, b) {
     if(a.get('defaultBranch')) {

--- a/app/controllers/settings.js
+++ b/app/controllers/settings.js
@@ -2,19 +2,18 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
   envVars: Ember.computed.filterBy('model.envVars', 'isNew', false),
-  freeBranches: function() {
+
+  branchesWithoutCron: Ember.computed('model.cronJobs.jobs.@each', function() {
     var cronJobs = this.get('model.cronJobs.jobs');
     var branches = this.get('model.branches').filter(function(branch) {
       return branch.get('exists_on_github');
     });
     return branches.filter(function(branch) {
-      return ! cronJobs.any(function(cron) {
-        return branch.get('name') === cron.get('branch').get('name');
-      });
+      return ! cronJobs.any(cron => branch.get('name') === cron.get('branch.name'));
     });
-  }.property('model.cronJobs.jobs.@each'),
+  }),
 
-  freeSortedBranches: Ember.computed.sort('freeBranches', function(a, b) {
+  sortedBranchesWithoutCron: Ember.computed.sort('branchesWithoutCron', function(a, b) {
     if(a.get('defaultBranch')) {
       return -1;
     } else if(b.get('defaultBranch')) {
@@ -23,6 +22,7 @@ export default Ember.Controller.extend({
       return a.get('name') > b.get('name');
     }
   }),
+
   actions: {
     sshKeyAdded(sshKey) {
       return this.set('model.customSshKey', sshKey);

--- a/app/controllers/settings.js
+++ b/app/controllers/settings.js
@@ -2,16 +2,16 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
   envVars: Ember.computed.filterBy('model.envVars', 'isNew', false),
-  cronJobs: Ember.computed.sort('model.cronJobs', function(a, b) {
-    if(a.get('branch.defaultBranch')) {
-      return -1;
-    } else if(b.get('branch.defaultBranch')) {
-      return 1;
-    } else {
-      return a.get('branch.name') > b.get('branch.name');
-    }
-  }),
-  branches: Ember.computed.sort('model.branches', function(a, b) {
+  freeBranches: function() {
+    var cronJobs = this.get('model.cronJobs.jobs');
+      return this.get('model.branches').filter(function(branch) {
+        return ! cronJobs.any(function(cron) {
+        return branch.get('name') === cron.get('branch').get('name');
+      });
+    });
+  }.property('model.cronJobs','cronJobs','this.model.cronJobs'),
+
+  freeSortedBranches: Ember.computed.sort('freeBranches', function(a, b) {
     if(a.get('defaultBranch')) {
       return -1;
     } else if(b.get('defaultBranch')) {

--- a/app/controllers/settings.js
+++ b/app/controllers/settings.js
@@ -4,8 +4,11 @@ export default Ember.Controller.extend({
   envVars: Ember.computed.filterBy('model.envVars', 'isNew', false),
   freeBranches: function() {
     var cronJobs = this.get('model.cronJobs.jobs');
-      return this.get('model.branches').filter(function(branch) {
-        return ! cronJobs.any(function(cron) {
+    var branches = this.get('model.branches').filter(function(branch) {
+      return branch.get('exists_on_github');
+    });
+    return branches.filter(function(branch) {
+      return ! cronJobs.any(function(cron) {
         return branch.get('name') === cron.get('branch').get('name');
       });
     });

--- a/app/templates/components/add-cron-job.hbs
+++ b/app/templates/components/add-cron-job.hbs
@@ -3,9 +3,7 @@
     <span class="label">Branch</span>
     {{#x-select value=selectedBranch required="true"}}
       {{#each branches as |branch|}}
-        {{#if branch.exists_on_github}}
-          {{#x-option value=branch}}{{branch.name}}{{/x-option}}
-        {{/if}}
+        {{#x-option value=branch}}{{branch.name}}{{/x-option}}
       {{/each}}
     {{/x-select}}
   </div>

--- a/app/templates/settings.hbs
+++ b/app/templates/settings.hbs
@@ -36,7 +36,7 @@
           <li>{{cron-job cron=cron}}</li>
         {{/each}}
 
-        <li>{{add-cron-job branches=freeSortedBranches}}</li>
+        <li>{{add-cron-job branches=sortedBranchesWithoutCron}}</li>
       </ul>
 
     </section>

--- a/app/templates/settings.hbs
+++ b/app/templates/settings.hbs
@@ -36,7 +36,7 @@
           <li>{{cron-job cron=cron}}</li>
         {{/each}}
 
-        <li>{{add-cron-job branches=branches}}</li>
+        <li>{{add-cron-job branches=freeSortedBranches}}</li>
       </ul>
 
     </section>


### PR DESCRIPTION
This PR limits the availabe branches in the dropdown box to branches without crons. 
(branches on which you can create a new cron job)

To edit a cron job a user currently creates a new cron on the same branch thus overriding the old one. That is unintuitive and not documented. 

![image](https://cloud.githubusercontent.com/assets/12047669/15859236/90fdeef4-2cc4-11e6-939c-2147a7e7d2cf.png)
