### PR TITLE
Remove reference to campfire on empty-repos page

### DIFF
--- a/app/templates/components/repos-empty.hbs
+++ b/app/templates/components/repos-empty.hbs
@@ -11,7 +11,6 @@
   </ul>
 
   <p>
-    If you have any questions or issues, hop on our <a href="https://travisci.campfirenow.com/10e50">Campfire support room</a> or
-    contact <a href="mailto:support@travis-ci.com">support</a> directly.
+    If you have any questions or issues, please contact <a href="mailto:support@travis-ci.com">our support</a> directly.
   </p>
 </div>


### PR DESCRIPTION
We used to use campfire, but now we no longer do.