### PR TITLE
Remove unused route

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -66,9 +66,6 @@ Router.map(function() {
         this.route('env_vars', { resetNamespace: true }, function() {
           this.route('new');
         });
-        if (config.endpoints.sshKey) {
-          this.resource('ssh_key');
-        }
       });
     });
   });


### PR DESCRIPTION
Since I enabled SSH keys in the test environment, I was seeing a lot of deprecation warnings about this. It appears to be unused? Do you agree, @drogus?