### PR TITLE
Remove unneeded branch line for cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ matrix:
 sudo: false
 
 cache:
-  branch: md5deep
   directories:
     - node_modules
     - bower_components


### PR DESCRIPTION
Per https://github.com/travis-ci/travis-ci/issues/3039#issuecomment-119302093 it looks like the md5deep branch has been deployed, so this line is not needed ...