### PR TITLE
Make jobs tooltip wider

### DIFF
--- a/app/styles/app/modules/tooltips.sass
+++ b/app/styles/app/modules/tooltips.sass
@@ -141,5 +141,12 @@ $tooltip-arrow-width: .8em
     &:before
       bottom: $tooltip-spacing - $tooltip-arrow-width 
 
-.tooltip-jobs
-  
+.tooltip-jobs[data-tooltip]
+  $tooltip-spacing: 3em
+  text-align: center
+  &:after
+    bottom: $tooltip-spacing
+    width: 9em
+    left: -3.5em
+  &:before
+    bottom: $tooltip-spacing - $tooltip-arrow-width


### PR DESCRIPTION
before
<img width="320" alt="jobs-tooltip-before" src="https://cloud.githubusercontent.com/assets/1234607/15992703/b47692a4-30a8-11e6-9dcc-205e8cbb7874.png">

after
<img width="311" alt="jobs-tooltip-after" src="https://cloud.githubusercontent.com/assets/1234607/15992702/b43f7436-30a8-11e6-8650-8f8637fc8a12.png">