### PR TITLE
move helpscout link to the left

### DIFF
--- a/app/styles/app/modules/helpscout-link.sass
+++ b/app/styles/app/modules/helpscout-link.sass
@@ -1,7 +1,7 @@
 .helpscout-link
   position: fixed
   bottom: 0
-  right: 2em
+  right: 4.5em
   display: block
   padding: 0.7em 1em 3.3em
   z-index: 99


### PR DESCRIPTION
so it won't cover the `top` link in the logs