### PR TITLE
😆😭🐛🙃🤔🤗❓

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ before_install:
   - export PATH=$PWD/travis-phantomjs:$PATH
   - "npm config set spin false"
   - "npm install -g npm@^2"
+  - "echo '😆😭🐛🙃🤔🤗 :bug: :tada:'"
 
 install:
   - npm install -g bower


### PR DESCRIPTION
Regarding emoji in commit messages:

Chrome not working:
![image](https://cloud.githubusercontent.com/assets/43280/16416174/03c645bc-3d0f-11e6-8fd7-5ce1eadb0875.png)

Chrome working, unclear what changed, it flashed to this partway through the build:
![image](https://cloud.githubusercontent.com/assets/43280/16416216/32af3c1c-3d0f-11e6-96a6-a61333ff8a7d.png)

Safari:
![image](https://cloud.githubusercontent.com/assets/43280/16416502/85b7cb62-3d10-11e6-857c-6e01d5d80cc1.png)

Firefox:
![image](https://cloud.githubusercontent.com/assets/43280/16416512/8f9247a2-3d10-11e6-90b2-b3ab894f08bd.png)

The API responds with this property for the commit, which looks correct to me:

```
"message":"\uf606\uf62d\uf41b\uf643\uf914\uf917\u2753"
```


I made another commit that added emoji output to the logs, which you can see [here](https://s3.amazonaws.com/archive.travis-ci.org/jobs/140800058/log.txt) (search for `echo`):

```
[0K$ echo 'ï˜†ï˜­ï›ï™ƒï¤”ï¤— :bug: :tada:'
ï˜†ï˜­ï›ï™ƒï¤”ï¤— :bug: :tada:
```

Some of that is ANSI colour codes or terminal colour control codes I think, but some of it _should_ be Unicode emoji. (I wouldn’t expect the `:tada:` to work in logs.)

These are existing known bugs, we here at Wicked Good Ember just wanted to poke around and see how things looked. I’ll find the relevant issues later and close this PR, it doesn’t contain anything of use, just diagnostics.