### PR TITLE
Experiment with ember-exam

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
   - bower install
 
 script:
-  - ember try:one $EMBER_VERSION --- ember test --reporter dot
+  - ember try:one $EMBER_VERSION --- ember exam --split=4 --reporter dot
 
 before_deploy:
   - ASSETS_HOST=https://s3.amazonaws.com/travis-error-pages ember build --env production

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
   - bower install
 
 script:
-  - ember try:one $EMBER_VERSION --- ember exam --split=4 --reporter dot
+  - ember try:one $EMBER_VERSION --- ember exam --split=4 --parallel --reporter dot
 
 before_deploy:
   - ASSETS_HOST=https://s3.amazonaws.com/travis-error-pages ember build --env production

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "ember-data": "2.6.1",
     "ember-data-filter": "1.13.0",
     "ember-disable-proxy-controllers": "^1.0.1",
+    "ember-exam": "0.4.4",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",

--- a/testem.js
+++ b/testem.js
@@ -11,6 +11,7 @@ var launchInCI = function() {
 module.exports = {
   "framework": "qunit",
   "test_page": "tests/index.html?hidepassed",
+  "parallel": 4,
   "launch_in_ci": launchInCI(),
   "launch_in_dev": [
     "PhantomJS"


### PR DESCRIPTION
The creator of [`ember-exam`](https://github.com/trentmwillis/ember-exam) gave a talk at Wicked Good Ember, so I wanted to try it out.

I used `gtime` (`brew install gnu-time`) with `--verbose`, which produces output like this:

```
	Command being timed: "ember exam --split=4 --parallel"
	User time (seconds): 30.10
	System time (seconds): 5.64
	Percent of CPU this job got: 137%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:26.00
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 1504116736
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 7
	Minor (reclaiming a frame) page faults: 495931
	Voluntary context switches: 7466
	Involuntary context switches: 88131
	Swaps: 0
	File system inputs: 4
	File system outputs: 10138
	Socket messages sent: 2108
	Socket messages received: 38566
	Signals delivered: 10
	Page size (bytes): 4096
	Exit status: 0
```

I selected some relevant-seeming data and ran some varieties of test commands.

| Command | User time | System time | Elapsed time | CPU % |
| --- | --- | --- | --- | --- |
| `ember test` | 21.24 | 5.18 | 33.16 | 79 |
| `ember exam` | 20.19 | 4.79 | 30.76 | 81 |
| `ember exam --split=2` | 15.36 | 4.68 | 24.73 | 81 |
| `ember exam --split=2 --parallel` | 23.72 | 5.37 | 27.61 | 105 |
| `ember exam --split=3` | 14.50 | 4.87 | 23.90 | 81 |
| `ember exam --split=3 --parallel` | 27.05 | 5.26 | 25.23 | 128 |
| `ember exam --split=4` | 12.67 | 4.12 | 19.62 | 85 |
| `ember exam --split=4 --parallel` | 30.10 | 5.64 | 26.00 | 137 |
| `ember exam --split=6` | 13.06 | 4.82 | 22.41 | 79 |
| `ember exam --split=6 --parallel` | 34.67 | 6.47 | 26.93 | 152 |

Note that the `--parallel` flag requires a setting change in `testem.js`; for each of the above, I set the number of processes to the same as the number of splits.

Single runs aren’t the best indicator but I don’t have too much experience in how to be more rigorous in this kind of experimentation. Assuming that minimising elapsed time is ideal, this experiment suggests that _not_ parallelising is faster, strangely to me, but that splitting _is_, also strangely!

I’m going to make some `.travis.yml` changes too to see what happens.