### PR TITLE
Remove unused code

### DIFF
--- a/app/components/branch-row.js
+++ b/app/components/branch-row.js
@@ -60,39 +60,7 @@ export default Ember.Component.extend({
     return lastBuilds;
   }.property(),
 
-  canTrigger: function() {
-    return this.get('permissions').hasPermission(this.get('branch.repository'));
-  }.property('permissions.all', 'build.repository'),
-
-  triggerBuild: function() {
-    var apiEndpoint, options, repoId;
-    apiEndpoint = config.apiEndpoint;
-    repoId = this.get('branch.repository.id');
-    options = {
-      type: 'POST',
-      body: {
-        request: {
-          branch: this.get('branch.name')
-        }
-      }
-    };
-    if (this.get('auth.signedIn')) {
-      options.headers = {
-        Authorization: "token " + (this.auth.token())
-      };
-    }
-    return $.ajax(apiEndpoint + "/v3/repo/" + repoId + "/requests", options).then(() => {
-      this.set('isTriggering', false);
-      return this.set('hasTriggered', true);
-    });
-  },
-
   actions: {
-    tiggerBuild(branch) {
-      this.set('isTriggering', true);
-      return this.triggerBuild();
-    },
-
     viewAllBuilds(branch) {
       return this.get('routing').transitionTo('builds');
     }

--- a/app/components/dashboard-row.js
+++ b/app/components/dashboard-row.js
@@ -36,10 +36,6 @@ export default Ember.Component.extend({
   },
 
   actions: {
-    tiggerBuild(branch) {
-      this.set('isTriggering', true);
-      return this.triggerBuild();
-    },
     openDropup() {
       this.openDropup();
     }


### PR DESCRIPTION
I came across this while looking for code that would be improved by `ember-concurrency`. Could it truly be unused?? Thoughts, @lislis, @drogus, and/or @clekstro? I don’t see the `tiggerBuild` action being called anywhere, nor the `triggerBuild` non-action and the `canTrigger` property. A legacy of removed code perhaps?