### PR TITLE
Add ember-concurrency

### DIFF
--- a/app/components/caches-item.js
+++ b/app/components/caches-item.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import config from 'travis/config/environment';
 
 const { service } = Ember.inject;
+import { task } from 'ember-concurrency';
 
 export default Ember.Component.extend({
   ajax: service(),
@@ -10,27 +11,23 @@ export default Ember.Component.extend({
   classNameBindings: ['cache.type'],
   isDeleting: false,
 
+  delete: task(function * () {
+    if (config.skipConfirmations || confirm('Are you sure?')) {
+      const data = {
+        branch: this.get('cache.branch')
+      };
+      const repo = this.get('repo');
+
+      yield this.get('ajax').ajax(`/repos/${repo.get('id')}/caches`, 'DELETE', {data});
+      return this.get('caches').removeObject(this.get('cache'));
+    } else {
+      return;
+    }
+  }),
+
   actions: {
-    "delete": function() {
-      var data, deletingDone, repo;
-      if (this.get('isDeleting')) {
-        return;
-      }
-      if (config.skipConfirmations || confirm('Are you sure?')) {
-        this.set('isDeleting', true);
-        data = {
-          branch: this.get('cache.branch')
-        };
-        deletingDone = () => {
-          return this.set('isDeleting', false);
-        };
-        repo = this.get('repo');
-        return this.get('ajax').ajax("/repos/" + (repo.get('id')) + "/caches", "DELETE", {
-          data: data
-        }).then(deletingDone, deletingDone).then(() => {
-          return this.get('caches').removeObject(this.get('cache'));
-        });
-      }
+    performDelete() {
+      this.get('delete').perform();
     }
   }
 });

--- a/app/components/caches-item.js
+++ b/app/components/caches-item.js
@@ -20,8 +20,6 @@ export default Ember.Component.extend({
 
       yield this.get('ajax').ajax(`/repos/${repo.get('id')}/caches`, 'DELETE', {data});
       return this.get('caches').removeObject(this.get('cache'));
-    } else {
-      return;
     }
   }),
 

--- a/app/components/cron-job.js
+++ b/app/components/cron-job.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 
 const { service } = Ember.inject;
+import { task } from 'ember-concurrency';
 
 export default Ember.Component.extend({
   classNames: ['settings-cron'],
@@ -70,16 +71,7 @@ export default Ember.Component.extend({
     }
   }.property('cron.disable_by_build'),
 
-  actions: {
-    "delete": function() {
-      if (this.get('isDeleting')) {
-        return;
-      }
-      this.set('isDeleting', true);
-
-      return this.get('cron').destroyRecord().then(() => {
-        this.set('isDeleting', false);
-      });
-    }
-  }
+  delete: task(function * (){
+    yield this.get('cron').destroyRecord();
+  })
 });

--- a/app/components/env-var.js
+++ b/app/components/env-var.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import { task } from 'ember-concurrency';
 
 export default Ember.Component.extend({
   classNames: ['settings-envvar'],
@@ -16,13 +17,7 @@ export default Ember.Component.extend({
     }
   }.property('envVar.value', 'envVar.public'),
 
-  actions: {
-    "delete": function() {
-      if (this.get('isDeleting')) {
-        return;
-      }
-      this.set('isDeleting', true);
-      return this.get('envVar').destroyRecord();
-    }
-  }
+  delete: task(function * () {
+    yield this.get('envVar').destroyRecord();
+  })
 });

--- a/app/components/no-builds.js
+++ b/app/components/no-builds.js
@@ -1,20 +1,16 @@
 import Ember from 'ember';
 import config from 'travis/config/environment';
+import { task } from 'ember-concurrency';
 
 export default Ember.Component.extend({
-  actions: {
-    triggerBuild() {
-      var apiEndpoint;
-      this.set('isLoading', true);
-      apiEndpoint = config.apiEndpoint;
-      return $.ajax(apiEndpoint + ("/v3/repo/" + (this.get('repo.repo.id')) + "/requests"), {
-        headers: {
-          Authorization: 'token ' + this.get('repo.auth')
-        },
-        type: "POST"
-      }).then(() => {
-        return this.set('isLoading', false);
-      });
-    }
-  }
+  triggerBuild: task(function * () {
+    const apiEndpoint = config.apiEndpoint;
+
+    yield $.ajax(`${apiEndpoint}/v3/repo/${this.get('repo.repo.id')}/requests`, {
+      headers: {
+        Authorization: `token ${this.get('repo.auth')}`
+      },
+      type: 'POST'
+    });
+  })
 });

--- a/app/components/not-active.js
+++ b/app/components/not-active.js
@@ -4,6 +4,8 @@ import config from 'travis/config/environment';
 const { service } = Ember.inject;
 const { alias } = Ember.computed;
 
+import { task } from 'ember-concurrency';
+
 export default Ember.Component.extend({
   auth: service(),
   flashes: service(),
@@ -22,33 +24,26 @@ export default Ember.Component.extend({
     }
   }.property('user.pushPermissions.[]', 'repo'),
 
-  actions: {
-    activate: function() {
-      let apiEndpoint = config.apiEndpoint,
-          repoId = this.get('repo.id');
+  activate: task(function * () {
+    const apiEndpoint = config.apiEndpoint;
+    const repoId = this.get('repo.id');
 
-      this.set('isActivating', true);
-      $.ajax(apiEndpoint + '/v3/repo/' + repoId + '/enable', {
+    try {
+      const response = yield $.ajax(`${apiEndpoint}/v3/repo/${repoId}/enable`, {
         headers: {
-          Authorization: 'token ' + this.get('auth').token()
+          Authorization: `token ${this.get('auth').token()}`
         },
         method: 'POST'
-      }).then((response) => {
-        if(response.active) {
-          let pusher = this.get('pusher'),
-              repoId = this.get('repo.id');
-
-          pusher.subscribe('repo-' + repoId);
-
-          this.get('repo').set('active', true);
-
-          this.get('flashes').success('Repository has been successfully activated.');
-        }
-        this.set('isActivating', false);
-      }, () => {
-        this.set('isActivating', false);
-        this.get('flashes').error('There was an error while trying to activate the repository.');
       });
+
+      if (response.active) {
+        const pusher = this.get('pusher');
+        pusher.subscribe(`repo-${repoId}`);
+        this.get('repo').set('active', true);
+        this.get('flashes').success('Repository has been successfully activated.');
+      }
+    } catch (e) {
+      this.get('flashes').error('There was an error while trying to active the repository.');
     }
-  }
+  })
 });

--- a/app/components/ssh-key.js
+++ b/app/components/ssh-key.js
@@ -1,22 +1,16 @@
 import Ember from 'ember';
+import { task } from 'ember-concurrency';
 
 export default Ember.Component.extend({
   classNames: ['settings-sshkey'],
-  isDeleting: false,
-  actions: {
-    "delete": function() {
-      var deletingDone;
-      if (this.get('isDeleting')) {
-        return;
-      }
-      this.set('isDeleting', true);
-      deletingDone = () => {
-        return this.set('isDeleting', false);
-      };
-      this.get('key').deleteRecord();
-      return this.get('key').save().then(deletingDone, deletingDone).then(() => {
-        return this.sendAction('sshKeyDeleted');
-      });
-    }
-  }
+
+  delete: task(function * () {
+    try {
+      const key = this.get('key');
+      key.deleteRecord();
+      yield key.save();
+    } catch (e) {}
+
+    this.sendAction('sshKeyDeleted');
+  })
 });

--- a/app/templates/caches.hbs
+++ b/app/templates/caches.hbs
@@ -1,7 +1,7 @@
 {{#if cachesExist}}
   <div class="caches-header">
     <h1 class="small-title">All caches <small>(<a href="http://docs.travis-ci.com/user/caching/" title="Read about caching">Read the docs</a>)</small></h1>
-    <a {{action "deleteRepoCache"}} href="#" class="{{if isDeleting 'deleting'}} delete-cache-button" title="Delete all repository caches">
+    <a {{action (perform deleteRepoCache)}} href="#" class="{{if deleteRepoCache.isRunning 'deleting'}} delete-cache-button" title="Delete all repository caches">
       Delete all repository caches
     </a>
   </div>

--- a/app/templates/components/add-cron-job.hbs
+++ b/app/templates/components/add-cron-job.hbs
@@ -1,4 +1,4 @@
-<form {{action "save" on="submit"}}>
+<form {{action (perform save) on="submit"}}>
   <div class="form-elem select">
     <span class="label">Branch</span>
     {{#x-select value=selectedBranch required="true"}}
@@ -23,7 +23,7 @@
     {{/x-select}}
   </div>
   <div class="form-elem">
-    {{#if isSaving}}
+    {{#if save.isRunning}}
       {{loading-indicator}}
     {{else}}
       <input type="submit" value="Add" class="form-submit" />

--- a/app/templates/components/add-env-var.hbs
+++ b/app/templates/components/add-env-var.hbs
@@ -1,4 +1,4 @@
-<form {{action "save" on="submit"}}>
+<form {{action (perform save) on='submit'}}>
   <div class="form-elem">
     {{input value=name class="env-name" key-up="nameChanged" placeholder="Name"}}
     {{#if nameIsBlank }}
@@ -12,7 +12,7 @@
     {{travis-switch active=public description="Display value in build log"}}
   </div>
   <div class="form-elem">
-    {{#if isSaving}}
+    {{#if save.isRunning}}
       {{loading-indicator}}
     {{else}}
       <input type="submit" value="Add" class="form-submit" />

--- a/app/templates/components/add-ssh-key.hbs
+++ b/app/templates/components/add-ssh-key.hbs
@@ -1,4 +1,4 @@
-<form {{action "save" on="submit"}}>
+<form {{action (perform save) on='submit'}}>
   <div class="form-elem">
     {{input value=description class="ssh-description" placeholder="Description"}}
   </div>
@@ -9,7 +9,7 @@
     {{/if}}
   </div>
   <div class="form-elem">
-    {{#if isSaving}}
+    {{#if save.isRunning}}
       {{loading-indicator}}
     {{else}}
       <input type="submit" value="Add" class="form-submit" />

--- a/app/templates/components/caches-item.hbs
+++ b/app/templates/components/caches-item.hbs
@@ -11,7 +11,7 @@
   <span class="label-align">{{travis-mb cache.size}}MB</span>
 </div>
 <div class="row-item">
-  <a {{action "delete"}} href="#" class="{{if isDeleting 'deleting'}} delete-cache-icon" title="Delete this cache">
+  <a {{action 'performDelete'}} href="#" class="{{if delete.isRunning 'deleting'}} delete-cache-icon" title="Delete this cache">
     <div class="tooltip">
       <span class="icon-trash">delete cache</span>
       <span class="tooltip-bubble">Delete</span>

--- a/app/templates/components/cron-job.hbs
+++ b/app/templates/components/cron-job.hbs
@@ -3,10 +3,10 @@
 <div class="cron-job-text disable-by-build">{{disableByBuild}}</div>
 <div class="cron-job-action">
   <div class="tooltip">
-    {{#if isDeleting}}
+    {{#if delete.isRunning}}
       {{loading-indicator}}
     {{else}}
-      <a href="#" title="" {{action "delete" on="click"}}>
+      <a href="#" title="" {{action (perform delete) on="click"}}>
         <span class="icon-delete"></span>
       </a>
       <div class="tooltip-bubble">Delete</div>

--- a/app/templates/components/env-var.hbs
+++ b/app/templates/components/env-var.hbs
@@ -8,7 +8,7 @@
     {{#if isDeleting}}
       {{loading-indicator}}
     {{else}}
-      <a href="#" title="" {{action "delete" on="click"}}>
+      <a href="#" title="" {{action (perform delete) on="click"}}>
         <span class="icon-delete"></span>
       </a>
       <div class="tooltip-bubble">Delete</div>

--- a/app/templates/components/limit-concurrent-builds.hbs
+++ b/app/templates/components/limit-concurrent-builds.hbs
@@ -1,4 +1,4 @@
-{{travis-switch active=enabled description=description action="toggle"}}
+{{travis-switch active=enabled description=description action=(perform toggle)}}
 <div class="tooltip-settings">
   <a href="http://docs.travis-ci.com/user/customizing-the-build/#Limiting-Concurrent-Builds" title="about the concurrency setting">
     <p class="tooltip-bubble">Read more about<br>concurrent builds</p>
@@ -8,6 +8,6 @@
 {{#if enabled}}
   <input value={{value}} onchange={{action limitChanged value="target.value"}} pattern="/^[0-9]+$/">
 {{/if}}
-{{#if isSaving}}
+{{#if toggle.isRunning}}
 {{loading-indicator inline=true}}
 {{/if}}

--- a/app/templates/components/no-builds.hbs
+++ b/app/templates/components/no-builds.hbs
@@ -79,7 +79,7 @@
         {{!-- {{#if isLoading}}
           {{loading-indicator}}
         {{else}}
-          <a href="#" class="button button--green" {{action "triggerBuild"}}>Trigger the first build</a>
+          <a href="#" class="button button--green" {{action (perform triggerBuild)}}>Trigger the first build</a>
         {{/if}} --}}
       {{/if}}
     {{/if}}

--- a/app/templates/components/not-active.hbs
+++ b/app/templates/components/not-active.hbs
@@ -66,8 +66,8 @@
     <p class="page-notice">You can activate the repository on {{#link-to "account" repo.owner}}your profile{{/link-to}},<br/>
     or by clicking the button below</p>
 
-    <button {{action 'activate'}} class="button button--green">Activate repository</button>
-    {{#if isActivating}}
+    <button {{action (perform activate)}} class="button button--green">Activate repository</button>
+    {{#if activate.isRunning}}
       {{loading-indicator}}
     {{/if}}
   {{/if}}

--- a/app/templates/components/settings-switch.hbs
+++ b/app/templates/components/settings-switch.hbs
@@ -7,6 +7,6 @@
   </span>
 </div>
 <span class="label">{{description}}</span>
-{{#if isSaving}}
+{{#if save.isRunning}}
   {{loading-indicator}}
 {{/if}}

--- a/app/templates/components/ssh-key.hbs
+++ b/app/templates/components/ssh-key.hbs
@@ -8,12 +8,12 @@
     <span>{{key.fingerprint}}</span>
   </div>
   <div class="ssh-key-action">
-    {{#if isDeleting}}
+    {{#if delete.isRunning}}
       {{loading-indicator}}
     {{else}}
       {{#if pushAccess}}
         <div class="tooltip">
-          <a href="#" title="" {{action "delete"}}>
+          <a href="#" title="" {{action (perform delete)}}>
             <span class="icon-delete"></span>
           </a>
           <div class="tooltip-bubble">Delete</div>

--- a/app/templates/env-vars.hbs
+++ b/app/templates/env-vars.hbs
@@ -8,7 +8,7 @@
           {{partial 'env_vars/form'}}
         {{else}}
           <a class="edit-var" {{action "edit"}} title="Edit env var">Edit</a>
-          <a {{action "delete"}} class="delete-var {{if isDeleting 'deleting'}}" title="Delete env var">
+          <a {{action (perform delete)}} class="delete-var {{if delete.isRunning 'deleting'}}" title="Delete env var">
             Delete
           </a>
           <span class="name">{{name}}</span>

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ember-cli-sentry": "2.3.3",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
+    "ember-concurrency": "0.7.8",
     "ember-data": "2.6.1",
     "ember-data-filter": "1.13.0",
     "ember-disable-proxy-controllers": "^1.0.1",


### PR DESCRIPTION
So far, I’ve added `task`s in some obvious places, by searching for `this.get('is`, which usually signifies that a flag is being set and checked to prevent duplicate firing of asynchronous events, such as updates and deletes. You can see that `ember-concurrency` reduces the boilerplate around this pattern.

(Some of the line savings and shortening is because I’m replacing things with template strings too. 😁)

It would likely be useful elsewhere in the codebase, but for now I’ll just clean up some of the simple cases.