### PR TITLE
Debug site launch failure

### DIFF
--- a/app/initializers/configure-inflector.js
+++ b/app/initializers/configure-inflector.js
@@ -1,10 +1,10 @@
 // As suggested here: https://github.com/samselikoff/ember-cli-mirage/issues/265#issuecomment-142059544
 
 import Ember from 'ember';
+import config from 'travis/config/environment';
 
-export default {
+const initializer = {
   name: 'inflector',
-  before: 'ember-cli-mirage',
 
   initialize: function() {
     const inflector = Ember.Inflector.inflector;
@@ -12,3 +12,9 @@ export default {
     inflector.irregular('cache', 'caches');
   }
 };
+
+if (config.environment !== 'production') {
+  initializer.before = 'ember-cli-mirage';
+}
+
+export default initializer;


### PR DESCRIPTION
As I mentioned [here](https://github.com/travis-ci/travis-web/pull/598#issuecomment-231853066), `master` is failing to deploy. This is an experimental branch to see why this might be happening. Since the Javascript error relates to initialisers, I’m removing the one I added recently. This will cause the tests to fail, but I can force a deployment to staging.