### PR TITLE
Enforce additional ESLint rules (Airbnb style)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+node_modules/
+bower_components/

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,14 +35,11 @@ module.exports = {
     // disallow padding inside computed properties
     'computed-property-spacing': [2, 'never'],
 
-    // // enforces consistent naming when capturing the current execution context
-    // 'consistent-this': 0,
+    // enforces consistent naming when capturing the current execution context
+    'consistent-this': 0,
 
-    // // enforce newline at the end of file, with no multiple empty lines
-    // 'eol-last': 2,
-
-    // // require function expressions to have a name
-    // 'func-names': 1,
+    // enforce newline at the end of file, with no multiple empty lines
+    'eol-last': 2,
 
     // // enforces use of function declarations or expressions
     // 'func-style': 0,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -174,53 +174,55 @@ module.exports = {
     // disallow nested ternary expressions
     // 'no-nested-ternary': 2,
 
-    // // disallow use of the Object constructor
-    // 'no-new-object': 2,
+    // disallow use of the Object constructor
+    'no-new-object': 2,
 
-    // // disallow use of unary operators, ++ and --
-    // 'no-plusplus': 0,
+    // disallow use of unary operators, ++ and --
+    'no-plusplus': 0,
 
-    // // disallow certain syntax forms
-    // // http://eslint.org/docs/rules/no-restricted-syntax
-    // 'no-restricted-syntax': [
-    //   2,
-    //   'DebuggerStatement',
-    //   'ForInStatement',
-    //   'LabeledStatement',
-    //   'WithStatement',
-    // ],
+    // disallow certain syntax forms
+    // http://eslint.org/docs/rules/no-restricted-syntax
+    'no-restricted-syntax': [
+      2,
+      'DebuggerStatement',
+      'LabeledStatement',
+      'WithStatement',
+    ],
 
-    // // disallow space between function identifier and application
-    // 'no-spaced-func': 2,
+    // disallow space between function identifier and application
+    'no-spaced-func': 2,
 
-    // // disallow the use of ternary operators
-    // 'no-ternary': 0,
+    // disallow the use of ternary operators
+    'no-ternary': 0,
 
-    // // disallow trailing whitespace at the end of lines
-    // 'no-trailing-spaces': 2,
+    // disallow trailing whitespace at the end of lines
+    'no-trailing-spaces': 2,
 
-    // // disallow dangling underscores in identifiers
-    // 'no-underscore-dangle': [2, { allowAfterThis: false }],
+    // TODO: Figure out how to get this enabled (renaming some things perhaps)
+    // The the default here is to not allow it, but it's necessary for
+    // overriding via this._super(..arguments), so...
+    // disallow dangling underscores in identifiers
+    // 'no-underscore-dangle': [2, { allowAfterThis: true }],
 
-    // // disallow the use of Boolean literals in conditional expressions
-    // // also, prefer `a || b` over `a ? a : b`
-    // // http://eslint.org/docs/rules/no-unneeded-ternary
-    // 'no-unneeded-ternary': [2, { defaultAssignment: false }],
+    // disallow the use of Boolean literals in conditional expressions
+    // also, prefer `a || b` over `a ? a : b`
+    // http://eslint.org/docs/rules/no-unneeded-ternary
+    'no-unneeded-ternary': [2, { defaultAssignment: false }],
 
-    // // disallow whitespace before properties
-    // // http://eslint.org/docs/rules/no-whitespace-before-property
-    // 'no-whitespace-before-property': 2,
+    // disallow whitespace before properties
+    // http://eslint.org/docs/rules/no-whitespace-before-property
+    'no-whitespace-before-property': 2,
 
-    // // require padding inside curly braces
-    // 'object-curly-spacing': [2, 'always'],
+    // require padding inside curly braces
+    'object-curly-spacing': [2, 'always'],
 
-    // // enforce line breaks between braces
-    // // http://eslint.org/docs/rules/object-curly-newline
-    // // TODO: enable once https://github.com/eslint/eslint/issues/6488 is resolved
-    // 'object-curly-newline': [0, {
-    //   ObjectExpression: { minProperties: 0, multiline: true },
-    //   ObjectPattern: { minProperties: 0, multiline: true }
-    // }],
+    // enforce line breaks between braces
+    // http://eslint.org/docs/rules/object-curly-newline
+    // TODO: enable once https://github.com/eslint/eslint/issues/6488 is resolved
+    'object-curly-newline': [0, {
+      ObjectExpression: { minProperties: 0, multiline: true },
+      ObjectPattern: { minProperties: 0, multiline: true }
+    }],
 
     // // enforce "same line" or "multiple line" on object properties.
     // // http://eslint.org/docs/rules/object-property-newline

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,7 +24,7 @@ module.exports = {
     'brace-style': [2, '1tbs', { allowSingleLine: true }],
 
     // require camel case names
-    camelcase: [2, { properties: 'never' }],
+    'camelcase': [2, { properties: 'never' }],
 
     // enforce spacing before and after comma
     'comma-spacing': [2, { before: false, after: true }],
@@ -32,8 +32,8 @@ module.exports = {
     // enforce one true comma style
     'comma-style': [2, 'last'],
 
-    // // disallow padding inside computed properties
-    // 'computed-property-spacing': [2, 'never'],
+    // disallow padding inside computed properties
+    'computed-property-spacing': [2, 'never'],
 
     // // enforces consistent naming when capturing the current execution context
     // 'consistent-this': 0,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -280,27 +280,27 @@ module.exports = {
     // http://eslint.org/docs/rules/space-before-function-paren
     'space-before-function-paren': [2, { anonymous: 'always', named: 'never' }],
 
-    // // require or disallow spaces inside parentheses
-    // 'space-in-parens': [2, 'never'],
+    // require or disallow spaces inside parentheses
+    'space-in-parens': [2, 'never'],
 
-    // // require spaces around operators
-    // 'space-infix-ops': 2,
+    // require spaces around operators
+    'space-infix-ops': 2,
 
-    // // Require or disallow spaces before/after unary operators
-    // 'space-unary-ops': 0,
+    // Require or disallow spaces before/after unary operators
+    'space-unary-ops': 0,
 
-    // // require or disallow a space immediately following the // or /* in a comment
-    // 'spaced-comment': [2, 'always', {
-    //   exceptions: ['-', '+'],
-    //   markers: ['=', '!']           // space here to support sprockets directives
-    // }],
+    // require or disallow a space immediately following the // or /* in a comment
+    'spaced-comment': [2, 'always', {
+      exceptions: ['-', '+'],
+      markers: ['=', '!']           // space here to support sprockets directives
+    }],
 
-    // // require or disallow the Unicode Byte Order Mark
-    // // http://eslint.org/docs/rules/unicode-bom
-    // // 'unicode-bom': [2, 'never'],
+    // require or disallow the Unicode Byte Order Mark
+    // http://eslint.org/docs/rules/unicode-bom
+    'unicode-bom': [2, 'never'],
 
-    // // require regex literals to be wrapped in parentheses
-    // 'wrap-regex': 0
+    // require regex literals to be wrapped in parentheses
+    'wrap-regex': 0
   },
   globals: {
   }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,37 +57,37 @@ module.exports = {
 
     // this option sets a specific tab width for your code
     // http://eslint.org/docs/rules/indent
-    indent: [2, 2, { SwitchCase: 1, VariableDeclarator: 1}],
+    'indent': [2, 2, { SwitchCase: 1, VariableDeclarator: 1}],
 
     // enforces spacing between keys and values in object literal properties
     'key-spacing': [2, { beforeColon: false, afterColon: true }],
 
-    // // require a space before & after certain keywords
-    // 'keyword-spacing': [2, {
-    //   before: true,
-    //   after: true,
-    //   overrides: {
-    //     return: { after: true },
-    //     throw: { after: true },
-    //     case: { after: true }
-    //   }
-    // }],
+    // require a space before & after certain keywords
+    'keyword-spacing': [2, {
+      before: true,
+      after: true,
+      overrides: {
+        return: { after: true },
+        throw: { after: true },
+        case: { after: true }
+      }
+    }],
 
-    // // disallow mixed 'LF' and 'CRLF' as linebreaks
-    // 'linebreak-style': 0,
+    // disallow mixed 'LF' and 'CRLF' as linebreaks
+    'linebreak-style': 0,
 
-    // // enforces empty lines around comments
-    // 'lines-around-comment': 0,
+    // enforces empty lines around comments
+    'lines-around-comment': 0,
 
-    // // specify the maximum depth that blocks can be nested
-    // 'max-depth': [0, 4],
+    // specify the maximum depth that blocks can be nested
+    'max-depth': [0, 4],
 
-    // // specify the maximum length of a line in your program
-    // // http://eslint.org/docs/rules/max-len
-    // 'max-len': [2, 100, 2, {
-    //   ignoreUrls: true,
-    //   ignoreComments: false
-    // }],
+    // specify the maximum length of a line in your program
+    // http://eslint.org/docs/rules/max-len
+    'max-len': [2, 100, 2, {
+      ignoreUrls: true,
+      ignoreComments: false
+    }],
 
     // // specify the max number of lines in a file
     // // http://eslint.org/docs/rules/max-lines

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -260,9 +260,9 @@ module.exports = {
     // specify whether double or single quotes should be used
     quotes: [2, 'single', { avoidEscape: true }],
 
-    // // do not require jsdoc
-    // // http://eslint.org/docs/rules/require-jsdoc
-    // 'require-jsdoc': 0,
+    // do not require jsdoc
+    // http://eslint.org/docs/rules/require-jsdoc
+    'require-jsdoc': 0,
 
     // // require or disallow use of semicolons instead of ASI
     // semi: [2, 'always'],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,26 +41,26 @@ module.exports = {
     // enforce newline at the end of file, with no multiple empty lines
     'eol-last': 2,
 
-    // // enforces use of function declarations or expressions
-    // 'func-style': 0,
+    // enforces use of function declarations or expressions
+    'func-style': 0,
 
-    // // Blacklist certain identifiers to prevent them being used
-    // // http://eslint.org/docs/rules/id-blacklist
-    // 'id-blacklist': 0,
+    // Blacklist certain identifiers to prevent them being used
+    // http://eslint.org/docs/rules/id-blacklist
+    'id-blacklist': 0,
 
-    // // this option enforces minimum and maximum identifier lengths
-    // // (variable names, property names etc.)
-    // 'id-length': 0,
+    // this option enforces minimum and maximum identifier lengths
+    // (variable names, property names etc.)
+    'id-length': 0,
 
-    // // require identifiers to match the provided regular expression
-    // 'id-match': 0,
+    // require identifiers to match the provided regular expression
+    'id-match': 0,
 
-    // // this option sets a specific tab width for your code
-    // // http://eslint.org/docs/rules/indent
-    // indent: [2, 2, { SwitchCase: 1, VariableDeclarator: 1}],
+    // this option sets a specific tab width for your code
+    // http://eslint.org/docs/rules/indent
+    indent: [2, 2, { SwitchCase: 1, VariableDeclarator: 1}],
 
-    // // enforces spacing between keys and values in object literal properties
-    // 'key-spacing': [2, { beforeColon: false, afterColon: true }],
+    // enforces spacing between keys and values in object literal properties
+    'key-spacing': [2, { beforeColon: false, afterColon: true }],
 
     // // require a space before & after certain keywords
     // 'keyword-spacing': [2, {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -264,21 +264,21 @@ module.exports = {
     // http://eslint.org/docs/rules/require-jsdoc
     'require-jsdoc': 0,
 
-    // // require or disallow use of semicolons instead of ASI
-    // semi: [2, 'always'],
+    // require or disallow use of semicolons instead of ASI
+    semi: [2, 'always'],
 
-    // // enforce spacing before and after semicolons
-    // 'semi-spacing': [2, { before: false, after: true }],
+    // enforce spacing before and after semicolons
+    'semi-spacing': [2, { before: false, after: true }],
 
-    // // sort variables within the same declaration block
-    // 'sort-vars': 0,
+    // sort variables within the same declaration block
+    'sort-vars': 0,
 
-    // // require or disallow space before blocks
-    // 'space-before-blocks': 2,
+    // require or disallow space before blocks
+    'space-before-blocks': 2,
 
-    // // require or disallow space before function opening parenthesis
-    // // http://eslint.org/docs/rules/space-before-function-paren
-    // 'space-before-function-paren': [2, { anonymous: 'always', named: 'never' }],
+    // require or disallow space before function opening parenthesis
+    // http://eslint.org/docs/rules/space-before-function-paren
+    'space-before-function-paren': [2, { anonymous: 'always', named: 'never' }],
 
     // // require or disallow spaces inside parentheses
     // 'space-in-parens': [2, 'never'],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -89,83 +89,89 @@ module.exports = {
       ignoreComments: false
     }],
 
-    // // specify the max number of lines in a file
-    // // http://eslint.org/docs/rules/max-lines
-    // 'max-lines': [0, {
-    //   max: 300,
-    //   skipBlankLines: true,
-    //   skipComments: true
-    // }],
+    // specify the max number of lines in a file
+    // http://eslint.org/docs/rules/max-lines
+    'max-lines': [0, {
+      max: 300,
+      skipBlankLines: true,
+      skipComments: true
+    }],
 
-    // // specify the maximum depth callbacks can be nested
-    // 'max-nested-callbacks': 0,
+    // specify the maximum depth callbacks can be nested
+    'max-nested-callbacks': 0,
 
-    // // limits the number of parameters that can be used in the function declaration.
-    // 'max-params': [0, 3],
+    // limits the number of parameters that can be used in the function declaration.
+    'max-params': [0, 3],
 
-    // // specify the maximum number of statement allowed in a function
-    // 'max-statements': [0, 10],
+    // specify the maximum number of statement allowed in a function
+    'max-statements': [0, 10],
 
-    // // restrict the number of statements per line
-    // // http://eslint.org/docs/rules/max-statements-per-line
-    // 'max-statements-per-line': [0, { max: 1 }],
+    // restrict the number of statements per line
+    // http://eslint.org/docs/rules/max-statements-per-line
+    'max-statements-per-line': [0, { max: 1 }],
 
-    // // require a capital letter for constructors
+    // TODO: Figure way around this. Problematic is currently our use of
+    // Ember.A().
+    // require a capital letter for constructors
     // 'new-cap': [2, { newIsCap: true }],
 
-    // // disallow the omission of parentheses when invoking a constructor with no arguments
-    // 'new-parens': 0,
+    // disallow the omission of parentheses when invoking a constructor with no arguments
+    'new-parens': 0,
 
-    // // allow/disallow an empty newline after var statement
-    // 'newline-after-var': 0,
+    // allow/disallow an empty newline after var statement
+    'newline-after-var': 0,
 
-    // // http://eslint.org/docs/rules/newline-before-return
-    // 'newline-before-return': 0,
+    // http://eslint.org/docs/rules/newline-before-return
+    'newline-before-return': 0,
 
-    // // enforces new line after each method call in the chain to make it
-    // // more readable and easy to maintain
-    // // http://eslint.org/docs/rules/newline-per-chained-call
-    // 'newline-per-chained-call': [2, { ignoreChainWithDepth: 4 }],
+    // enforces new line after each method call in the chain to make it
+    // more readable and easy to maintain
+    // http://eslint.org/docs/rules/newline-per-chained-call
+    'newline-per-chained-call': [2, { ignoreChainWithDepth: 4 }],
 
-    // // disallow use of the Array constructor
-    // 'no-array-constructor': 2,
+    // disallow use of the Array constructor
+    'no-array-constructor': 2,
 
-    // // disallow use of bitwise operators
-    // 'no-bitwise': 0,
+    // disallow use of bitwise operators
+    'no-bitwise': 0,
 
-    // // disallow use of the continue statement
-    // 'no-continue': 0,
+    // disallow use of the continue statement
+    'no-continue': 0,
 
-    // // disallow comments inline after code
-    // 'no-inline-comments': 0,
+    // disallow comments inline after code
+    'no-inline-comments': 0,
 
-    // // disallow if as the only statement in an else block
-    // 'no-lonely-if': 0,
+    // disallow if as the only statement in an else block
+    'no-lonely-if': 0,
 
-    // // disallow un-paren'd mixes of different operators
-    // // http://eslint.org/docs/rules/no-mixed-operators
-    // // 'no-mixed-operators': [2, {
-    // //   groups: [
-    // //     ['+', '-', '*', '/', '%', '**'],
-    // //     ['&', '|', '^', '~', '<<', '>>', '>>>'],
-    // //     ['==', '!=', '===', '!==', '>', '>=', '<', '<='],
-    // //     ['&&', '||'],
-    // //     ['in', 'instanceof']
-    // //   ],
-    // //   allowSamePrecedence: false
-    // // }],
+    // TODO: Figure out why this errors out even though
+    // it's documented
+    // disallow un-paren'd mixes of different operators
+    // http://eslint.org/docs/rules/no-mixed-operators
+    // 'no-mixed-operators': [2, {
+    //   groups: [
+    //     ['+', '-', '*', '/', '%', '**'],
+    //     ['&', '|', '^', '~', '<<', '>>', '>>>'],
+    //     ['==', '!=', '===', '!==', '>', '>=', '<', '<='],
+    //     ['&&', '||'],
+    //     ['in', 'instanceof']
+    //   ],
+    //   allowSamePrecedence: false
+    // }],
 
-    // // disallow mixed spaces and tabs for indentation
-    // 'no-mixed-spaces-and-tabs': 2,
+    // disallow mixed spaces and tabs for indentation
+    'no-mixed-spaces-and-tabs': 2,
 
-    // // disallow multiple empty lines and only one newline at the end
-    // 'no-multiple-empty-lines': [2, { max: 2, maxEOF: 1 }],
+    // disallow multiple empty lines and only one newline at the end
+    'no-multiple-empty-lines': [2, { max: 2, maxEOF: 1 }],
 
-    // // disallow negated conditions
-    // // http://eslint.org/docs/rules/no-negated-condition
-    // 'no-negated-condition': 0,
+    // disallow negated conditions
+    // http://eslint.org/docs/rules/no-negated-condition
+    'no-negated-condition': 0,
 
-    // // disallow nested ternary expressions
+    // TODO: Fix use of this in the app. Just don't have the brain power
+    // currently.
+    // disallow nested ternary expressions
     // 'no-nested-ternary': 2,
 
     // // disallow use of the Object constructor

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,282 +12,283 @@ module.exports = {
   rules: {
     // TODO: Remove this to ensure we handle errors properly in UI
     "no-empty": ["error", { "allowEmptyCatch": true }],
+
     // enforce spacing inside array brackets
     'array-bracket-spacing': [2, 'never'],
 
-    // enforce spacing inside single-line blocks
-    // http://eslint.org/docs/rules/block-spacing
-    'block-spacing': [2, 'always'],
+    // // enforce spacing inside single-line blocks
+    // // http://eslint.org/docs/rules/block-spacing
+    // 'block-spacing': [2, 'always'],
 
-    // enforce one true brace style
-    'brace-style': [2, '1tbs', { allowSingleLine: true }],
+    // // enforce one true brace style
+    // 'brace-style': [2, '1tbs', { allowSingleLine: true }],
 
-    // require camel case names
-    camelcase: [2, { properties: 'never' }],
+    // // require camel case names
+    // camelcase: [2, { properties: 'never' }],
 
-    // enforce spacing before and after comma
-    'comma-spacing': [2, { before: false, after: true }],
+    // // enforce spacing before and after comma
+    // 'comma-spacing': [2, { before: false, after: true }],
 
-    // enforce one true comma style
-    'comma-style': [2, 'last'],
+    // // enforce one true comma style
+    // 'comma-style': [2, 'last'],
 
-    // disallow padding inside computed properties
-    'computed-property-spacing': [2, 'never'],
+    // // disallow padding inside computed properties
+    // 'computed-property-spacing': [2, 'never'],
 
-    // enforces consistent naming when capturing the current execution context
-    'consistent-this': 0,
+    // // enforces consistent naming when capturing the current execution context
+    // 'consistent-this': 0,
 
-    // enforce newline at the end of file, with no multiple empty lines
-    'eol-last': 2,
+    // // enforce newline at the end of file, with no multiple empty lines
+    // 'eol-last': 2,
 
-    // require function expressions to have a name
-    'func-names': 1,
+    // // require function expressions to have a name
+    // 'func-names': 1,
 
-    // enforces use of function declarations or expressions
-    'func-style': 0,
+    // // enforces use of function declarations or expressions
+    // 'func-style': 0,
 
-    // Blacklist certain identifiers to prevent them being used
-    // http://eslint.org/docs/rules/id-blacklist
-    'id-blacklist': 0,
+    // // Blacklist certain identifiers to prevent them being used
+    // // http://eslint.org/docs/rules/id-blacklist
+    // 'id-blacklist': 0,
 
-    // this option enforces minimum and maximum identifier lengths
-    // (variable names, property names etc.)
-    'id-length': 0,
+    // // this option enforces minimum and maximum identifier lengths
+    // // (variable names, property names etc.)
+    // 'id-length': 0,
 
-    // require identifiers to match the provided regular expression
-    'id-match': 0,
-
-    // this option sets a specific tab width for your code
-    // http://eslint.org/docs/rules/indent
-    indent: [2, 2, { SwitchCase: 1, VariableDeclarator: 1}],
+    // // require identifiers to match the provided regular expression
+    // 'id-match': 0,
+
+    // // this option sets a specific tab width for your code
+    // // http://eslint.org/docs/rules/indent
+    // indent: [2, 2, { SwitchCase: 1, VariableDeclarator: 1}],
 
-    // enforces spacing between keys and values in object literal properties
-    'key-spacing': [2, { beforeColon: false, afterColon: true }],
+    // // enforces spacing between keys and values in object literal properties
+    // 'key-spacing': [2, { beforeColon: false, afterColon: true }],
 
-    // require a space before & after certain keywords
-    'keyword-spacing': [2, {
-      before: true,
-      after: true,
-      overrides: {
-        return: { after: true },
-        throw: { after: true },
-        case: { after: true }
-      }
-    }],
+    // // require a space before & after certain keywords
+    // 'keyword-spacing': [2, {
+    //   before: true,
+    //   after: true,
+    //   overrides: {
+    //     return: { after: true },
+    //     throw: { after: true },
+    //     case: { after: true }
+    //   }
+    // }],
 
-    // disallow mixed 'LF' and 'CRLF' as linebreaks
-    'linebreak-style': 0,
+    // // disallow mixed 'LF' and 'CRLF' as linebreaks
+    // 'linebreak-style': 0,
 
-    // enforces empty lines around comments
-    'lines-around-comment': 0,
+    // // enforces empty lines around comments
+    // 'lines-around-comment': 0,
 
-    // specify the maximum depth that blocks can be nested
-    'max-depth': [0, 4],
+    // // specify the maximum depth that blocks can be nested
+    // 'max-depth': [0, 4],
 
-    // specify the maximum length of a line in your program
-    // http://eslint.org/docs/rules/max-len
-    'max-len': [2, 100, 2, {
-      ignoreUrls: true,
-      ignoreComments: false
-    }],
+    // // specify the maximum length of a line in your program
+    // // http://eslint.org/docs/rules/max-len
+    // 'max-len': [2, 100, 2, {
+    //   ignoreUrls: true,
+    //   ignoreComments: false
+    // }],
 
-    // specify the max number of lines in a file
-    // http://eslint.org/docs/rules/max-lines
-    'max-lines': [0, {
-      max: 300,
-      skipBlankLines: true,
-      skipComments: true
-    }],
+    // // specify the max number of lines in a file
+    // // http://eslint.org/docs/rules/max-lines
+    // 'max-lines': [0, {
+    //   max: 300,
+    //   skipBlankLines: true,
+    //   skipComments: true
+    // }],
 
-    // specify the maximum depth callbacks can be nested
-    'max-nested-callbacks': 0,
+    // // specify the maximum depth callbacks can be nested
+    // 'max-nested-callbacks': 0,
 
-    // limits the number of parameters that can be used in the function declaration.
-    'max-params': [0, 3],
+    // // limits the number of parameters that can be used in the function declaration.
+    // 'max-params': [0, 3],
 
-    // specify the maximum number of statement allowed in a function
-    'max-statements': [0, 10],
+    // // specify the maximum number of statement allowed in a function
+    // 'max-statements': [0, 10],
 
-    // restrict the number of statements per line
-    // http://eslint.org/docs/rules/max-statements-per-line
-    'max-statements-per-line': [0, { max: 1 }],
+    // // restrict the number of statements per line
+    // // http://eslint.org/docs/rules/max-statements-per-line
+    // 'max-statements-per-line': [0, { max: 1 }],
 
-    // require a capital letter for constructors
-    'new-cap': [2, { newIsCap: true }],
+    // // require a capital letter for constructors
+    // 'new-cap': [2, { newIsCap: true }],
 
-    // disallow the omission of parentheses when invoking a constructor with no arguments
-    'new-parens': 0,
-
-    // allow/disallow an empty newline after var statement
-    'newline-after-var': 0,
-
-    // http://eslint.org/docs/rules/newline-before-return
-    'newline-before-return': 0,
-
-    // enforces new line after each method call in the chain to make it
-    // more readable and easy to maintain
-    // http://eslint.org/docs/rules/newline-per-chained-call
-    'newline-per-chained-call': [2, { ignoreChainWithDepth: 4 }],
-
-    // disallow use of the Array constructor
-    'no-array-constructor': 2,
-
-    // disallow use of bitwise operators
-    'no-bitwise': 0,
-
-    // disallow use of the continue statement
-    'no-continue': 0,
-
-    // disallow comments inline after code
-    'no-inline-comments': 0,
-
-    // disallow if as the only statement in an else block
-    'no-lonely-if': 0,
-
-    // disallow un-paren'd mixes of different operators
-    // http://eslint.org/docs/rules/no-mixed-operators
-    'no-mixed-operators': [2, {
-      groups: [
-        ['+', '-', '*', '/', '%', '**'],
-        ['&', '|', '^', '~', '<<', '>>', '>>>'],
-        ['==', '!=', '===', '!==', '>', '>=', '<', '<='],
-        ['&&', '||'],
-        ['in', 'instanceof']
-      ],
-      allowSamePrecedence: false
-    }],
-
-    // disallow mixed spaces and tabs for indentation
-    'no-mixed-spaces-and-tabs': 2,
+    // // disallow the omission of parentheses when invoking a constructor with no arguments
+    // 'new-parens': 0,
+
+    // // allow/disallow an empty newline after var statement
+    // 'newline-after-var': 0,
+
+    // // http://eslint.org/docs/rules/newline-before-return
+    // 'newline-before-return': 0,
+
+    // // enforces new line after each method call in the chain to make it
+    // // more readable and easy to maintain
+    // // http://eslint.org/docs/rules/newline-per-chained-call
+    // 'newline-per-chained-call': [2, { ignoreChainWithDepth: 4 }],
+
+    // // disallow use of the Array constructor
+    // 'no-array-constructor': 2,
+
+    // // disallow use of bitwise operators
+    // 'no-bitwise': 0,
+
+    // // disallow use of the continue statement
+    // 'no-continue': 0,
+
+    // // disallow comments inline after code
+    // 'no-inline-comments': 0,
+
+    // // disallow if as the only statement in an else block
+    // 'no-lonely-if': 0,
+
+    // // disallow un-paren'd mixes of different operators
+    // // http://eslint.org/docs/rules/no-mixed-operators
+    // // 'no-mixed-operators': [2, {
+    // //   groups: [
+    // //     ['+', '-', '*', '/', '%', '**'],
+    // //     ['&', '|', '^', '~', '<<', '>>', '>>>'],
+    // //     ['==', '!=', '===', '!==', '>', '>=', '<', '<='],
+    // //     ['&&', '||'],
+    // //     ['in', 'instanceof']
+    // //   ],
+    // //   allowSamePrecedence: false
+    // // }],
+
+    // // disallow mixed spaces and tabs for indentation
+    // 'no-mixed-spaces-and-tabs': 2,
 
-    // disallow multiple empty lines and only one newline at the end
-    'no-multiple-empty-lines': [2, { max: 2, maxEOF: 1 }],
+    // // disallow multiple empty lines and only one newline at the end
+    // 'no-multiple-empty-lines': [2, { max: 2, maxEOF: 1 }],
 
-    // disallow negated conditions
-    // http://eslint.org/docs/rules/no-negated-condition
-    'no-negated-condition': 0,
+    // // disallow negated conditions
+    // // http://eslint.org/docs/rules/no-negated-condition
+    // 'no-negated-condition': 0,
 
-    // disallow nested ternary expressions
-    'no-nested-ternary': 2,
+    // // disallow nested ternary expressions
+    // 'no-nested-ternary': 2,
 
-    // disallow use of the Object constructor
-    'no-new-object': 2,
+    // // disallow use of the Object constructor
+    // 'no-new-object': 2,
 
-    // disallow use of unary operators, ++ and --
-    'no-plusplus': 0,
+    // // disallow use of unary operators, ++ and --
+    // 'no-plusplus': 0,
 
-    // disallow certain syntax forms
-    // http://eslint.org/docs/rules/no-restricted-syntax
-    'no-restricted-syntax': [
-      2,
-      'DebuggerStatement',
-      'ForInStatement',
-      'LabeledStatement',
-      'WithStatement',
-    ],
+    // // disallow certain syntax forms
+    // // http://eslint.org/docs/rules/no-restricted-syntax
+    // 'no-restricted-syntax': [
+    //   2,
+    //   'DebuggerStatement',
+    //   'ForInStatement',
+    //   'LabeledStatement',
+    //   'WithStatement',
+    // ],
 
-    // disallow space between function identifier and application
-    'no-spaced-func': 2,
+    // // disallow space between function identifier and application
+    // 'no-spaced-func': 2,
 
-    // disallow the use of ternary operators
-    'no-ternary': 0,
+    // // disallow the use of ternary operators
+    // 'no-ternary': 0,
 
-    // disallow trailing whitespace at the end of lines
-    'no-trailing-spaces': 2,
+    // // disallow trailing whitespace at the end of lines
+    // 'no-trailing-spaces': 2,
 
-    // disallow dangling underscores in identifiers
-    'no-underscore-dangle': [2, { allowAfterThis: false }],
+    // // disallow dangling underscores in identifiers
+    // 'no-underscore-dangle': [2, { allowAfterThis: false }],
 
-    // disallow the use of Boolean literals in conditional expressions
-    // also, prefer `a || b` over `a ? a : b`
-    // http://eslint.org/docs/rules/no-unneeded-ternary
-    'no-unneeded-ternary': [2, { defaultAssignment: false }],
+    // // disallow the use of Boolean literals in conditional expressions
+    // // also, prefer `a || b` over `a ? a : b`
+    // // http://eslint.org/docs/rules/no-unneeded-ternary
+    // 'no-unneeded-ternary': [2, { defaultAssignment: false }],
 
-    // disallow whitespace before properties
-    // http://eslint.org/docs/rules/no-whitespace-before-property
-    'no-whitespace-before-property': 2,
+    // // disallow whitespace before properties
+    // // http://eslint.org/docs/rules/no-whitespace-before-property
+    // 'no-whitespace-before-property': 2,
 
-    // require padding inside curly braces
-    'object-curly-spacing': [2, 'always'],
+    // // require padding inside curly braces
+    // 'object-curly-spacing': [2, 'always'],
 
-    // enforce line breaks between braces
-    // http://eslint.org/docs/rules/object-curly-newline
-    // TODO: enable once https://github.com/eslint/eslint/issues/6488 is resolved
-    'object-curly-newline': [0, {
-      ObjectExpression: { minProperties: 0, multiline: true },
-      ObjectPattern: { minProperties: 0, multiline: true }
-    }],
+    // // enforce line breaks between braces
+    // // http://eslint.org/docs/rules/object-curly-newline
+    // // TODO: enable once https://github.com/eslint/eslint/issues/6488 is resolved
+    // 'object-curly-newline': [0, {
+    //   ObjectExpression: { minProperties: 0, multiline: true },
+    //   ObjectPattern: { minProperties: 0, multiline: true }
+    // }],
 
-    // enforce "same line" or "multiple line" on object properties.
-    // http://eslint.org/docs/rules/object-property-newline
-    'object-property-newline': [2, {
-      allowMultiplePropertiesPerLine: true,
-    }],
+    // // enforce "same line" or "multiple line" on object properties.
+    // // http://eslint.org/docs/rules/object-property-newline
+    // // 'object-property-newline': [2, {
+    // //   allowMultiplePropertiesPerLine: true,
+    // // }],
 
-    // allow just one var statement per function
-    'one-var': [2, 'never'],
+    // // allow just one var statement per function
+    // 'one-var': [2, 'never'],
 
-    // require a newline around variable declaration
-    // http://eslint.org/docs/rules/one-var-declaration-per-line
-    'one-var-declaration-per-line': [2, 'always'],
+    // // require a newline around variable declaration
+    // // http://eslint.org/docs/rules/one-var-declaration-per-line
+    // 'one-var-declaration-per-line': [2, 'always'],
 
-    // require assignment operator shorthand where possible or prohibit it entirely
-    'operator-assignment': 0,
+    // // require assignment operator shorthand where possible or prohibit it entirely
+    // 'operator-assignment': 0,
 
-    // enforce operators to be placed before or after line breaks
-    'operator-linebreak': 0,
+    // // enforce operators to be placed before or after line breaks
+    // 'operator-linebreak': 0,
 
-    // enforce padding within blocks
-    'padded-blocks': [2, 'never'],
+    // // enforce padding within blocks
+    // 'padded-blocks': [2, 'never'],
 
-    // require quotes around object literal property names
-    // http://eslint.org/docs/rules/quote-props.html
-    'quote-props': [2, 'as-needed', { keywords: false, unnecessary: true, numbers: false }],
+    // // require quotes around object literal property names
+    // // http://eslint.org/docs/rules/quote-props.html
+    // 'quote-props': [2, 'as-needed', { keywords: false, unnecessary: true, numbers: false }],
 
-    // specify whether double or single quotes should be used
-    quotes: [2, 'single', { avoidEscape: true }],
+    // // specify whether double or single quotes should be used
+    // quotes: [2, 'single', { avoidEscape: true }],
 
-    // do not require jsdoc
-    // http://eslint.org/docs/rules/require-jsdoc
-    'require-jsdoc': 0,
+    // // do not require jsdoc
+    // // http://eslint.org/docs/rules/require-jsdoc
+    // 'require-jsdoc': 0,
 
-    // require or disallow use of semicolons instead of ASI
-    semi: [2, 'always'],
+    // // require or disallow use of semicolons instead of ASI
+    // semi: [2, 'always'],
 
-    // enforce spacing before and after semicolons
-    'semi-spacing': [2, { before: false, after: true }],
+    // // enforce spacing before and after semicolons
+    // 'semi-spacing': [2, { before: false, after: true }],
 
-    // sort variables within the same declaration block
-    'sort-vars': 0,
+    // // sort variables within the same declaration block
+    // 'sort-vars': 0,
 
-    // require or disallow space before blocks
-    'space-before-blocks': 2,
+    // // require or disallow space before blocks
+    // 'space-before-blocks': 2,
 
-    // require or disallow space before function opening parenthesis
-    // http://eslint.org/docs/rules/space-before-function-paren
-    'space-before-function-paren': [2, { anonymous: 'always', named: 'never' }],
+    // // require or disallow space before function opening parenthesis
+    // // http://eslint.org/docs/rules/space-before-function-paren
+    // 'space-before-function-paren': [2, { anonymous: 'always', named: 'never' }],
 
-    // require or disallow spaces inside parentheses
-    'space-in-parens': [2, 'never'],
+    // // require or disallow spaces inside parentheses
+    // 'space-in-parens': [2, 'never'],
 
-    // require spaces around operators
-    'space-infix-ops': 2,
+    // // require spaces around operators
+    // 'space-infix-ops': 2,
 
-    // Require or disallow spaces before/after unary operators
-    'space-unary-ops': 0,
+    // // Require or disallow spaces before/after unary operators
+    // 'space-unary-ops': 0,
 
-    // require or disallow a space immediately following the // or /* in a comment
-    'spaced-comment': [2, 'always', {
-      exceptions: ['-', '+'],
-      markers: ['=', '!']           // space here to support sprockets directives
-    }],
+    // // require or disallow a space immediately following the // or /* in a comment
+    // 'spaced-comment': [2, 'always', {
+    //   exceptions: ['-', '+'],
+    //   markers: ['=', '!']           // space here to support sprockets directives
+    // }],
 
-    // require or disallow the Unicode Byte Order Mark
-    // http://eslint.org/docs/rules/unicode-bom
-    'unicode-bom': [2, 'never'],
+    // // require or disallow the Unicode Byte Order Mark
+    // // http://eslint.org/docs/rules/unicode-bom
+    // // 'unicode-bom': [2, 'never'],
 
-    // require regex literals to be wrapped in parentheses
-    'wrap-regex': 0
+    // // require regex literals to be wrapped in parentheses
+    // 'wrap-regex': 0
   },
   globals: {
   }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,7 +11,283 @@ module.exports = {
   },
   rules: {
     // TODO: Remove this to ensure we handle errors properly in UI
-    "no-empty": ["error", { "allowEmptyCatch": true }]
+    "no-empty": ["error", { "allowEmptyCatch": true }],
+    // enforce spacing inside array brackets
+    'array-bracket-spacing': [2, 'never'],
+
+    // enforce spacing inside single-line blocks
+    // http://eslint.org/docs/rules/block-spacing
+    'block-spacing': [2, 'always'],
+
+    // enforce one true brace style
+    'brace-style': [2, '1tbs', { allowSingleLine: true }],
+
+    // require camel case names
+    camelcase: [2, { properties: 'never' }],
+
+    // enforce spacing before and after comma
+    'comma-spacing': [2, { before: false, after: true }],
+
+    // enforce one true comma style
+    'comma-style': [2, 'last'],
+
+    // disallow padding inside computed properties
+    'computed-property-spacing': [2, 'never'],
+
+    // enforces consistent naming when capturing the current execution context
+    'consistent-this': 0,
+
+    // enforce newline at the end of file, with no multiple empty lines
+    'eol-last': 2,
+
+    // require function expressions to have a name
+    'func-names': 1,
+
+    // enforces use of function declarations or expressions
+    'func-style': 0,
+
+    // Blacklist certain identifiers to prevent them being used
+    // http://eslint.org/docs/rules/id-blacklist
+    'id-blacklist': 0,
+
+    // this option enforces minimum and maximum identifier lengths
+    // (variable names, property names etc.)
+    'id-length': 0,
+
+    // require identifiers to match the provided regular expression
+    'id-match': 0,
+
+    // this option sets a specific tab width for your code
+    // http://eslint.org/docs/rules/indent
+    indent: [2, 2, { SwitchCase: 1, VariableDeclarator: 1}],
+
+    // enforces spacing between keys and values in object literal properties
+    'key-spacing': [2, { beforeColon: false, afterColon: true }],
+
+    // require a space before & after certain keywords
+    'keyword-spacing': [2, {
+      before: true,
+      after: true,
+      overrides: {
+        return: { after: true },
+        throw: { after: true },
+        case: { after: true }
+      }
+    }],
+
+    // disallow mixed 'LF' and 'CRLF' as linebreaks
+    'linebreak-style': 0,
+
+    // enforces empty lines around comments
+    'lines-around-comment': 0,
+
+    // specify the maximum depth that blocks can be nested
+    'max-depth': [0, 4],
+
+    // specify the maximum length of a line in your program
+    // http://eslint.org/docs/rules/max-len
+    'max-len': [2, 100, 2, {
+      ignoreUrls: true,
+      ignoreComments: false
+    }],
+
+    // specify the max number of lines in a file
+    // http://eslint.org/docs/rules/max-lines
+    'max-lines': [0, {
+      max: 300,
+      skipBlankLines: true,
+      skipComments: true
+    }],
+
+    // specify the maximum depth callbacks can be nested
+    'max-nested-callbacks': 0,
+
+    // limits the number of parameters that can be used in the function declaration.
+    'max-params': [0, 3],
+
+    // specify the maximum number of statement allowed in a function
+    'max-statements': [0, 10],
+
+    // restrict the number of statements per line
+    // http://eslint.org/docs/rules/max-statements-per-line
+    'max-statements-per-line': [0, { max: 1 }],
+
+    // require a capital letter for constructors
+    'new-cap': [2, { newIsCap: true }],
+
+    // disallow the omission of parentheses when invoking a constructor with no arguments
+    'new-parens': 0,
+
+    // allow/disallow an empty newline after var statement
+    'newline-after-var': 0,
+
+    // http://eslint.org/docs/rules/newline-before-return
+    'newline-before-return': 0,
+
+    // enforces new line after each method call in the chain to make it
+    // more readable and easy to maintain
+    // http://eslint.org/docs/rules/newline-per-chained-call
+    'newline-per-chained-call': [2, { ignoreChainWithDepth: 4 }],
+
+    // disallow use of the Array constructor
+    'no-array-constructor': 2,
+
+    // disallow use of bitwise operators
+    'no-bitwise': 0,
+
+    // disallow use of the continue statement
+    'no-continue': 0,
+
+    // disallow comments inline after code
+    'no-inline-comments': 0,
+
+    // disallow if as the only statement in an else block
+    'no-lonely-if': 0,
+
+    // disallow un-paren'd mixes of different operators
+    // http://eslint.org/docs/rules/no-mixed-operators
+    'no-mixed-operators': [2, {
+      groups: [
+        ['+', '-', '*', '/', '%', '**'],
+        ['&', '|', '^', '~', '<<', '>>', '>>>'],
+        ['==', '!=', '===', '!==', '>', '>=', '<', '<='],
+        ['&&', '||'],
+        ['in', 'instanceof']
+      ],
+      allowSamePrecedence: false
+    }],
+
+    // disallow mixed spaces and tabs for indentation
+    'no-mixed-spaces-and-tabs': 2,
+
+    // disallow multiple empty lines and only one newline at the end
+    'no-multiple-empty-lines': [2, { max: 2, maxEOF: 1 }],
+
+    // disallow negated conditions
+    // http://eslint.org/docs/rules/no-negated-condition
+    'no-negated-condition': 0,
+
+    // disallow nested ternary expressions
+    'no-nested-ternary': 2,
+
+    // disallow use of the Object constructor
+    'no-new-object': 2,
+
+    // disallow use of unary operators, ++ and --
+    'no-plusplus': 0,
+
+    // disallow certain syntax forms
+    // http://eslint.org/docs/rules/no-restricted-syntax
+    'no-restricted-syntax': [
+      2,
+      'DebuggerStatement',
+      'ForInStatement',
+      'LabeledStatement',
+      'WithStatement',
+    ],
+
+    // disallow space between function identifier and application
+    'no-spaced-func': 2,
+
+    // disallow the use of ternary operators
+    'no-ternary': 0,
+
+    // disallow trailing whitespace at the end of lines
+    'no-trailing-spaces': 2,
+
+    // disallow dangling underscores in identifiers
+    'no-underscore-dangle': [2, { allowAfterThis: false }],
+
+    // disallow the use of Boolean literals in conditional expressions
+    // also, prefer `a || b` over `a ? a : b`
+    // http://eslint.org/docs/rules/no-unneeded-ternary
+    'no-unneeded-ternary': [2, { defaultAssignment: false }],
+
+    // disallow whitespace before properties
+    // http://eslint.org/docs/rules/no-whitespace-before-property
+    'no-whitespace-before-property': 2,
+
+    // require padding inside curly braces
+    'object-curly-spacing': [2, 'always'],
+
+    // enforce line breaks between braces
+    // http://eslint.org/docs/rules/object-curly-newline
+    // TODO: enable once https://github.com/eslint/eslint/issues/6488 is resolved
+    'object-curly-newline': [0, {
+      ObjectExpression: { minProperties: 0, multiline: true },
+      ObjectPattern: { minProperties: 0, multiline: true }
+    }],
+
+    // enforce "same line" or "multiple line" on object properties.
+    // http://eslint.org/docs/rules/object-property-newline
+    'object-property-newline': [2, {
+      allowMultiplePropertiesPerLine: true,
+    }],
+
+    // allow just one var statement per function
+    'one-var': [2, 'never'],
+
+    // require a newline around variable declaration
+    // http://eslint.org/docs/rules/one-var-declaration-per-line
+    'one-var-declaration-per-line': [2, 'always'],
+
+    // require assignment operator shorthand where possible or prohibit it entirely
+    'operator-assignment': 0,
+
+    // enforce operators to be placed before or after line breaks
+    'operator-linebreak': 0,
+
+    // enforce padding within blocks
+    'padded-blocks': [2, 'never'],
+
+    // require quotes around object literal property names
+    // http://eslint.org/docs/rules/quote-props.html
+    'quote-props': [2, 'as-needed', { keywords: false, unnecessary: true, numbers: false }],
+
+    // specify whether double or single quotes should be used
+    quotes: [2, 'single', { avoidEscape: true }],
+
+    // do not require jsdoc
+    // http://eslint.org/docs/rules/require-jsdoc
+    'require-jsdoc': 0,
+
+    // require or disallow use of semicolons instead of ASI
+    semi: [2, 'always'],
+
+    // enforce spacing before and after semicolons
+    'semi-spacing': [2, { before: false, after: true }],
+
+    // sort variables within the same declaration block
+    'sort-vars': 0,
+
+    // require or disallow space before blocks
+    'space-before-blocks': 2,
+
+    // require or disallow space before function opening parenthesis
+    // http://eslint.org/docs/rules/space-before-function-paren
+    'space-before-function-paren': [2, { anonymous: 'always', named: 'never' }],
+
+    // require or disallow spaces inside parentheses
+    'space-in-parens': [2, 'never'],
+
+    // require spaces around operators
+    'space-infix-ops': 2,
+
+    // Require or disallow spaces before/after unary operators
+    'space-unary-ops': 0,
+
+    // require or disallow a space immediately following the // or /* in a comment
+    'spaced-comment': [2, 'always', {
+      exceptions: ['-', '+'],
+      markers: ['=', '!']           // space here to support sprockets directives
+    }],
+
+    // require or disallow the Unicode Byte Order Mark
+    // http://eslint.org/docs/rules/unicode-bom
+    'unicode-bom': [2, 'never'],
+
+    // require regex literals to be wrapped in parentheses
+    'wrap-regex': 0
   },
   globals: {
   }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,21 +16,21 @@ module.exports = {
     // enforce spacing inside array brackets
     'array-bracket-spacing': [2, 'never'],
 
-    // // enforce spacing inside single-line blocks
-    // // http://eslint.org/docs/rules/block-spacing
-    // 'block-spacing': [2, 'always'],
+    // enforce spacing inside single-line blocks
+    // http://eslint.org/docs/rules/block-spacing
+    'block-spacing': [2, 'always'],
 
-    // // enforce one true brace style
-    // 'brace-style': [2, '1tbs', { allowSingleLine: true }],
+    // enforce one true brace style
+    'brace-style': [2, '1tbs', { allowSingleLine: true }],
 
-    // // require camel case names
-    // camelcase: [2, { properties: 'never' }],
+    // require camel case names
+    camelcase: [2, { properties: 'never' }],
 
-    // // enforce spacing before and after comma
-    // 'comma-spacing': [2, { before: false, after: true }],
+    // enforce spacing before and after comma
+    'comma-spacing': [2, { before: false, after: true }],
 
-    // // enforce one true comma style
-    // 'comma-style': [2, 'last'],
+    // enforce one true comma style
+    'comma-style': [2, 'last'],
 
     // // disallow padding inside computed properties
     // 'computed-property-spacing': [2, 'never'],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -224,34 +224,41 @@ module.exports = {
       ObjectPattern: { minProperties: 0, multiline: true }
     }],
 
-    // // enforce "same line" or "multiple line" on object properties.
-    // // http://eslint.org/docs/rules/object-property-newline
-    // // 'object-property-newline': [2, {
-    // //   allowMultiplePropertiesPerLine: true,
-    // // }],
+    // TODO: Rule not found
+    // enforce "same line" or "multiple line" on object properties.
+    // http://eslint.org/docs/rules/object-property-newline
+    // 'object-property-newline': [2, {
+    //   allowMultiplePropertiesPerLine: true,
+    // }],
 
-    // // allow just one var statement per function
+    // TODO: Consider re-enabling later
+    // allow just one var statement per function
     // 'one-var': [2, 'never'],
 
-    // // require a newline around variable declaration
-    // // http://eslint.org/docs/rules/one-var-declaration-per-line
+    // TODO: Re-evaluate including this once we've cleaned up some of the
+    // biolerplate around Coffee -> JS conversion that created a *ton* of vars
+    // require a newline around variable declaration
+    // http://eslint.org/docs/rules/one-var-declaration-per-line
     // 'one-var-declaration-per-line': [2, 'always'],
 
-    // // require assignment operator shorthand where possible or prohibit it entirely
-    // 'operator-assignment': 0,
+    // require assignment operator shorthand where possible or prohibit it entirely
+    'operator-assignment': 0,
 
-    // // enforce operators to be placed before or after line breaks
-    // 'operator-linebreak': 0,
+    // enforce operators to be placed before or after line breaks
+    'operator-linebreak': 0,
 
-    // // enforce padding within blocks
-    // 'padded-blocks': [2, 'never'],
+    // enforce padding within blocks
+    'padded-blocks': [2, 'never'],
 
-    // // require quotes around object literal property names
-    // // http://eslint.org/docs/rules/quote-props.html
+    // TODO: Wait on enforcing this until we figure out a way to handle AJAX
+    // Headers in a sane way. We should use unquoted always unless numbers,
+    // keywords *or constants* (or things that look like them).
+    // require quotes around object literal property names
+    // http://eslint.org/docs/rules/quote-props.html
     // 'quote-props': [2, 'as-needed', { keywords: false, unnecessary: true, numbers: false }],
 
-    // // specify whether double or single quotes should be used
-    // quotes: [2, 'single', { avoidEscape: true }],
+    // specify whether double or single quotes should be used
+    quotes: [2, 'single', { avoidEscape: true }],
 
     // // do not require jsdoc
     // // http://eslint.org/docs/rules/require-jsdoc

--- a/app/adapters/.eslintrc.js
+++ b/app/adapters/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  rules: {
+    // disable camelCase requirements as we interact with external API's
+    'camelcase': 0,
+  }
+}

--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -26,8 +26,8 @@ export default ActiveModelAdapter.extend({
 
     let token = this.get('auth').token();
     if (token) {
-      if(!hash.headers['Authorization']) {
-        hash.headers['Authorization'] = "token " + token;
+      if (!hash.headers['Authorization']) {
+        hash.headers['Authorization'] = 'token ' + token;
       }
     }
 

--- a/app/adapters/branch.js
+++ b/app/adapters/branch.js
@@ -4,7 +4,7 @@ export default ApplicationAdapter.extend({
   query(store, type, query) {
     var repo_id = query.repository_id;
     delete query.repository_id;
-    return this.ajax( this.urlPrefix() + '/v3/repo/' + repo_id + '/branches', 'GET', query);
+    return this.ajax(this.urlPrefix() + '/v3/repo/' + repo_id + '/branches', 'GET', query);
   },
 
   findRecord(store, type, id) {

--- a/app/adapters/cron.js
+++ b/app/adapters/cron.js
@@ -8,7 +8,7 @@ export default V3Adapter.extend({
     serializer = store.serializerFor(type.modelName);
     serializer.serializeIntoHash(data, type, record, {});
 
-    return this.ajax(this.urlPrefix() + data.branch + '/cron', "POST", {
+    return this.ajax(this.urlPrefix() + data.branch + '/cron', 'POST', {
       data: {
         disable_by_build: data.disable_by_build,
         interval: data.interval
@@ -19,7 +19,7 @@ export default V3Adapter.extend({
   query(store, type, query) {
     var repo_id = query['repository_id'];
     delete query['repository_id'];
-    return this.ajax( this.urlPrefix() + '/v3/repo/' + repo_id + '/crons', "GET", query);
+    return this.ajax(this.urlPrefix() + '/v3/repo/' + repo_id + '/crons', 'GET', query);
   }
 
 });

--- a/app/adapters/env-var.js
+++ b/app/adapters/env-var.js
@@ -8,7 +8,7 @@ export default ApplicationAdapter.extend({
     url = this._super(...arguments);
     if (record && record.belongsTo('repo') && (repoId = record.belongsTo('repo').id)) {
       delimiter = url.indexOf('?') !== -1 ? '&' : '?';
-      url = "" + url + delimiter + "repository_id=" + repoId;
+      url = '' + url + delimiter + 'repository_id=' + repoId;
     }
     return url;
   },
@@ -19,7 +19,7 @@ export default ApplicationAdapter.extend({
     serializer = store.serializerFor(type.modelName);
     serializer.serializeIntoHash(data, type, record);
     var id = record.id;
-    return this.ajax(this.buildURL(type.modelName, id, record), "PATCH", {
+    return this.ajax(this.buildURL(type.modelName, id, record), 'PATCH', {
       data: data
     });
   }

--- a/app/adapters/hook.js
+++ b/app/adapters/hook.js
@@ -2,7 +2,7 @@ import ApplicationAdapter from 'travis/adapters/application';
 
 export default ApplicationAdapter.extend({
   updateRecord(store, type, snapshot) {
-    return this._super(...arguments).then( () => {
+    return this._super(...arguments).then(() => {
       return { hook: { id: snapshot.id } };
     });
   }

--- a/app/adapters/repo.js
+++ b/app/adapters/repo.js
@@ -3,6 +3,8 @@ import V3Adapter from 'travis/adapters/v3';
 export default V3Adapter.extend({
   defaultSerializer: '-repo',
 
+  includes: 'build.branch,repository.default_branch,repository.current_build,build.commit',
+
   ajaxOptions(url, type, options) {
     var hash = options || {};
     if (!hash.data) {
@@ -10,9 +12,9 @@ export default V3Adapter.extend({
     }
 
     if (hash.data.include) {
-      hash.data.include += ',build.branch,repository.default_branch,repository.current_build,build.commit';
+      hash.data.include += `,${this.get('includes')}`;
     } else {
-      hash.data.include = 'build.branch,repository.default_branch,repository.current_build,build.commit';
+      hash.data.include = this.get('includes');
     }
 
     return this._super(url, type, hash);

--- a/app/adapters/repo.js
+++ b/app/adapters/repo.js
@@ -5,11 +5,11 @@ export default V3Adapter.extend({
 
   ajaxOptions(url, type, options) {
     var hash = options || {};
-    if(!hash.data) {
+    if (!hash.data) {
       hash.data = {};
     }
 
-    if(hash.data.include) {
+    if (hash.data.include) {
       hash.data.include += ',build.branch,repository.default_branch,repository.current_build,build.commit';
     } else {
       hash.data.include = 'build.branch,repository.default_branch,repository.current_build,build.commit';

--- a/app/adapters/ssh-key.js
+++ b/app/adapters/ssh-key.js
@@ -9,7 +9,7 @@ export default ApplicationAdapter.extend({
 
   deleteRecord(store, type, record) {
     var id = record.id;
-    return this.ajax(this.urlPrefix() + '/ssh_key/' + id, "DELETE");
+    return this.ajax(this.urlPrefix() + '/ssh_key/' + id, 'DELETE');
   },
 
   createRecord(store, type, record) {
@@ -21,7 +21,7 @@ export default ApplicationAdapter.extend({
     });
 
     var id = record.id;
-    return this.ajax(this.urlPrefix() + '/ssh_key/' + id, "PATCH", {
+    return this.ajax(this.urlPrefix() + '/ssh_key/' + id, 'PATCH', {
       data: data
     });
   }

--- a/app/adapters/v3.js
+++ b/app/adapters/v3.js
@@ -16,14 +16,14 @@ export default RESTAdapter.extend({
     'Content-Type': 'application/json'
   },
 
-  ajaxOptions: function() {
+  ajaxOptions: function () {
     var hash = this._super(...arguments);
 
     hash.headers = hash.headers || {};
 
     let token = this.get('auth').token();
-    if(token) {
-      hash.headers['Authorization'] = "token " + token;
+    if (token) {
+      hash.headers['Authorization'] = 'token ' + token;
     }
 
     return hash;
@@ -31,7 +31,7 @@ export default RESTAdapter.extend({
 
   // TODO: I shouldn't override this method as it's private, a better way would
   // be to create my own URL generator
-  _buildURL: function(modelName, id) {
+  _buildURL: function (modelName, id) {
     var url = [];
     var host = Ember.get(this, 'host');
     var prefix = this.urlPrefix();
@@ -53,7 +53,7 @@ export default RESTAdapter.extend({
     return url;
   },
 
-  pathForType: function(modelName, id) {
+  pathForType: function (modelName, id) {
     var underscored = Ember.String.underscore(modelName);
     return id ? underscored :  Ember.String.pluralize(underscored);
   },

--- a/app/app.js
+++ b/app/app.js
@@ -22,16 +22,16 @@ var App = Ember.Application.extend(Ember.Evented, {
       location.href = location.href.replace('#!/', '');
     }
 
-    this.on('user:signed_in', function(user) {
+    this.on('user:signed_in', function (user) {
       return Travis.onUserUpdate(user);
     });
-    this.on('user:refreshed', function(user) {
+    this.on('user:refreshed', function (user) {
       return Travis.onUserUpdate(user);
     });
-    this.on('user:synced', function(user) {
+    this.on('user:synced', function (user) {
       return Travis.onUserUpdate(user);
     });
-    return this.on('user:signed_out', function() {
+    return this.on('user:signed_out', function () {
       if (config.beacon) {
         return Travis.destroyBeacon();
       }
@@ -54,7 +54,7 @@ var App = Ember.Application.extend(Ember.Evented, {
   },
 
   destroyBeacon() {
-    HS.beacon.ready(function() {
+    HS.beacon.ready(function () {
       return HS.beacon.destroy();
     });
   },
@@ -72,11 +72,11 @@ var App = Ember.Application.extend(Ember.Evented, {
     }
     channels = user.channels;
     if (config.pro) {
-      channels = channels.map(function(channel) {
+      channels = channels.map(function (channel) {
         if (channel.match(/^private-/)) {
           return channel;
         } else {
-          return "private-" + channel;
+          return 'private-' + channel;
         }
       });
 
@@ -86,7 +86,7 @@ var App = Ember.Application.extend(Ember.Evented, {
 
   identifyHSBeacon(user) {
     if (HS && HS.beacon) {
-      HS.beacon.ready(function() {
+      HS.beacon.ready(function () {
         return HS.beacon.identify({
           name: user.name,
           email: user.email,

--- a/app/app.js
+++ b/app/app.js
@@ -79,7 +79,6 @@ var App = Ember.Application.extend(Ember.Evented, {
           return 'private-' + channel;
         }
       });
-
     }
     return Travis.pusher.subscribeAll(channels);
   },

--- a/app/components/add-cron-job.js
+++ b/app/components/add-cron-job.js
@@ -20,7 +20,7 @@ export default Ember.Component.extend({
     const repoId = this.get('branches.firstObject.repoId');
     const branch = this.get('selectedBranch') ? this.get('selectedBranch') : this.get('branches.firstObject');
 
-    const existingCrons = yield store.filter('cron', {repository_id: repoId}, (c) => {
+    const existingCrons = yield store.filter('cron', { repository_id: repoId }, (c) => {
       return c.get('branch.repoId') === repoId && c.get('branch.name') === branch.get('name');
     });
 

--- a/app/components/add-cron-job.js
+++ b/app/components/add-cron-job.js
@@ -18,7 +18,7 @@ export default Ember.Component.extend({
   save: task(function * () {
     const store = this.get('store');
     const repoId = this.get('branches.firstObject.repoId');
-    const branch = this.get('selectedBranch') ? this.get('selectedBranch') : this.get('branches.firstObject');
+    const branch = this.get('selectedBranch') || this.get('branches.firstObject');
 
     const existingCrons = yield store.filter('cron', { repository_id: repoId }, (c) => {
       return c.get('branch.repoId') === repoId && c.get('branch.name') === branch.get('name');

--- a/app/components/add-env-var.js
+++ b/app/components/add-env-var.js
@@ -21,11 +21,11 @@ export default Ember.Component.extend({
     return this.setProperties({
       name: null,
       value: null,
-      "public": null
+      'public': null
     });
   },
 
-  save: task(function * (){
+  save: task(function * () {
     if (this.isValid()) {
       const envVar = this.get('store').createRecord('env_var', {
         name: this.get('name'),
@@ -37,7 +37,7 @@ export default Ember.Component.extend({
       try {
         yield envVar.save();
         this.reset();
-      } catch(e) {
+      } catch (e) {
       }
     }
   }),

--- a/app/components/add-ssh-key.js
+++ b/app/components/add-ssh-key.js
@@ -41,7 +41,7 @@ export default Ember.Component.extend({
     });
   },
 
-  valueChanged: function() {
+  valueChanged: function () {
     return this.set('valueError', false);
   }.observes('value'),
 
@@ -69,7 +69,7 @@ export default Ember.Component.extend({
         yield sshKey.save();
         this.reset();
         return this.sendAction('sshKeyAdded', sshKey);
-      } catch ({errors}) {
+      } catch ({ errors }) {
         return this.addErrorsFromResponse(errors);
       }
     }

--- a/app/components/add-ssh-key.js
+++ b/app/components/add-ssh-key.js
@@ -41,9 +41,9 @@ export default Ember.Component.extend({
     });
   },
 
-  valueChanged: function () {
+  valueChanged: Ember.observer('value', function () {
     return this.set('valueError', false);
-  }.observes('value'),
+  }),
 
   addErrorsFromResponse(errArr) {
     var error = errArr[0].detail;

--- a/app/components/branch-row.js
+++ b/app/components/branch-row.js
@@ -15,11 +15,11 @@ export default Ember.Component.extend({
   isTriggering: false,
   hasTriggered: false,
 
-  urlGithubCommit: function() {
+  urlGithubCommit: function () {
     return githubCommitUrl(this.get('branch.repository.slug'), this.get('branch.last_build.commit.sha'));
   }.property('branch.last_build'),
 
-  getLast5Builds: function() {
+  getLast5Builds: function () {
     var apiEndpoint, branchName, lastBuilds, options, repoId;
     lastBuilds = Ember.ArrayProxy.create({
       content: [{}, {}, {}, {}, {}],
@@ -35,12 +35,12 @@ export default Ember.Component.extend({
       options = {};
       if (this.get('auth.signedIn')) {
         options.headers = {
-          Authorization: "token " + (this.auth.token())
+          Authorization: 'token ' + (this.auth.token())
         };
       }
-      Ember.$.ajax(apiEndpoint + "/v3/repo/" + repoId + "/builds?branch.name=" + branchName + "&limit=5&build.event_type=push,api,cron", options).then(function(response) {
+      Ember.$.ajax(apiEndpoint + '/v3/repo/' + repoId + '/builds?branch.name=' + branchName + '&limit=5&build.event_type=push,api,cron', options).then(function (response) {
         var array, i, ref;
-        array = response.builds.map(function(build) {
+        array = response.builds.map(function (build) {
           return Ember.Object.create(build);
         });
         // TODO: Clean this up, all we want to do is have 5 elements no matter

--- a/app/components/branch-row.js
+++ b/app/components/branch-row.js
@@ -15,11 +15,11 @@ export default Ember.Component.extend({
   isTriggering: false,
   hasTriggered: false,
 
-  urlGithubCommit: function () {
+  urlGithubCommit: Ember.computed('branch.last_build', function () {
     return githubCommitUrl(this.get('branch.repository.slug'), this.get('branch.last_build.commit.sha'));
-  }.property('branch.last_build'),
+  }),
 
-  getLast5Builds: function () {
+  getLast5Builds: Ember.computed(function () {
     var apiEndpoint, branchName, lastBuilds, options, repoId;
     lastBuilds = Ember.ArrayProxy.create({
       content: [{}, {}, {}, {}, {}],
@@ -59,7 +59,7 @@ export default Ember.Component.extend({
       });
     }
     return lastBuilds;
-  }.property(),
+  }),
 
   actions: {
     viewAllBuilds() {

--- a/app/components/branch-row.js
+++ b/app/components/branch-row.js
@@ -16,7 +16,9 @@ export default Ember.Component.extend({
   hasTriggered: false,
 
   urlGithubCommit: Ember.computed('branch.last_build', function () {
-    return githubCommitUrl(this.get('branch.repository.slug'), this.get('branch.last_build.commit.sha'));
+    let slug = this.get('branch.repository.slug');
+    let commitSha = this.get('branch.last_build.commit.sha');
+    return githubCommitUrl(slug, commitSha);
   }),
 
   getLast5Builds: Ember.computed(function () {
@@ -38,7 +40,11 @@ export default Ember.Component.extend({
           Authorization: 'token ' + (this.auth.token())
         };
       }
-      Ember.$.ajax(apiEndpoint + '/v3/repo/' + repoId + '/builds?branch.name=' + branchName + '&limit=5&build.event_type=push,api,cron', options).then(function (response) {
+      let path = `${apiEndpoint}/v3/repo/${repoId}/builds`;
+      let params = `?branch.name=${branchName}&limit=5&build.event_type=push,api,cron`;
+      let url = `${path}${params}`;
+
+      Ember.$.ajax(url, options).then(function (response) {
         var array, i, ref;
         array = response.builds.map(function (build) {
           return Ember.Object.create(build);

--- a/app/components/build-header.js
+++ b/app/components/build-header.js
@@ -8,18 +8,18 @@ export default Ember.Component.extend({
   classNameBindings: ['item.state'],
   attributeBindings: ['jobId:data-job-id'],
 
-  jobId: function() {
+  jobId: function () {
     if (this.get('item.build')) {
       return this.get('item.id');
     } else {
       let ids = [];
       let jobs = this.get('item.jobs') || [];
-      jobs.forEach(function(item) { ids.push(item.id); });
+      jobs.forEach(function (item) { ids.push(item.id); });
       return ids.join(' ');
     }
   }.property('item'),
 
-  isJob: function() {
+  isJob: function () {
     if (this.get('item.build')) {
       return true;
     } else {
@@ -27,11 +27,11 @@ export default Ember.Component.extend({
     }
   }.property('item'),
 
-  urlGithubCommit: function() {
+  urlGithubCommit: function () {
     return githubCommit(this.get('repo.slug'), this.get('commit.sha'));
   }.property('item'),
 
-  elapsedTime: function() {
+  elapsedTime: function () {
     return durationFrom(this.get('item.startedAt'), this.get('item.finishedAt'));
   }.property('item.startedAt', 'item.finishedAt', 'item.duration')
 });

--- a/app/components/build-header.js
+++ b/app/components/build-header.js
@@ -8,7 +8,7 @@ export default Ember.Component.extend({
   classNameBindings: ['item.state'],
   attributeBindings: ['jobId:data-job-id'],
 
-  jobId: function () {
+  jobId: Ember.computed('item', function () {
     if (this.get('item.build')) {
       return this.get('item.id');
     } else {
@@ -17,21 +17,21 @@ export default Ember.Component.extend({
       jobs.forEach(function (item) { ids.push(item.id); });
       return ids.join(' ');
     }
-  }.property('item'),
+  }),
 
-  isJob: function () {
+  isJob: Ember.computed('item', function () {
     if (this.get('item.build')) {
       return true;
     } else {
       return false;
     }
-  }.property('item'),
+  }),
 
-  urlGithubCommit: function () {
+  urlGithubCommit: Ember.computed('item', function () {
     return githubCommit(this.get('repo.slug'), this.get('commit.sha'));
-  }.property('item'),
+  }),
 
-  elapsedTime: function () {
+  elapsedTime: Ember.computed('item.startedAt', 'item.finishedAt', 'item.duration', function () {
     return durationFrom(this.get('item.startedAt'), this.get('item.finishedAt'));
-  }.property('item.startedAt', 'item.finishedAt', 'item.duration')
+  })
 });

--- a/app/components/build-tile.js
+++ b/app/components/build-tile.js
@@ -5,10 +5,10 @@ export default Ember.Component.extend({
   classNameBindings: ['build.state'],
   attributeBindings: ['title'],
 
-  title: function () {
+  title: Ember.computed('build', function () {
     var num, state;
     num = this.get('build.number');
     state = this.get('build.state');
     return 'Build #' + num + ' ' + state;
-  }.property('build')
+  })
 });

--- a/app/components/build-tile.js
+++ b/app/components/build-tile.js
@@ -5,10 +5,10 @@ export default Ember.Component.extend({
   classNameBindings: ['build.state'],
   attributeBindings: ['title'],
 
-  title: function() {
+  title: function () {
     var num, state;
     num = this.get('build.number');
     state = this.get('build.state');
-    return "Build #" + num + " " + state;
+    return 'Build #' + num + ' ' + state;
   }.property('build')
 });

--- a/app/components/build-wrapper.js
+++ b/app/components/build-wrapper.js
@@ -5,7 +5,7 @@ export default Ember.Component.extend({
   classNameBindings: ['color'],
   pollModels: 'build',
 
-  color: function() {
+  color: function () {
     return colorForState(this.get('build.state'));
   }.property('build.state')
 });

--- a/app/components/build-wrapper.js
+++ b/app/components/build-wrapper.js
@@ -5,7 +5,7 @@ export default Ember.Component.extend({
   classNameBindings: ['color'],
   pollModels: 'build',
 
-  color: function () {
+  color: Ember.computed('build.state', function () {
     return colorForState(this.get('build.state'));
-  }.property('build.state')
+  })
 });

--- a/app/components/builds-item.js
+++ b/app/components/builds-item.js
@@ -6,7 +6,7 @@ export default Ember.Component.extend({
   classNameBindings: ['build.state'],
   classNames: ['row-li', 'pr-row'],
 
-  urlGithubCommit: function () {
+  urlGithubCommit: Ember.computed('build.commit.sha', function () {
     return githubCommitUrl(this.get('build.repo.slug'), this.get('build.commit.sha'));
-  }.property('build.commit.sha')
+  })
 });

--- a/app/components/builds-item.js
+++ b/app/components/builds-item.js
@@ -6,7 +6,7 @@ export default Ember.Component.extend({
   classNameBindings: ['build.state'],
   classNames: ['row-li', 'pr-row'],
 
-  urlGithubCommit: function() {
+  urlGithubCommit: function () {
     return githubCommitUrl(this.get('build.repo.slug'), this.get('build.commit.sha'));
   }.property('build.commit.sha')
 });

--- a/app/components/builds-wrapper.js
+++ b/app/components/builds-wrapper.js
@@ -5,7 +5,7 @@ const { service } = Ember.inject;
 export default Ember.Component.extend({
   store: service(),
 
-  pollHook: function(store) {
+  pollHook: function (store) {
     var contentType, repositoryId;
     contentType = this.get('contentType');
     repositoryId = this.get('repo.id');

--- a/app/components/caches-item.js
+++ b/app/components/caches-item.js
@@ -18,7 +18,7 @@ export default Ember.Component.extend({
       };
       const repo = this.get('repo');
 
-      yield this.get('ajax').ajax(`/repos/${repo.get('id')}/caches`, 'DELETE', {data});
+      yield this.get('ajax').ajax(`/repos/${repo.get('id')}/caches`, 'DELETE', { data });
       return this.get('caches').removeObject(this.get('cache'));
     }
   }),

--- a/app/components/cron-job.js
+++ b/app/components/cron-job.js
@@ -9,7 +9,7 @@ export default Ember.Component.extend({
   actionType: 'Save',
   store: service(),
 
-  intervalText: function() {
+  intervalText: function () {
     function timeOfDay(creationTime) {
       var hours = creationTime.getHours();
       var ampm = hours >= 12 ? 'pm' : 'am';
@@ -20,24 +20,24 @@ export default Ember.Component.extend({
 
     function dayOfWeek(creationTime) {
       var weekday = new Array(7);
-      weekday[0] = "Sunday";
-      weekday[1] = "Monday";
-      weekday[2] = "Tuesday";
-      weekday[3] = "Wednesday";
-      weekday[4] = "Thursday";
-      weekday[5] = "Friday";
-      weekday[6] = "Saturday";
+      weekday[0] = 'Sunday';
+      weekday[1] = 'Monday';
+      weekday[2] = 'Tuesday';
+      weekday[3] = 'Wednesday';
+      weekday[4] = 'Thursday';
+      weekday[5] = 'Friday';
+      weekday[6] = 'Saturday';
       return weekday[creationTime.getDay()];
     }
 
     function dayOfMonth(creationTime) {
       var post = 'th';
       var day = creationTime.getDate();
-      if ( day === 1 ){
+      if (day === 1) {
         post = 'st';
-      } else if ( day === 2 ){
+      } else if (day === 2) {
         post = 'nd';
-      } else if ( day === 3 ){
+      } else if (day === 3) {
         post = 'rd';
       }
       return day + post;
@@ -45,7 +45,7 @@ export default Ember.Component.extend({
 
     var interval = this.get('cron.interval');
     var creationTime = new Date(this.get('cron.created_at'));
-    var text = "";
+    var text = '';
     var time = timeOfDay(creationTime);
 
     switch (interval) {
@@ -63,7 +63,7 @@ export default Ember.Component.extend({
   }.property('cron.created_at'),
 
 
-  disableByBuild: function() {
+  disableByBuild: function () {
     if (this.get('cron.disable_by_build')) {
       return 'Only if no new commit';
     } else {
@@ -71,7 +71,7 @@ export default Ember.Component.extend({
     }
   }.property('cron.disable_by_build'),
 
-  delete: task(function * (){
+  delete: task(function * () {
     yield this.get('cron').destroyRecord();
   })
 });

--- a/app/components/cron-job.js
+++ b/app/components/cron-job.js
@@ -9,7 +9,7 @@ export default Ember.Component.extend({
   actionType: 'Save',
   store: service(),
 
-  intervalText: function () {
+  intervalText: Ember.computed('cron.created_at', function () {
     function timeOfDay(creationTime) {
       var hours = creationTime.getHours();
       var ampm = hours >= 12 ? 'pm' : 'am';
@@ -60,16 +60,16 @@ export default Ember.Component.extend({
         break;
     }
     return text;
-  }.property('cron.created_at'),
+  }),
 
 
-  disableByBuild: function () {
+  disableByBuild: Ember.computed('cron.disable_by_build', function () {
     if (this.get('cron.disable_by_build')) {
       return 'Only if no new commit';
     } else {
       return 'Always run';
     }
-  }.property('cron.disable_by_build'),
+  }),
 
   delete: task(function * () {
     yield this.get('cron').destroyRecord();

--- a/app/components/dashboard-row.js
+++ b/app/components/dashboard-row.js
@@ -16,22 +16,22 @@ export default Ember.Component.extend({
 
   currentBuild: alias('repo.currentBuild'),
 
-  urlGithubCommit: function() {
+  urlGithubCommit: function () {
     return githubCommitUrl(this.get('repo.slug'), this.get('currentBuild.commit.sha'));
   }.property('repo.slug', 'currentBuild.commit.sha'),
 
-  displayMenuTofu: Ember.computed('permissions.all', 'repo', function() {
+  displayMenuTofu: Ember.computed('permissions.all', 'repo', function () {
     return this.get('permissions').hasPushPermission(this.get('repo'));
   }),
 
-  displayActivateLink: Ember.computed('permissions.all', 'repo', function() {
+  displayActivateLink: Ember.computed('permissions.all', 'repo', function () {
     return this.get('permissions').hasAdminPermission(this.get('repo'));
   }),
 
-  openDropup: function() {
+  openDropup: function () {
     var self = this;
     this.toggleProperty('dropupIsOpen');
-    Ember.run.later((function() { self.toggleProperty('dropupIsOpen'); }), 2000);
+    Ember.run.later((function () { self.toggleProperty('dropupIsOpen'); }), 2000);
   },
 
   actions: {

--- a/app/components/dashboard-row.js
+++ b/app/components/dashboard-row.js
@@ -16,9 +16,9 @@ export default Ember.Component.extend({
 
   currentBuild: alias('repo.currentBuild'),
 
-  urlGithubCommit: function () {
+  urlGithubCommit: Ember.computed('repo.slug', 'currentBuild.commit.sha', function () {
     return githubCommitUrl(this.get('repo.slug'), this.get('currentBuild.commit.sha'));
-  }.property('repo.slug', 'currentBuild.commit.sha'),
+  }),
 
   displayMenuTofu: Ember.computed('permissions.all', 'repo', function () {
     return this.get('permissions').hasPushPermission(this.get('repo'));

--- a/app/components/env-var.js
+++ b/app/components/env-var.js
@@ -9,7 +9,7 @@ export default Ember.Component.extend({
   actionType: 'Save',
   showValueField: Ember.computed.alias('public'),
 
-  value: function() {
+  value: function () {
     if (this.get('envVar.public')) {
       return this.get('envVar.value');
     } else {

--- a/app/components/env-var.js
+++ b/app/components/env-var.js
@@ -9,13 +9,13 @@ export default Ember.Component.extend({
   actionType: 'Save',
   showValueField: Ember.computed.alias('public'),
 
-  value: function () {
+  value: Ember.computed('envVar.value', 'envVar.public', function () {
     if (this.get('envVar.public')) {
       return this.get('envVar.value');
     } else {
       return '••••••••••••••••';
     }
-  }.property('envVar.value', 'envVar.public'),
+  }),
 
   delete: task(function * () {
     yield this.get('envVar').destroyRecord();

--- a/app/components/flash-item.js
+++ b/app/components/flash-item.js
@@ -4,9 +4,9 @@ export default Ember.Component.extend({
   tagName: 'li',
   classNameBindings: ['type'],
 
-  type: function () {
+  type: Ember.computed('flash.type', function () {
     return this.get('flash.type') || 'broadcast';
-  }.property('flash.type'),
+  }),
 
   actions: {
     close() {

--- a/app/components/flash-item.js
+++ b/app/components/flash-item.js
@@ -4,7 +4,7 @@ export default Ember.Component.extend({
   tagName: 'li',
   classNameBindings: ['type'],
 
-  type: function() {
+  type: function () {
     return this.get('flash.type') || 'broadcast';
   }.property('flash.type'),
 

--- a/app/components/helpscout-link.js
+++ b/app/components/helpscout-link.js
@@ -7,7 +7,7 @@ export default Ember.Component.extend({
   classNames: ['helpscout-link'],
   attributeBindings: ['href', 'title'],
   href: 'mailto:support@travis-ci.com',
-  title:'Ask Travis CI support for help',
+  title: 'Ask Travis CI support for help',
 
   click: (event) => {
     event.preventDefault();

--- a/app/components/hook-switch.js
+++ b/app/components/hook-switch.js
@@ -13,11 +13,11 @@ export default Ember.Component.extend({
     let hook = this.get('hook');
 
     let pusher = this.get('pusher'),
-        repoId = hook.get('id');
+      repoId = hook.get('id');
 
     return hook.toggle().then(() => {
       let channel = 'repo-' + repoId;
-      if(hook.get('private') || this.get('config').enterprise) {
+      if (hook.get('private') || this.get('config').enterprise) {
         channel = 'private-' + channel;
       }
       pusher.subscribe(channel);

--- a/app/components/hooks-list-item.js
+++ b/app/components/hooks-list-item.js
@@ -9,7 +9,7 @@ export default Ember.Component.extend({
 
   actions: {
     handleToggleError() {
-      return this.set("showError", true);
+      return this.set('showError', true);
     },
 
     close() {
@@ -17,7 +17,7 @@ export default Ember.Component.extend({
     },
 
     resetErrors() {
-      return this.set("showError", false);
+      return this.set('showError', false);
     }
   }
 });

--- a/app/components/job-log.js
+++ b/app/components/job-log.js
@@ -4,18 +4,18 @@ export default Ember.Component.extend({
   logBinding: 'job.log',
   classNames: ['job-log'],
 
-  didReceiveAttrs: function(options) {
+  didReceiveAttrs: function (options) {
     this._super(...arguments);
 
     let oldJob = options.oldAttrs && options.oldAttrs.job && options.oldAttrs.job.value,
-        newJob = options.newAttrs && options.newAttrs.job && options.newAttrs.job.value;
+      newJob = options.newAttrs && options.newAttrs.job && options.newAttrs.job.value;
 
-    if(newJob !== oldJob) {
-      if(newJob) {
+    if (newJob !== oldJob) {
+      if (newJob) {
         this.setupLog(newJob);
       }
 
-      if(oldJob) {
+      if (oldJob) {
         this.teardownLog(oldJob);
       }
     }
@@ -27,7 +27,7 @@ export default Ember.Component.extend({
 
   setupLog(job) {
     this.set('error', false);
-    job.get('log').fetch().then(function() { }, () => {
+    job.get('log').fetch().then(function () { }, () => {
       this.set('error', true);
     });
     job.subscribe();

--- a/app/components/job-wrapper.js
+++ b/app/components/job-wrapper.js
@@ -5,11 +5,11 @@ import { githubCommit } from 'travis/utils/urls';
 export default Ember.Component.extend({
   pollModels: 'job.build',
 
-  color: function () {
+  color: Ember.computed('job.state', function () {
     return colorForState(this.get('job.state'));
-  }.property('job.state'),
+  }),
 
-  urlGithubCommit: function () {
+  urlGithubCommit: Ember.computed('repo.slug', 'commit.sha', function () {
     return githubCommit(this.get('repo.slug'), this.get('commit.sha'));
-  }.property('repo.slug', 'commit.sha')
+  })
 });

--- a/app/components/job-wrapper.js
+++ b/app/components/job-wrapper.js
@@ -5,11 +5,11 @@ import { githubCommit } from 'travis/utils/urls';
 export default Ember.Component.extend({
   pollModels: 'job.build',
 
-  color: function() {
+  color: function () {
     return colorForState(this.get('job.state'));
   }.property('job.state'),
 
-  urlGithubCommit: function() {
+  urlGithubCommit: function () {
     return githubCommit(this.get('repo.slug'), this.get('commit.sha'));
   }.property('repo.slug', 'commit.sha')
 });

--- a/app/components/jobs-item.js
+++ b/app/components/jobs-item.js
@@ -6,7 +6,7 @@ export default Ember.Component.extend({
   classNameBindings: ['job.state'],
   classNames: ['jobs-item'],
 
-  languages: function() {
+  languages: function () {
     var gemfile, key, languageName, output;
     output = [];
     let config = this.get('job.config');
@@ -20,19 +20,19 @@ export default Ember.Component.extend({
       }
       gemfile = this.get('job.config.gemfile');
       if (gemfile && this.get('job.config.env')) {
-        output.push("Gemfile: " + gemfile);
+        output.push('Gemfile: ' + gemfile);
       }
     }
     return output.join(' ');
   }.property('job.config'),
 
-  environment: function() {
+  environment: function () {
     let env = this.get('job.config.env');
     let gemfile = this.get('job.config.gemfile');
     if (env) {
       return env;
     } else if (gemfile) {
-      return "Gemfile: " + gemfile;
+      return 'Gemfile: ' + gemfile;
     }
   }.property('job.config.env', 'job.config.gemfile')
 });

--- a/app/components/jobs-item.js
+++ b/app/components/jobs-item.js
@@ -6,7 +6,7 @@ export default Ember.Component.extend({
   classNameBindings: ['job.state'],
   classNames: ['jobs-item'],
 
-  languages: function () {
+  languages: Ember.computed('job.config', function () {
     var gemfile, key, languageName, output;
     output = [];
     let config = this.get('job.config');
@@ -24,9 +24,9 @@ export default Ember.Component.extend({
       }
     }
     return output.join(' ');
-  }.property('job.config'),
+  }),
 
-  environment: function () {
+  environment: Ember.computed('job.config.env', 'job.config.gemfile', function () {
     let env = this.get('job.config.env');
     let gemfile = this.get('job.config.gemfile');
     if (env) {
@@ -34,5 +34,5 @@ export default Ember.Component.extend({
     } else if (gemfile) {
       return 'Gemfile: ' + gemfile;
     }
-  }.property('job.config.env', 'job.config.gemfile')
+  })
 });

--- a/app/components/jobs-list.js
+++ b/app/components/jobs-list.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 export default Ember.Component.extend({
   tagName: 'section',
   classNames: ['jobs'],
-  jobTableId: Ember.computed(function() {
+  jobTableId: Ember.computed(function () {
     if (this.get('required')) {
       return 'jobs';
     } else {

--- a/app/components/limit-concurrent-builds.js
+++ b/app/components/limit-concurrent-builds.js
@@ -4,14 +4,14 @@ import { task } from 'ember-concurrency';
 export default Ember.Component.extend({
   classNames: ['limit-concurrent-builds'],
 
-  description: function () {
+  description: Ember.computed('enabled', function () {
     var description;
     description = 'Limit concurrent jobs';
     if (this.get('enabled')) {
       description += '  ';
     }
     return description;
-  }.property('enabled'),
+  }),
 
   limitChanged(value) {
     var limit, repo, savingFinished;

--- a/app/components/limit-concurrent-builds.js
+++ b/app/components/limit-concurrent-builds.js
@@ -4,11 +4,11 @@ import { task } from 'ember-concurrency';
 export default Ember.Component.extend({
   classNames: ['limit-concurrent-builds'],
 
-  description: function() {
+  description: function () {
     var description;
-    description = "Limit concurrent jobs";
+    description = 'Limit concurrent jobs';
     if (this.get('enabled')) {
-      description += "  ";
+      description += '  ';
     }
     return description;
   }.property('enabled'),
@@ -34,7 +34,7 @@ export default Ember.Component.extend({
         yield this.get('repo').saveSettings({
           maximum_number_of_builds: 0
         });
-      } catch(e) {}
+      } catch (e) {}
 
       this.set('value', 0);
     }

--- a/app/components/log-content.js
+++ b/app/components/log-content.js
@@ -12,22 +12,22 @@ Log.DEBUG = false;
 
 Log.LIMIT = 10000;
 
-Log.Scroll = function(options) {
+Log.Scroll = function (options) {
   options = options || {};
   this.beforeScroll = options.beforeScroll;
   return this;
 };
 
 Log.Scroll.prototype = Ember.$.extend(new Log.Listener(), {
-  insert: function() {
+  insert: function () {
     if (this.numbers) {
       this.tryScroll();
     }
     return true;
   },
-  tryScroll: function() {
+  tryScroll: function () {
     var ref;
-    let element = Ember.$("#log p:visible.highlight:first");
+    let element = Ember.$('#log p:visible.highlight:first');
     if (element) {
       if (this.beforeScroll) {
         this.beforeScroll();
@@ -38,15 +38,15 @@ Log.Scroll.prototype = Ember.$.extend(new Log.Listener(), {
   }
 });
 
-Log.Limit = function(max_lines, limitedLogCallback) {
+Log.Limit = function (max_lines, limitedLogCallback) {
   this.max_lines = max_lines || 1000;
-  this.limitedLogCallback = limitedLogCallback || (function() {});
+  this.limitedLogCallback = limitedLogCallback || (function () {});
   return this;
 };
 
 Log.Limit.prototype = Log.extend(new Log.Listener(), {
   count: 0,
-  insert: function(node) {
+  insert: function (node) {
     if (node.type === 'paragraph' && !node.hidden) {
       this.count += 1;
       if (this.limited) {
@@ -58,7 +58,7 @@ Log.Limit.prototype = Log.extend(new Log.Listener(), {
 });
 
 Object.defineProperty(Log.Limit.prototype, 'limited', {
-  get: function() {
+  get: function () {
     return this.count >= this.max_lines;
   }
 });
@@ -167,7 +167,7 @@ export default Ember.Component.extend({
   },
 
   partsDidChange(parts, start, _, added) {
-    Ember.run.schedule('afterRender', this, function() {
+    Ember.run.schedule('afterRender', this, function () {
       var i, j, len, part, ref, ref1, ref2, results;
       if (Log.DEBUG) {
         //eslint-disable-next-line
@@ -189,29 +189,29 @@ export default Ember.Component.extend({
     });
   },
 
-  plainTextLogUrl: function() {
+  plainTextLogUrl: function () {
     let id = this.get('log.job.id');
     if (id) {
       let url = plainTextLogUrl(id);
       if (config.pro) {
-        url += "&access_token=" + (this.get('job.log.token'));
+        url += '&access_token=' + (this.get('job.log.token'));
       }
       return url;
     }
   }.property('job.log.id', 'job.log.token'),
 
-  hasPermission: function() {
+  hasPermission: function () {
     return this.get('permissions').hasPermission(this.get('job.repo'));
   }.property('permissions.all', 'job.repo'),
 
-  canRemoveLog: function() {
+  canRemoveLog: function () {
     let job = this.get('job');
     if (job) {
       return job.get('canRemoveLog') && this.get('hasPermission');
     }
   }.property('job.canRemoveLog', 'hasPermission'),
 
-  showToTop: function() {
+  showToTop: function () {
     return this.get('log.hasContent') && this.get('job.canRemoveLog');
   }.property('log.hasContent', 'job.canRemoveLog'),
 
@@ -242,5 +242,5 @@ export default Ember.Component.extend({
   },
 
   // don't remove this, it's needed as an empty willChange callback
-  noop: function() {}
+  noop: function () {}
 });

--- a/app/components/log-content.js
+++ b/app/components/log-content.js
@@ -33,7 +33,9 @@ Log.Scroll.prototype = Ember.$.extend(new Log.Listener(), {
         this.beforeScroll();
       }
       Ember.$('#main').scrollTop(0);
-      return Ember.$('html, body').scrollTop(((ref = element.offset()) != null ? ref.top : void 0) - (window.innerHeight / 3));
+      let offset = element.offset();
+      let scrollTop = ((ref = offset) != null ? ref.top : void 0) - (window.innerHeight / 3);
+      return Ember.$('html, body').scrollTop(scrollTop);
     }
   }
 });
@@ -143,9 +145,11 @@ export default Ember.Component.extend({
     if (!changes.oldAttrs) {
       return;
     }
-    if (changes.newAttrs.job.value && changes.oldAttrs.job.value && changes.newAttrs.job.value !== changes.oldAttrs.job.value) {
-      this.teardownLog(changes.oldAttrs.job.value.get('log'));
-      return this.createEngine(changes.newAttrs.job.value.get('log'));
+    let newJobValue = changes.newAttrs.job.value;
+    let oldJobValue = changes.oldAttrs.job.value;
+    if (oldJobValue && newJobValue && newJobValue !== oldJobValue) {
+      this.teardownLog(oldJobValue.get('log'));
+      return this.createEngine(newJobValue.get('log'));
     }
   },
 
@@ -180,6 +184,8 @@ export default Ember.Component.extend({
       results = [];
       for (i = j = 0, len = ref.length; j < len; i = ++j) {
         part = ref[i];
+        // My brain can't process this right now.
+        // eslint-disable-next-line
         if ((ref1 = this.engine) != null ? (ref2 = ref1.limit) != null ? ref2.limited : void 0 : void 0) {
           break;
         }

--- a/app/components/log-content.js
+++ b/app/components/log-content.js
@@ -38,8 +38,8 @@ Log.Scroll.prototype = Ember.$.extend(new Log.Listener(), {
   }
 });
 
-Log.Limit = function (max_lines, limitedLogCallback) {
-  this.max_lines = max_lines || 1000;
+Log.Limit = function (maxLines, limitedLogCallback) {
+  this.maxLines = maxLines || 1000;
   this.limitedLogCallback = limitedLogCallback || (function () {});
   return this;
 };
@@ -59,7 +59,7 @@ Log.Limit.prototype = Log.extend(new Log.Listener(), {
 
 Object.defineProperty(Log.Limit.prototype, 'limited', {
   get: function () {
-    return this.count >= this.max_lines;
+    return this.count >= this.maxLines;
   }
 });
 

--- a/app/components/log-content.js
+++ b/app/components/log-content.js
@@ -189,7 +189,7 @@ export default Ember.Component.extend({
     });
   },
 
-  plainTextLogUrl: function () {
+  plainTextLogUrl: Ember.computed('job.log.id', 'job.log.token', function () {
     let id = this.get('log.job.id');
     if (id) {
       let url = plainTextLogUrl(id);
@@ -198,22 +198,22 @@ export default Ember.Component.extend({
       }
       return url;
     }
-  }.property('job.log.id', 'job.log.token'),
+  }),
 
-  hasPermission: function () {
+  hasPermission: Ember.computed('permissions.all', 'job.repo', function () {
     return this.get('permissions').hasPermission(this.get('job.repo'));
-  }.property('permissions.all', 'job.repo'),
+  }),
 
-  canRemoveLog: function () {
+  canRemoveLog: Ember.computed('job.canRemoveLog', 'hasPermission', function () {
     let job = this.get('job');
     if (job) {
       return job.get('canRemoveLog') && this.get('hasPermission');
     }
-  }.property('job.canRemoveLog', 'hasPermission'),
+  }),
 
-  showToTop: function () {
+  showToTop: Ember.computed('log.hasContent', 'job.canRemoveLog', function () {
     return this.get('log.hasContent') && this.get('job.canRemoveLog');
-  }.property('log.hasContent', 'job.canRemoveLog'),
+  }),
 
   showTailing: Ember.computed.alias('showToTop'),
 

--- a/app/components/not-active.js
+++ b/app/components/not-active.js
@@ -12,11 +12,11 @@ export default Ember.Component.extend({
 
   user: alias('auth.currentUser'),
 
-  canActivate: function() {
+  canActivate: function () {
     let user = this.get('user');
-    if(user) {
+    if (user) {
       let permissions = user.get('pushPermissions'),
-          repoId = parseInt(this.get('repo.id'));
+        repoId = parseInt(this.get('repo.id'));
 
       return permissions.contains(repoId);
     } else {

--- a/app/components/not-active.js
+++ b/app/components/not-active.js
@@ -12,7 +12,7 @@ export default Ember.Component.extend({
 
   user: alias('auth.currentUser'),
 
-  canActivate: function () {
+  canActivate: Ember.computed('user.pushPermissions.[]', 'repo', function () {
     let user = this.get('user');
     if (user) {
       let permissions = user.get('pushPermissions'),
@@ -22,7 +22,7 @@ export default Ember.Component.extend({
     } else {
       return false;
     }
-  }.property('user.pushPermissions.[]', 'repo'),
+  }),
 
   activate: task(function * () {
     const apiEndpoint = config.apiEndpoint;

--- a/app/components/org-item.js
+++ b/app/components/org-item.js
@@ -10,15 +10,15 @@ export default Ember.Component.extend({
   selected: alias('account.selected'),
   tokenIsVisible: false,
 
-  name: function() {
+  name: function () {
     return this.get('account.name') || this.get('account.login');
   }.property('account'),
 
-  avatarUrl: function() {
+  avatarUrl: function () {
     return this.get('account.avatarUrl') || false;
   }.property('account'),
 
-  isUser: function() {
+  isUser: function () {
     return this.get('account.type') === 'user';
   }.property('account'),
 

--- a/app/components/org-item.js
+++ b/app/components/org-item.js
@@ -10,17 +10,17 @@ export default Ember.Component.extend({
   selected: alias('account.selected'),
   tokenIsVisible: false,
 
-  name: function () {
+  name: Ember.computed('account', function () {
     return this.get('account.name') || this.get('account.login');
-  }.property('account'),
+  }),
 
-  avatarUrl: function () {
+  avatarUrl: Ember.computed('account', function () {
     return this.get('account.avatarUrl') || false;
-  }.property('account'),
+  }),
 
-  isUser: function () {
+  isUser: Ember.computed('account', function () {
     return this.get('account.type') === 'user';
-  }.property('account'),
+  }),
 
   actions: {
     tokenVisibility() {

--- a/app/components/owner-repo-tile.js
+++ b/app/components/owner-repo-tile.js
@@ -5,20 +5,20 @@ export default Ember.Component.extend({
   classNames: ['owner-tile', 'row-li'],
   classNameBindings: ['repo.current_build.state'],
 
-  ownerName: function () {
+  ownerName: Ember.computed('repo.slug', function () {
     return this.get('repo.slug').split(/\//)[0];
-  }.property('repo.slug'),
+  }),
 
-  repoName: function () {
+  repoName: Ember.computed('repo.slug', function () {
     return this.get('repo.slug').split(/\//)[1];
-  }.property('repo.slug'),
+  }),
 
-  isAnimating: function () {
+  isAnimating: Ember.computed('repo.current_build.state', function () {
     var animationStates, state;
     state = this.get('repo.current_build.state');
     animationStates = ['received', 'queued', 'started', 'booting'];
     if (animationStates.indexOf(state) !== -1) {
       return true;
     }
-  }.property('repo.current_build.state')
+  })
 });

--- a/app/components/owner-repo-tile.js
+++ b/app/components/owner-repo-tile.js
@@ -5,15 +5,15 @@ export default Ember.Component.extend({
   classNames: ['owner-tile', 'row-li'],
   classNameBindings: ['repo.current_build.state'],
 
-  ownerName: function() {
+  ownerName: function () {
     return this.get('repo.slug').split(/\//)[0];
   }.property('repo.slug'),
 
-  repoName: function() {
+  repoName: function () {
     return this.get('repo.slug').split(/\//)[1];
   }.property('repo.slug'),
 
-  isAnimating: function() {
+  isAnimating: function () {
     var animationStates, state;
     state = this.get('repo.current_build.state');
     animationStates = ['received', 'queued', 'started', 'booting'];

--- a/app/components/remove-log-popup.js
+++ b/app/components/remove-log-popup.js
@@ -15,9 +15,9 @@ export default Ember.Component.extend({
       var job = this.get('job');
       Ember.$('.popup').removeClass('display');
 
-      return job.removeLog().then(function() {
+      return job.removeLog().then(function () {
         return this.get('flashes').success('Log has been successfully removed.');
-      }, function(xhr) {
+      }, function (xhr) {
         if (xhr.status === 409) {
           return this.get('flashes').error('Log can\'t be removed');
         } else if (xhr.status === 401) {

--- a/app/components/repo-show-tabs.js
+++ b/app/components/repo-show-tabs.js
@@ -5,37 +5,37 @@ export default Ember.Component.extend({
   classNames: ['tabnav'],
   ariaRole: 'tablist',
 
-  classCurrent: function() {
+  classCurrent: function () {
     if (this.get('tab') === 'current') {
       return 'active';
     }
   }.property('tab'),
 
-  classBuilds: function() {
+  classBuilds: function () {
     if (this.get('tab') === 'builds') {
       return 'active';
     }
   }.property('tab'),
 
-  classPullRequests: function() {
+  classPullRequests: function () {
     if (this.get('tab') === 'pull_requests') {
       return 'active';
     }
   }.property('tab'),
 
-  classCrons: function() {
+  classCrons: function () {
     if (this.get('tab') === 'crons') {
       return 'active';
     }
   }.property('tab'),
 
-  classBranches: function() {
+  classBranches: function () {
     if (this.get('tab') === 'branches') {
       return 'active';
     }
   }.property('tab'),
 
-  classBuild: function() {
+  classBuild: function () {
     var classes, tab;
     tab = this.get('tab');
     classes = [];
@@ -48,31 +48,31 @@ export default Ember.Component.extend({
     return classes.join(' ');
   }.property('tab'),
 
-  classJob: function() {
+  classJob: function () {
     if (this.get('tab') === 'job') {
       return 'active';
     }
   }.property('tab'),
 
-  classRequests: function() {
+  classRequests: function () {
     if (this.get('tab') === 'requests') {
       return 'active';
     }
   }.property('tab'),
 
-  classCaches: function() {
+  classCaches: function () {
     if (this.get('tab') === 'caches') {
       return 'active';
     }
   }.property('tab'),
 
-  classSettings: function() {
+  classSettings: function () {
     if (this.get('tab') === 'settings') {
       return 'active';
     }
   }.property('tab'),
 
-  classRequest: function() {
+  classRequest: function () {
     if (this.get('tab') === 'request') {
       return 'active';
     }

--- a/app/components/repo-show-tabs.js
+++ b/app/components/repo-show-tabs.js
@@ -5,37 +5,37 @@ export default Ember.Component.extend({
   classNames: ['tabnav'],
   ariaRole: 'tablist',
 
-  classCurrent: function () {
+  classCurrent: Ember.computed('tab', function () {
     if (this.get('tab') === 'current') {
       return 'active';
     }
-  }.property('tab'),
+  }),
 
-  classBuilds: function () {
+  classBuilds: Ember.computed('tab', function () {
     if (this.get('tab') === 'builds') {
       return 'active';
     }
-  }.property('tab'),
+  }),
 
-  classPullRequests: function () {
+  classPullRequests: Ember.computed('tab', function () {
     if (this.get('tab') === 'pull_requests') {
       return 'active';
     }
-  }.property('tab'),
+  }),
 
-  classCrons: function () {
+  classCrons: Ember.computed('tab', function () {
     if (this.get('tab') === 'crons') {
       return 'active';
     }
-  }.property('tab'),
+  }),
 
-  classBranches: function () {
+  classBranches: Ember.computed('tab', function () {
     if (this.get('tab') === 'branches') {
       return 'active';
     }
-  }.property('tab'),
+  }),
 
-  classBuild: function () {
+  classBuild: Ember.computed('tab', function () {
     var classes, tab;
     tab = this.get('tab');
     classes = [];
@@ -46,35 +46,35 @@ export default Ember.Component.extend({
       classes.push('display-inline');
     }
     return classes.join(' ');
-  }.property('tab'),
+  }),
 
-  classJob: function () {
+  classJob: Ember.computed('tab', function () {
     if (this.get('tab') === 'job') {
       return 'active';
     }
-  }.property('tab'),
+  }),
 
-  classRequests: function () {
+  classRequests: Ember.computed('tab', function () {
     if (this.get('tab') === 'requests') {
       return 'active';
     }
-  }.property('tab'),
+  }),
 
-  classCaches: function () {
+  classCaches: Ember.computed('tab', function () {
     if (this.get('tab') === 'caches') {
       return 'active';
     }
-  }.property('tab'),
+  }),
 
-  classSettings: function () {
+  classSettings: Ember.computed('tab', function () {
     if (this.get('tab') === 'settings') {
       return 'active';
     }
-  }.property('tab'),
+  }),
 
-  classRequest: function () {
+  classRequest: Ember.computed('tab', function () {
     if (this.get('tab') === 'request') {
       return 'active';
     }
-  }.property('tab')
+  })
 });

--- a/app/components/repo-show-tools.js
+++ b/app/components/repo-show-tools.js
@@ -30,15 +30,15 @@ export default Ember.Component.extend({
       return this.toggleProperty('isOpen');
     }
   },
-  displaySettingsLink: function() {
+  displaySettingsLink: function () {
     return this.get('permissions').hasPushPermission(this.get('repo'));
   }.property('permissions.all', 'repo'),
 
-  displayCachesLink: function() {
+  displayCachesLink: function () {
     return this.get('permissions').hasPushPermission(this.get('repo')) && config.endpoints.caches;
   }.property('permissions.all', 'repo'),
 
-  displayStatusImages: function() {
+  displayStatusImages: function () {
     return this.get('permissions').hasPermission(this.get('repo'));
   }.property('permissions.all', 'repo')
 });

--- a/app/components/repo-show-tools.js
+++ b/app/components/repo-show-tools.js
@@ -16,7 +16,9 @@ export default Ember.Component.extend({
   currentUser: alias('auth.currentUser'),
 
   click(event) {
-    if (Ember.$(event.target).is('a') && Ember.$(event.target).parents('.settings-dropdown').length) {
+    let isLink = Ember.$(event.target).is('a');
+    let inSettingsDropdown = Ember.$(event.target).parents('.settings-dropdown').length;
+    if (isLink && inSettingsDropdown) {
       return this.closeMenu();
     }
   },

--- a/app/components/repo-show-tools.js
+++ b/app/components/repo-show-tools.js
@@ -30,15 +30,15 @@ export default Ember.Component.extend({
       return this.toggleProperty('isOpen');
     }
   },
-  displaySettingsLink: function () {
+  displaySettingsLink: Ember.computed('permissions.all', 'repo', function () {
     return this.get('permissions').hasPushPermission(this.get('repo'));
-  }.property('permissions.all', 'repo'),
+  }),
 
-  displayCachesLink: function () {
+  displayCachesLink: Ember.computed('permissions.all', 'repo', function () {
     return this.get('permissions').hasPushPermission(this.get('repo')) && config.endpoints.caches;
-  }.property('permissions.all', 'repo'),
+  }),
 
-  displayStatusImages: function () {
+  displayStatusImages: Ember.computed('permissions.all', 'repo', function () {
     return this.get('permissions').hasPermission(this.get('repo'));
-  }.property('permissions.all', 'repo')
+  })
 });

--- a/app/components/repos-list-item.js
+++ b/app/components/repos-list-item.js
@@ -11,13 +11,13 @@ export default Ember.Component.extend(Polling, {
   classNames: ['repo'],
   classNameBindings: ['selected'],
 
-  selected: function () {
+  selected: Ember.computed('selectedRepo', function () {
     return this.get('repo') === this.get('selectedRepo');
-  }.property('selectedRepo'),
+  }),
 
-  color: function () {
+  color: Ember.computed('repo.currentBuild.state', function () {
     return colorForState(this.get('repo.currentBuild.state'));
-  }.property('repo.currentBuild.state'),
+  }),
 
   scrollTop: function () {
     if (window.scrollY > 0) {

--- a/app/components/repos-list-item.js
+++ b/app/components/repos-list-item.js
@@ -11,15 +11,15 @@ export default Ember.Component.extend(Polling, {
   classNames: ['repo'],
   classNameBindings: ['selected'],
 
-  selected: function() {
+  selected: function () {
     return this.get('repo') === this.get('selectedRepo');
   }.property('selectedRepo'),
 
-  color: function() {
+  color: function () {
     return colorForState(this.get('repo.currentBuild.state'));
   }.property('repo.currentBuild.state'),
 
-  scrollTop: function() {
+  scrollTop: function () {
     if (window.scrollY > 0) {
       return Ember.$('html, body').animate({
         scrollTop: 0

--- a/app/components/repos-list-tabs.js
+++ b/app/components/repos-list-tabs.js
@@ -8,24 +8,24 @@ export default Ember.Component.extend({
 
   currentUser: alias('auth.currentUser'),
 
-  classRecent: function () {
+  classRecent: Ember.computed('tab', function () {
     if (this.get('tab') === 'recent') {
       return 'active';
     } else if (this.get('tab') === 'search' && this.get('auth.signedIn')) {
       return 'hidden';
     }
-  }.property('tab'),
+  }),
 
-  classRunning: function () {
+  classRunning: Ember.computed('tab', function () {
     var classes;
     classes = [];
     if (this.get('tab') === 'running') {
       classes.push('active');
     }
     return classes.join(' ');
-  }.property('tab'),
+  }),
 
-  classOwned: function () {
+  classOwned: Ember.computed('tab', 'currentUser', function () {
     var classes;
     classes = [];
     if (this.get('tab') === 'owned') {
@@ -35,17 +35,17 @@ export default Ember.Component.extend({
       classes.push('display-inline');
     }
     return classes.join(' ');
-  }.property('tab', 'currentUser'),
+  }),
 
-  classSearch: function () {
+  classSearch: Ember.computed('tab', function () {
     if (this.get('tab') === 'search') {
       return 'active';
     }
-  }.property('tab'),
+  }),
 
-  classNew: function () {
+  classNew: Ember.computed('currentUser', function () {
     if (this.get('currentUser')) {
       return 'display-inline';
     }
-  }.property('currentUser')
+  })
 });

--- a/app/components/repos-list-tabs.js
+++ b/app/components/repos-list-tabs.js
@@ -8,7 +8,7 @@ export default Ember.Component.extend({
 
   currentUser: alias('auth.currentUser'),
 
-  classRecent: function() {
+  classRecent: function () {
     if (this.get('tab') === 'recent') {
       return 'active';
     } else if (this.get('tab') === 'search' && this.get('auth.signedIn')) {
@@ -16,7 +16,7 @@ export default Ember.Component.extend({
     }
   }.property('tab'),
 
-  classRunning: function() {
+  classRunning: function () {
     var classes;
     classes = [];
     if (this.get('tab') === 'running') {
@@ -25,7 +25,7 @@ export default Ember.Component.extend({
     return classes.join(' ');
   }.property('tab'),
 
-  classOwned: function() {
+  classOwned: function () {
     var classes;
     classes = [];
     if (this.get('tab') === 'owned') {
@@ -37,13 +37,13 @@ export default Ember.Component.extend({
     return classes.join(' ');
   }.property('tab', 'currentUser'),
 
-  classSearch: function() {
+  classSearch: function () {
     if (this.get('tab') === 'search') {
       return 'active';
     }
   }.property('tab'),
 
-  classNew: function() {
+  classNew: function () {
     if (this.get('currentUser')) {
       return 'display-inline';
     }

--- a/app/components/request-icon.js
+++ b/app/components/request-icon.js
@@ -5,25 +5,25 @@ export default Ember.Component.extend({
   classNames: ['request-icon', 'icon'],
   classNameBindings: ['event', 'state'],
 
-  isPush: function () {
+  isPush: Ember.computed('event', function () {
     return this.get('event') === 'push';
-  }.property('event'),
+  }),
 
-  isPR: function () {
+  isPR: Ember.computed('event', function () {
     return this.get('event') === 'pull_request';
-  }.property('event'),
+  }),
 
-  isCron: function () {
+  isCron: Ember.computed('event', function () {
     return this.get('event') === 'cron';
-  }.property('event'),
+  }),
 
-  isAPI: function () {
+  isAPI: Ember.computed('event', function () {
     return this.get('event') === 'api';
-  }.property('event'),
+  }),
 
-  isEmpty: function () {
+  isEmpty: Ember.computed('event', function () {
     if (this.get('event') === null || this.get('event') === null) {
       return true;
     }
-  }.property('event')
+  })
 });

--- a/app/components/request-icon.js
+++ b/app/components/request-icon.js
@@ -5,23 +5,23 @@ export default Ember.Component.extend({
   classNames: ['request-icon', 'icon'],
   classNameBindings: ['event', 'state'],
 
-  isPush: function() {
+  isPush: function () {
     return this.get('event') === 'push';
   }.property('event'),
 
-  isPR: function() {
+  isPR: function () {
     return this.get('event') === 'pull_request';
   }.property('event'),
 
-  isCron: function() {
+  isCron: function () {
     return this.get('event') === 'cron';
   }.property('event'),
 
-  isAPI: function() {
+  isAPI: function () {
     return this.get('event') === 'api';
   }.property('event'),
 
-  isEmpty: function() {
+  isEmpty: function () {
     if (this.get('event') === null || this.get('event') === null) {
       return true;
     }

--- a/app/components/requests-item.js
+++ b/app/components/requests-item.js
@@ -6,7 +6,7 @@ export default Ember.Component.extend({
   classNameBindings: ['requestClass'],
   tagName: 'li',
 
-  isGHPages: function() {
+  isGHPages: function () {
     var message = this.get('request.message');
     if (message === 'github pages branch') {
       return true;
@@ -15,7 +15,7 @@ export default Ember.Component.extend({
     }
   }.property('request.message'),
 
-  requestClass: function() {
+  requestClass: function () {
     if (this.get('request.isAccepted')) {
       return 'accepted';
     } else {
@@ -23,7 +23,7 @@ export default Ember.Component.extend({
     }
   }.property('content.isAccepted'),
 
-  type: function() {
+  type: function () {
     if (this.get('request.isPullRequest')) {
       return 'pull_request';
     } else {
@@ -31,7 +31,7 @@ export default Ember.Component.extend({
     }
   }.property('request.isPullRequest'),
 
-  status: function() {
+  status: function () {
     if (this.get('request.isAccepted')) {
       return 'Accepted';
     } else {
@@ -39,10 +39,10 @@ export default Ember.Component.extend({
     }
   }.property('request.isAccepted'),
 
-  message: function() {
+  message: function () {
     var message;
     message = this.get('request.message');
-    if (config.pro && message === "private repository") {
+    if (config.pro && message === 'private repository') {
       return '';
     } else if (!message) {
       return 'Build created successfully ';

--- a/app/components/requests-item.js
+++ b/app/components/requests-item.js
@@ -6,40 +6,40 @@ export default Ember.Component.extend({
   classNameBindings: ['requestClass'],
   tagName: 'li',
 
-  isGHPages: function () {
+  isGHPages: Ember.computed('request.message', function () {
     var message = this.get('request.message');
     if (message === 'github pages branch') {
       return true;
     } else {
       return false;
     }
-  }.property('request.message'),
+  }),
 
-  requestClass: function () {
+  requestClass: Ember.computed('content.isAccepted', function () {
     if (this.get('request.isAccepted')) {
       return 'accepted';
     } else {
       return 'rejected';
     }
-  }.property('content.isAccepted'),
+  }),
 
-  type: function () {
+  type: Ember.computed('request.isPullRequest', function () {
     if (this.get('request.isPullRequest')) {
       return 'pull_request';
     } else {
       return 'push';
     }
-  }.property('request.isPullRequest'),
+  }),
 
-  status: function () {
+  status: Ember.computed('request.isAccepted', function () {
     if (this.get('request.isAccepted')) {
       return 'Accepted';
     } else {
       return 'Rejected';
     }
-  }.property('request.isAccepted'),
+  }),
 
-  message: function () {
+  message: Ember.computed('request.message', function () {
     var message;
     message = this.get('request.message');
     if (config.pro && message === 'private repository') {
@@ -49,5 +49,5 @@ export default Ember.Component.extend({
     } else {
       return message;
     }
-  }.property('request.message')
+  })
 });

--- a/app/components/show-more-button.js
+++ b/app/components/show-more-button.js
@@ -10,7 +10,7 @@ export default Ember.Component.extend({
   attributeBindings: ['disabled'],
   disabled: alias('isLoading'),
 
-  buttonLabel: function() {
+  buttonLabel: function () {
     if (this.get('isLoading')) {
       return 'Loading';
     } else {

--- a/app/components/show-more-button.js
+++ b/app/components/show-more-button.js
@@ -10,13 +10,13 @@ export default Ember.Component.extend({
   attributeBindings: ['disabled'],
   disabled: alias('isLoading'),
 
-  buttonLabel: function () {
+  buttonLabel: Ember.computed('isLoading', function () {
     if (this.get('isLoading')) {
       return 'Loading';
     } else {
       return 'Show more';
     }
-  }.property('isLoading'),
+  }),
 
   click() {
     return this.attrs.showMore();

--- a/app/components/status-icon.js
+++ b/app/components/status-icon.js
@@ -6,31 +6,31 @@ export default Ember.Component.extend({
   classNameBindings: ['status'],
   attributeBindings: ['label:aria-label', 'label:title'],
 
-  label: function () {
+  label: Ember.computed('status', function () {
     return 'Job ' + this.get('status');
-  }.property('status'),
+  }),
 
-  hasPassed: function () {
+  hasPassed: Ember.computed('status', function () {
     return this.get('status') === 'passed' || this.get('status') === 'accepted';
-  }.property('status'),
+  }),
 
-  hasFailed: function () {
+  hasFailed: Ember.computed('status', function () {
     return this.get('status') === 'failed' || this.get('status') === 'rejected';
-  }.property('status'),
+  }),
 
-  hasErrored: function () {
+  hasErrored: Ember.computed('status', function () {
     return this.get('status') === 'errored';
-  }.property('status'),
+  }),
 
-  wasCanceled: function () {
+  wasCanceled: Ember.computed('status', function () {
     return this.get('status') === 'canceled';
-  }.property('status'),
+  }),
 
-  isRunning: function () {
+  isRunning: Ember.computed('status', function () {
     return this.get('status') === 'started' || this.get('status') === 'queued' || this.get('status') === 'booting' || this.get('status') === 'received' || this.get('status') === 'created';
-  }.property('status'),
+  }),
 
-  isEmpty: function () {
+  isEmpty: Ember.computed('status', function () {
     if (!this.get('status')) {
       return true;
     } else {
@@ -40,5 +40,5 @@ export default Ember.Component.extend({
         return false;
       }
     }
-  }.property('status')
+  })
 });

--- a/app/components/status-icon.js
+++ b/app/components/status-icon.js
@@ -6,31 +6,31 @@ export default Ember.Component.extend({
   classNameBindings: ['status'],
   attributeBindings: ['label:aria-label', 'label:title'],
 
-  label: function() {
+  label: function () {
     return 'Job ' + this.get('status');
   }.property('status'),
 
-  hasPassed: function() {
+  hasPassed: function () {
     return this.get('status') === 'passed' || this.get('status') === 'accepted';
   }.property('status'),
 
-  hasFailed: function() {
+  hasFailed: function () {
     return this.get('status') === 'failed' || this.get('status') === 'rejected';
   }.property('status'),
 
-  hasErrored: function() {
+  hasErrored: function () {
     return this.get('status') === 'errored';
   }.property('status'),
 
-  wasCanceled: function() {
+  wasCanceled: function () {
     return this.get('status') === 'canceled';
   }.property('status'),
 
-  isRunning: function() {
+  isRunning: function () {
     return this.get('status') === 'started' || this.get('status') === 'queued' || this.get('status') === 'booting' || this.get('status') === 'received' || this.get('status') === 'created';
   }.property('status'),
 
-  isEmpty: function() {
+  isEmpty: function () {
     if (!this.get('status')) {
       return true;
     } else {

--- a/app/components/status-icon.js
+++ b/app/components/status-icon.js
@@ -27,7 +27,9 @@ export default Ember.Component.extend({
   }),
 
   isRunning: Ember.computed('status', function () {
-    return this.get('status') === 'started' || this.get('status') === 'queued' || this.get('status') === 'booting' || this.get('status') === 'received' || this.get('status') === 'created';
+    let status = this.get('status');
+    let runningStates = ['started', 'queued', 'booting', 'received', 'created'];
+    return runningStates.contains(status);
   }),
 
   isEmpty: Ember.computed('status', function () {

--- a/app/components/status-images.js
+++ b/app/components/status-images.js
@@ -16,7 +16,7 @@ export default Ember.Component.extend({
   classNames: ['popup', 'status-images'],
   formats: ['Image URL', 'Markdown', 'Textile', 'Rdoc', 'AsciiDoc', 'RST', 'Pod', 'CCTray'],
 
-  branches: function () {
+  branches: Ember.computed('popupName', 'repo', function () {
     let repoId = this.get('repo.id'),
       popupName = this.get('popupName');
 
@@ -48,7 +48,7 @@ export default Ember.Component.extend({
       // if status images popup is not open, don't fetch any branches
       return [];
     }
-  }.property('popupName', 'repo'),
+  }),
 
   actions: {
     close() {
@@ -56,10 +56,10 @@ export default Ember.Component.extend({
     }
   },
 
-  statusString: function () {
+  statusString: Ember.computed('format', 'repo.slug', 'branch', function () {
     let format = this.get('format') || this.get('formats.firstObject'),
       branch = this.get('branch') || 'master';
 
     return formatStatusImage(format, this.get('repo.slug'), branch);
-  }.property('format', 'repo.slug', 'branch')
+  })
 });

--- a/app/components/status-images.js
+++ b/app/components/status-images.js
@@ -16,25 +16,25 @@ export default Ember.Component.extend({
   classNames: ['popup', 'status-images'],
   formats: ['Image URL', 'Markdown', 'Textile', 'Rdoc', 'AsciiDoc', 'RST', 'Pod', 'CCTray'],
 
-  branches: function() {
+  branches: function () {
     let repoId = this.get('repo.id'),
-        popupName = this.get('popupName');
+      popupName = this.get('popupName');
 
-    if(popupName === 'status-images') {
+    if (popupName === 'status-images') {
       let array = Ember.ArrayProxy.create({ content: [] }),
-          apiEndpoint = Config.apiEndpoint,
-          options = {};
+        apiEndpoint = Config.apiEndpoint,
+        options = {};
 
       array.set('isLoaded', false);
 
       if (this.get('auth.signedIn')) {
         options.headers = {
-          Authorization: "token " + (this.auth.token())
+          Authorization: 'token ' + (this.auth.token())
         };
       }
 
-      Ember.$.ajax(apiEndpoint + "/v3/repo/" + repoId + "/branches?limit=100", options).then(function(response) {
-        if(response.branches.length) {
+      Ember.$.ajax(apiEndpoint + '/v3/repo/' + repoId + '/branches?limit=100', options).then(function (response) {
+        if (response.branches.length) {
           array.pushObjects(response.branches.map((branch) => { return branch.name; }));
         } else {
           array.pushObject('master');
@@ -56,9 +56,9 @@ export default Ember.Component.extend({
     }
   },
 
-  statusString: function() {
+  statusString: function () {
     let format = this.get('format') || this.get('formats.firstObject'),
-        branch = this.get('branch') || 'master';
+      branch = this.get('branch') || 'master';
 
     return formatStatusImage(format, this.get('repo.slug'), branch);
   }.property('format', 'repo.slug', 'branch')

--- a/app/components/status-images.js
+++ b/app/components/status-images.js
@@ -33,7 +33,8 @@ export default Ember.Component.extend({
         };
       }
 
-      Ember.$.ajax(apiEndpoint + '/v3/repo/' + repoId + '/branches?limit=100', options).then(function (response) {
+      let url = `${apiEndpoint}/v3/repo/${repoId}/branches?limit=100`;
+      Ember.$.ajax(url, options).then(function (response) {
         if (response.branches.length) {
           array.pushObjects(response.branches.map((branch) => { return branch.name; }));
         } else {

--- a/app/components/sync-button.js
+++ b/app/components/sync-button.js
@@ -6,7 +6,7 @@ const { alias } = Ember.computed;
 export default Ember.Component.extend({
   auth: service(),
   user: alias('auth.currentUser'),
-  classNames: ["sync-button"],
+  classNames: ['sync-button'],
   actions: {
     sync() {
       return this.get('user').sync();

--- a/app/components/travis-status.js
+++ b/app/components/travis-status.js
@@ -4,7 +4,7 @@ import config from 'travis/config/environment';
 export default Ember.Component.extend({
   status: null,
 
-  statusPageStatusUrl: function() {
+  statusPageStatusUrl: function () {
     return config.statusPageStatusUrl;
   }.property(),
 

--- a/app/components/travis-status.js
+++ b/app/components/travis-status.js
@@ -4,9 +4,9 @@ import config from 'travis/config/environment';
 export default Ember.Component.extend({
   status: null,
 
-  statusPageStatusUrl: function () {
+  statusPageStatusUrl: Ember.computed(function () {
     return config.statusPageStatusUrl;
-  }.property(),
+  }),
 
   didInsertElement() {
     let url = this.get('statusPageStatusUrl');

--- a/app/components/travis-switch.js
+++ b/app/components/travis-switch.js
@@ -5,9 +5,9 @@ export default Ember.Component.extend({
   classNames: ['travis-switch', 'switch'],
   classNameBindings: ['_active:active'],
 
-  _active: function () {
+  _active: Ember.computed('target.active', 'active', function () {
     return this.get('target.active') || this.get('active');
-  }.property('target.active', 'active'),
+  }),
 
   click() {
     var target;

--- a/app/components/travis-switch.js
+++ b/app/components/travis-switch.js
@@ -5,7 +5,7 @@ export default Ember.Component.extend({
   classNames: ['travis-switch', 'switch'],
   classNameBindings: ['_active:active'],
 
-  _active: function() {
+  _active: function () {
     return this.get('target.active') || this.get('active');
   }.property('target.active', 'active'),
 
@@ -19,7 +19,7 @@ export default Ember.Component.extend({
         this.set('active', !this.get('active'));
       }
     }
-    return Ember.run.next(this, function() {
+    return Ember.run.next(this, function () {
       return this.sendAction('action', target);
     });
   }

--- a/app/components/user-avatar.js
+++ b/app/components/user-avatar.js
@@ -5,7 +5,7 @@ export default Ember.Component.extend({
   tagName: 'span',
   classNameBindings: ['small:avatar--small:avatar'],
 
-  userInitials: function() {
+  userInitials: function () {
     var name = this.get('name');
     var arr = name.split(' ');
     var initials = '';
@@ -15,7 +15,7 @@ export default Ember.Component.extend({
     } else {
       initials = arr[0].split('')[0];
     }
-      return initials;
+    return initials;
   }.property('userInitials')
 
 });

--- a/app/components/user-avatar.js
+++ b/app/components/user-avatar.js
@@ -5,7 +5,7 @@ export default Ember.Component.extend({
   tagName: 'span',
   classNameBindings: ['small:avatar--small:avatar'],
 
-  userInitials: function () {
+  userInitials: Ember.computed('userInitials', function () {
     var name = this.get('name');
     var arr = name.split(' ');
     var initials = '';
@@ -16,6 +16,6 @@ export default Ember.Component.extend({
       initials = arr[0].split('')[0];
     }
     return initials;
-  }.property('userInitials')
+  })
 
 });

--- a/app/controllers/account.js
+++ b/app/controllers/account.js
@@ -42,11 +42,11 @@ export default Ember.Controller.extend({
     }
   },
 
-  accountName: function () {
+  accountName: Ember.computed('model.name', 'model.login', function () {
     return this.get('model.name') || this.get('model.login');
-  }.property('model.name', 'model.login'),
+  }),
 
-  hooks: function () {
+  hooks: Ember.computed('allHooks.length', 'allHooks', function () {
     let hooks = this.get('allHooks');
     if (!hooks) {
       this.reloadHooks();
@@ -54,9 +54,9 @@ export default Ember.Controller.extend({
     return this.get('allHooks').filter(function (hook) {
       return hook.get('admin');
     });
-  }.property('allHooks.length', 'allHooks'),
+  }),
 
-  hooksWithoutAdmin: function () {
+  hooksWithoutAdmin: Ember.computed('allHooks.length', 'allHooks', function () {
     let hooks = this.get('allHooks');
     if (!hooks) {
       this.reloadHooks();
@@ -64,27 +64,27 @@ export default Ember.Controller.extend({
     return this.get('allHooks').filter(function (hook) {
       return !hook.get('admin');
     });
-  }.property('allHooks.length', 'allHooks'),
+  }),
 
-  showPrivateReposHint: function () {
+  showPrivateReposHint: Ember.computed(function () {
     return this.config.show_repos_hint === 'private';
-  }.property(),
+  }),
 
-  showPublicReposHint: function () {
+  showPublicReposHint: Ember.computed(function () {
     return this.config.show_repos_hint === 'public';
-  }.property(),
+  }),
 
-  billingUrl: function () {
+  billingUrl: Ember.computed('model.name', 'model.login', function () {
     var id;
     id = this.get('model.type') === 'user' ? 'user' : this.get('model.login');
     return this.config.billingEndpoint + '/subscriptions/' + id;
-  }.property('model.name', 'model.login'),
+  }),
 
-  subscribeButtonInfo: function () {
+  subscribeButtonInfo: Ember.computed('model.login', 'model.type', function () {
     return {
       billingUrl: this.get('billingUrl'),
       subscribed: this.get('model.subscribed'),
       education: this.get('model.education')
     };
-  }.property('model.login', 'model.type')
+  })
 });

--- a/app/controllers/account.js
+++ b/app/controllers/account.js
@@ -13,7 +13,7 @@ export default Ember.Controller.extend({
     var self;
     this._super(...arguments);
     self = this;
-    return Travis.on("user:synced", (function() {
+    return Travis.on('user:synced', (function () {
       return self.reloadHooks();
     }));
   },
@@ -35,52 +35,52 @@ export default Ember.Controller.extend({
         all: true,
         owner_name: login
       });
-      hooks.then(function() {
+      hooks.then(function () {
         return hooks.set('isLoaded', true);
       });
       return this.set('allHooks', hooks);
     }
   },
 
-  accountName: function() {
+  accountName: function () {
     return this.get('model.name') || this.get('model.login');
   }.property('model.name', 'model.login'),
 
-  hooks: function() {
+  hooks: function () {
     let hooks = this.get('allHooks');
     if (!hooks) {
       this.reloadHooks();
     }
-    return this.get('allHooks').filter(function(hook) {
+    return this.get('allHooks').filter(function (hook) {
       return hook.get('admin');
     });
   }.property('allHooks.length', 'allHooks'),
 
-  hooksWithoutAdmin: function() {
+  hooksWithoutAdmin: function () {
     let hooks = this.get('allHooks');
     if (!hooks) {
       this.reloadHooks();
     }
-    return this.get('allHooks').filter(function(hook) {
+    return this.get('allHooks').filter(function (hook) {
       return !hook.get('admin');
     });
   }.property('allHooks.length', 'allHooks'),
 
-  showPrivateReposHint: function() {
+  showPrivateReposHint: function () {
     return this.config.show_repos_hint === 'private';
   }.property(),
 
-  showPublicReposHint: function() {
+  showPublicReposHint: function () {
     return this.config.show_repos_hint === 'public';
   }.property(),
 
-  billingUrl: function() {
+  billingUrl: function () {
     var id;
     id = this.get('model.type') === 'user' ? 'user' : this.get('model.login');
-    return this.config.billingEndpoint + "/subscriptions/" + id;
+    return this.config.billingEndpoint + '/subscriptions/' + id;
   }.property('model.name', 'model.login'),
 
-  subscribeButtonInfo: function() {
+  subscribeButtonInfo: function () {
     return {
       billingUrl: this.get('billingUrl'),
       subscribed: this.get('model.subscribed'),

--- a/app/controllers/branches.js
+++ b/app/controllers/branches.js
@@ -1,10 +1,10 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
-  defaultBranch: function() {
+  defaultBranch: function () {
     var output, repos;
     repos = this.get('model');
-    output = repos.filter(function(item) {
+    output = repos.filter(function (item) {
       return item.default_branch;
     });
     if (output.length) {
@@ -12,24 +12,24 @@ export default Ember.Controller.extend({
     }
   }.property('model'),
 
-  branchesExist: function() {
+  branchesExist: function () {
     var branches = this.get('model');
 
     return branches.length;
   }.property('model'),
 
-  activeBranches: function() {
+  activeBranches: function () {
     var repos;
     repos = this.get('model');
-    return repos = repos.filter(function(item) {
+    return repos = repos.filter(function (item) {
       return item.exists_on_github && !item.default_branch;
     }).sortBy('last_build.finished_at').reverse();
   }.property('model'),
 
-  inactiveBranches: function() {
+  inactiveBranches: function () {
     var repos;
     repos = this.get('model');
-    return repos = repos.filter(function(item) {
+    return repos = repos.filter(function (item) {
       return !item.exists_on_github && !item.default_branch;
     }).sortBy('last_build.finished_at').reverse();
   }.property('model')

--- a/app/controllers/branches.js
+++ b/app/controllers/branches.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
-  defaultBranch: function () {
+  defaultBranch: Ember.computed('model', function () {
     var output, repos;
     repos = this.get('model');
     output = repos.filter(function (item) {
@@ -10,27 +10,27 @@ export default Ember.Controller.extend({
     if (output.length) {
       return output[0];
     }
-  }.property('model'),
+  }),
 
-  branchesExist: function () {
+  branchesExist: Ember.computed('model', function () {
     var branches = this.get('model');
 
     return branches.length;
-  }.property('model'),
+  }),
 
-  activeBranches: function () {
+  activeBranches: Ember.computed('model', function () {
     var repos;
     repos = this.get('model');
     return repos = repos.filter(function (item) {
       return item.exists_on_github && !item.default_branch;
     }).sortBy('last_build.finished_at').reverse();
-  }.property('model'),
+  }),
 
-  inactiveBranches: function () {
+  inactiveBranches: Ember.computed('model', function () {
     var repos;
     repos = this.get('model');
     return repos = repos.filter(function (item) {
       return !item.exists_on_github && !item.default_branch;
     }).sortBy('last_build.finished_at').reverse();
-  }.property('model')
+  })
 });

--- a/app/controllers/build.js
+++ b/app/controllers/build.js
@@ -13,18 +13,18 @@ export default Ember.Controller.extend(GithubUrlProperties, {
   tab: alias('repoController.tab'),
   sendFaviconStateChanges: true,
 
-  jobsLoaded: function() {
+  jobsLoaded: function () {
     let jobs = this.get('build.jobs');
     if (jobs) {
       return jobs.isEvery('config');
     }
   }.property('build.jobs.@each.config'),
 
-  loading: function() {
+  loading: function () {
     return this.get('build.isLoading');
   }.property('build.isLoading'),
 
-  buildStateDidChange: function() {
+  buildStateDidChange: function () {
     if (this.get('sendFaviconStateChanges')) {
       return this.send('faviconStateDidChange', this.get('build.state'));
     }

--- a/app/controllers/build.js
+++ b/app/controllers/build.js
@@ -13,20 +13,20 @@ export default Ember.Controller.extend(GithubUrlProperties, {
   tab: alias('repoController.tab'),
   sendFaviconStateChanges: true,
 
-  jobsLoaded: function () {
+  jobsLoaded: Ember.computed('build.jobs.@each.config', function () {
     let jobs = this.get('build.jobs');
     if (jobs) {
       return jobs.isEvery('config');
     }
-  }.property('build.jobs.@each.config'),
+  }),
 
-  loading: function () {
+  loading: Ember.computed('build.isLoading', function () {
     return this.get('build.isLoading');
-  }.property('build.isLoading'),
+  }),
 
-  buildStateDidChange: function () {
+  buildStateDidChange: Ember.observer('build.state', function () {
     if (this.get('sendFaviconStateChanges')) {
       return this.send('faviconStateDidChange', this.get('build.state'));
     }
-  }.observes('build.state')
+  })
 });

--- a/app/controllers/builds.js
+++ b/app/controllers/builds.js
@@ -17,28 +17,28 @@ export default Ember.Controller.extend({
     id = this.get('repo.id');
     number = this.get('builds.lastObject.number');
     const tabName = this.get('tab');
-    const singularTab = tabName.substr(0, tabName.length-1);
-    type = this.get('tab') === "builds" ? 'push' : singularTab;
+    const singularTab = tabName.substr(0, tabName.length - 1);
+    type = this.get('tab') === 'builds' ? 'push' : singularTab;
     this.olderThanNumber(id, number, type);
   },
 
-  displayShowMoreButton: function() {
+  displayShowMoreButton: function () {
     return this.get('tab') !== 'branches' && parseInt(this.get('builds.lastObject.number')) > 1;
   }.property('tab', 'builds.lastObject.number'),
 
-  displayPullRequests: function() {
+  displayPullRequests: function () {
     return this.get('tab') === 'pull_requests';
   }.property('tab'),
 
-  displayBranches: function() {
+  displayBranches: function () {
     return this.get('tab') === 'branches';
   }.property('tab'),
 
-  displayCrons: function() {
+  displayCrons: function () {
     return this.get('tab') === 'crons';
   }.property('tab'),
 
-  noticeData: function() {
+  noticeData: function () {
     return {
       repo: this.get('repo'),
       auth: this.auth.token()

--- a/app/controllers/builds.js
+++ b/app/controllers/builds.js
@@ -22,28 +22,28 @@ export default Ember.Controller.extend({
     this.olderThanNumber(id, number, type);
   },
 
-  displayShowMoreButton: function () {
+  displayShowMoreButton: Ember.computed('tab', 'builds.lastObject.number', function () {
     return this.get('tab') !== 'branches' && parseInt(this.get('builds.lastObject.number')) > 1;
-  }.property('tab', 'builds.lastObject.number'),
+  }),
 
-  displayPullRequests: function () {
+  displayPullRequests: Ember.computed('tab', function () {
     return this.get('tab') === 'pull_requests';
-  }.property('tab'),
+  }),
 
-  displayBranches: function () {
+  displayBranches: Ember.computed('tab', function () {
     return this.get('tab') === 'branches';
-  }.property('tab'),
+  }),
 
-  displayCrons: function () {
+  displayCrons: Ember.computed('tab', function () {
     return this.get('tab') === 'crons';
-  }.property('tab'),
+  }),
 
-  noticeData: function () {
+  noticeData: Ember.computed('repo', function () {
     return {
       repo: this.get('repo'),
       auth: this.auth.token()
     };
-  }.property('repo'),
+  }),
 
   olderThanNumber(id, number, type) {
     var options;

--- a/app/controllers/caches.js
+++ b/app/controllers/caches.js
@@ -10,7 +10,7 @@ export default Ember.Controller.extend({
   repo: Ember.computed.alias('repoController.repo'),
   isDeleting: false,
 
-  cachesExist: function() {
+  cachesExist: function () {
     return this.get('model.pushes.length') || this.get('model.pullRequests.length');
   }.property('model.pushes.length', 'model.pullRequests.length'),
 

--- a/app/controllers/caches.js
+++ b/app/controllers/caches.js
@@ -10,9 +10,9 @@ export default Ember.Controller.extend({
   repo: Ember.computed.alias('repoController.repo'),
   isDeleting: false,
 
-  cachesExist: function () {
+  cachesExist: Ember.computed('model.pushes.length', 'model.pullRequests.length', function () {
     return this.get('model.pushes.length') || this.get('model.pullRequests.length');
-  }.property('model.pushes.length', 'model.pullRequests.length'),
+  }),
 
   deleteRepoCache: task(function * () {
     if (config.skipConfirmations || confirm('Are you sure?')) {

--- a/app/controllers/current-user.js
+++ b/app/controllers/current-user.js
@@ -7,12 +7,12 @@ export default Ember.Controller.extend({
 
   model: Ember.computed.alias('auth.currentUser'),
 
-  syncingDidChange: function () {
+  syncingDidChange: Ember.observer('isSyncing', 'auth.currentUser', function () {
     var user;
     if ((user = this.get('model')) && user.get('isSyncing') && !user.get('syncedAt')) {
       return Ember.run.scheduleOnce('routerTransitions', this, function () {
         return Ember.getOwner(this).lookup('router:main').send('renderFirstSync');
       });
     }
-  }.observes('isSyncing', 'auth.currentUser')
+  })
 });

--- a/app/controllers/current-user.js
+++ b/app/controllers/current-user.js
@@ -7,10 +7,10 @@ export default Ember.Controller.extend({
 
   model: Ember.computed.alias('auth.currentUser'),
 
-  syncingDidChange: function() {
+  syncingDidChange: function () {
     var user;
     if ((user = this.get('model')) && user.get('isSyncing') && !user.get('syncedAt')) {
-      return Ember.run.scheduleOnce('routerTransitions', this, function() {
+      return Ember.run.scheduleOnce('routerTransitions', this, function () {
         return Ember.getOwner(this).lookup('router:main').send('renderFirstSync');
       });
     }

--- a/app/controllers/dashboard/repositories.js
+++ b/app/controllers/dashboard/repositories.js
@@ -6,14 +6,14 @@ export default Ember.Controller.extend({
   filter: null,
   org: null,
 
-  filteredRepositories: function() {
+  filteredRepositories: function () {
     var filter, org, repos;
     filter = this.get('filter');
     repos = this.get('model');
     org = this.get('org');
-    repos = repos.filter(function(item) {
+    repos = repos.filter(function (item) {
       return item.get('currentBuild') !== null;
-    }).sort(function(a, b) {
+    }).sort(function (a, b) {
       if (a.currentBuild.finished_at === null) {
         return -1;
       }
@@ -32,14 +32,14 @@ export default Ember.Controller.extend({
     });
 
     if (org) {
-      repos = repos.filter(function(item) {
+      repos = repos.filter(function (item) {
         return item.get('owner.login') === org;
       });
     }
     if (Ember.isBlank(filter)) {
       return repos;
     } else {
-      return repos.filter(function(item) {
+      return repos.filter(function (item) {
         return item.slug.match(new RegExp(filter));
       });
     }
@@ -56,11 +56,11 @@ export default Ember.Controller.extend({
     return this.set('filter', value);
   },
 
-  selectedOrg: function() {
+  selectedOrg: function () {
     return this.get('orgs').findBy('login', this.get('org'));
   }.property('org', 'orgs.[]'),
 
-  orgs: function() {
+  orgs: function () {
     var apiEndpoint, orgs;
     orgs = Ember.ArrayProxy.create({
       content: [],
@@ -71,9 +71,9 @@ export default Ember.Controller.extend({
       headers: {
         Authorization: 'token ' + this.auth.token()
       }
-    }).then(function(response) {
+    }).then(function (response) {
       var array;
-      array = response.organizations.map(function(org) {
+      array = response.organizations.map(function (org) {
         return Ember.Object.create(org);
       });
       orgs.set('content', array);

--- a/app/controllers/dashboard/repositories.js
+++ b/app/controllers/dashboard/repositories.js
@@ -6,7 +6,7 @@ export default Ember.Controller.extend({
   filter: null,
   org: null,
 
-  filteredRepositories: function () {
+  filteredRepositories: Ember.computed('filter', 'model', 'org', function () {
     var filter, org, repos;
     filter = this.get('filter');
     repos = this.get('model');
@@ -43,7 +43,7 @@ export default Ember.Controller.extend({
         return item.slug.match(new RegExp(filter));
       });
     }
-  }.property('filter', 'model', 'org'),
+  }),
 
   updateFilter() {
     var value;
@@ -56,11 +56,11 @@ export default Ember.Controller.extend({
     return this.set('filter', value);
   },
 
-  selectedOrg: function () {
+  selectedOrg: Ember.computed('org', 'orgs.[]', function () {
     return this.get('orgs').findBy('login', this.get('org'));
-  }.property('org', 'orgs.[]'),
+  }),
 
-  orgs: function () {
+  orgs: Ember.computed(function () {
     var apiEndpoint, orgs;
     orgs = Ember.ArrayProxy.create({
       content: [],
@@ -80,7 +80,7 @@ export default Ember.Controller.extend({
       return orgs.set('isLoading', false);
     });
     return orgs;
-  }.property(),
+  }),
 
   actions: {
     updateFilter(value) {

--- a/app/controllers/error.js
+++ b/app/controllers/error.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 export default Ember.Controller.extend({
   layoutName: Ember.computed({
     get() {
-      if(this._layoutName) {
+      if (this._layoutName) {
         return 'layouts/' + this._layoutName;
       }
     },

--- a/app/controllers/home-pro.js
+++ b/app/controllers/home-pro.js
@@ -5,7 +5,7 @@ import config from 'travis/config/environment';
 export default Ember.Controller.extend({
   actions: {
     gaCta(location) {
-      if(config.gaCode) {
+      if (config.gaCode) {
         _gaq.push(['_trackPageview', '/virtual/signup?' + location]);
       }
       this.auth.signIn();

--- a/app/controllers/job.js
+++ b/app/controllers/job.js
@@ -11,11 +11,11 @@ export default Ember.Controller.extend({
   currentUser: alias('auth.currentUser'),
   tab: alias('repoController.tab'),
 
-  urlGithubCommit: function() {
+  urlGithubCommit: function () {
     return githubCommit(this.get('repo.slug'), this.get('commit.sha'));
   }.property('repo.slug', 'commit.sha'),
 
-  jobStateDidChange: function() {
+  jobStateDidChange: function () {
     return this.send('faviconStateDidChange', this.get('job.state'));
   }.observes('job.state')
 });

--- a/app/controllers/job.js
+++ b/app/controllers/job.js
@@ -11,11 +11,11 @@ export default Ember.Controller.extend({
   currentUser: alias('auth.currentUser'),
   tab: alias('repoController.tab'),
 
-  urlGithubCommit: function () {
+  urlGithubCommit: Ember.computed('repo.slug', 'commit.sha', function () {
     return githubCommit(this.get('repo.slug'), this.get('commit.sha'));
-  }.property('repo.slug', 'commit.sha'),
+  }),
 
-  jobStateDidChange: function () {
+  jobStateDidChange: Ember.observer('job.state', function () {
     return this.send('faviconStateDidChange', this.get('job.state'));
-  }.observes('job.state')
+  })
 });

--- a/app/controllers/loading.js
+++ b/app/controllers/loading.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 export default Ember.Controller.extend({
   layoutName: Ember.computed({
     get() {
-      if(this._layoutName) {
+      if (this._layoutName) {
         return 'layouts/' + this._layoutName;
       }
     },

--- a/app/controllers/owner.js
+++ b/app/controllers/owner.js
@@ -3,19 +3,19 @@ import Ember from 'ember';
 export default Ember.Controller.extend({
   isLoading: false,
 
-  githubProfile: function () {
+  githubProfile: Ember.computed('model', function () {
     return this.get('config').sourceEndpoint + '/' + (this.get('model.login'));
-  }.property('model'),
+  }),
 
-  avatarURL: function () {
+  avatarURL: Ember.computed('model', function () {
     if (this.get('model.avatar_url')) {
       return (this.get('model.avatar_url')) + '?s=125';
     } else {
       return 'https://secure.gravatar.com/avatar/?d=mm&s=125';
     }
-  }.property('model'),
+  }),
 
-  owner: function () {
+  owner: Ember.computed('model', function () {
     var data;
     data = this.get('model');
     return {
@@ -25,5 +25,5 @@ export default Ember.Controller.extend({
       avatarUrl: data.avatar_url,
       syncedAt: data.synced_at
     };
-  }.property('model')
+  })
 });

--- a/app/controllers/owner.js
+++ b/app/controllers/owner.js
@@ -3,19 +3,19 @@ import Ember from 'ember';
 export default Ember.Controller.extend({
   isLoading: false,
 
-  githubProfile: function() {
-    return this.get('config').sourceEndpoint + "/" + (this.get('model.login'));
+  githubProfile: function () {
+    return this.get('config').sourceEndpoint + '/' + (this.get('model.login'));
   }.property('model'),
 
-  avatarURL: function() {
+  avatarURL: function () {
     if (this.get('model.avatar_url')) {
-      return (this.get('model.avatar_url')) + "?s=125";
+      return (this.get('model.avatar_url')) + '?s=125';
     } else {
       return 'https://secure.gravatar.com/avatar/?d=mm&s=125';
     }
   }.property('model'),
 
-  owner: function() {
+  owner: function () {
     var data;
     data = this.get('model');
     return {

--- a/app/controllers/owner/repositories.js
+++ b/app/controllers/owner/repositories.js
@@ -2,12 +2,12 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
   isLoading: false,
-  repos: function() {
+  repos: function () {
     var data, repos;
     data = this.get('model');
     repos = [];
     if (data.repositories) {
-      repos = data.repositories.filter(function(item) {
+      repos = data.repositories.filter(function (item) {
         if (item.active) {
           return item;
         }

--- a/app/controllers/owner/repositories.js
+++ b/app/controllers/owner/repositories.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
   isLoading: false,
-  repos: function () {
+  repos: Ember.computed('model', function () {
     var data, repos;
     data = this.get('model');
     repos = [];
@@ -14,5 +14,5 @@ export default Ember.Controller.extend({
       }).sortBy('currentBuild.finished_at').reverse();
     }
     return repos;
-  }.property('model')
+  })
 });

--- a/app/controllers/owner/running.js
+++ b/app/controllers/owner/running.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
   isLoading: false,
-  running: function () {
+  running: Ember.computed('model', function () {
     var data, repos;
     data = this.get('model');
     repos = data.repositories.filter(function (item) {
@@ -13,5 +13,5 @@ export default Ember.Controller.extend({
       }
     });
     return repos;
-  }.property('model')
+  })
 });

--- a/app/controllers/owner/running.js
+++ b/app/controllers/owner/running.js
@@ -2,10 +2,10 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
   isLoading: false,
-  running: function() {
+  running: function () {
     var data, repos;
     data = this.get('model');
-    repos = data.repositories.filter(function(item) {
+    repos = data.repositories.filter(function (item) {
       if (item.currentBuild !== null) {
         if (item.currentBuild.state === 'started') {
           return item;

--- a/app/controllers/plans.js
+++ b/app/controllers/plans.js
@@ -5,7 +5,7 @@ import config from 'travis/config/environment';
 export default Ember.Controller.extend({
   actions: {
     gaCta(location) {
-      if(config.gaCode) {
+      if (config.gaCode) {
         _gaq.push(['_trackPageview', '/virtual/signup?' + location]);
       }
       this.auth.signIn();

--- a/app/controllers/profile.js
+++ b/app/controllers/profile.js
@@ -13,7 +13,7 @@ export default Ember.Controller.extend({
   account: alias('accountController.model'),
 
   activate(action) {
-    return this[("view_" + action).camelize()]();
+    return this[('view_' + action).camelize()]();
   },
 
   viewHooks() {

--- a/app/controllers/repo.js
+++ b/app/controllers/repo.js
@@ -27,17 +27,17 @@ export default Ember.Controller.extend({
     this.set('repo', null);
   },
 
-  isEmpty: function () {
+  isEmpty: Ember.computed('repos.isLoaded', 'repos.length', function () {
     return this.get('repos.isLoaded') && this.get('repos.length') === 0;
-  }.property('repos.isLoaded', 'repos.length'),
+  }),
 
-  statusImageUrl: function () {
+  statusImageUrl: Ember.computed('repo.slug', function () {
     return statusImage(this.get('repo.slug'));
-  }.property('repo.slug'),
+  }),
 
-  showCurrentBuild: function () {
+  showCurrentBuild: Ember.computed('repo.currentBuild.id', 'repo.active', function () {
     return this.get('repo.currentBuild.id') && this.get('repo.active');
-  }.property('repo.currentBuild.id', 'repo.active'),
+  }),
 
   actions: {
     statusImages() {
@@ -46,13 +46,13 @@ export default Ember.Controller.extend({
     }
   },
 
-  slug: function () {
+  slug: Ember.computed('repo.slug', function () {
     return this.get('repo.slug');
-  }.property('repo.slug'),
+  }),
 
-  isLoading: function () {
+  isLoading: Ember.computed('repo.isLoading', function () {
     return this.get('repo.isLoading');
-  }.property('repo.isLoading'),
+  }),
 
   init() {
     this._super(...arguments);
@@ -155,7 +155,7 @@ export default Ember.Controller.extend({
     return this.set('tab', tab);
   },
 
-  urlGithub: function () {
+  urlGithub: Ember.computed('repo.slug', function () {
     return githubRepo(this.get('repo.slug'));
-  }.property('repo.slug')
+  })
 });

--- a/app/controllers/repo.js
+++ b/app/controllers/repo.js
@@ -27,15 +27,15 @@ export default Ember.Controller.extend({
     this.set('repo', null);
   },
 
-  isEmpty: function() {
+  isEmpty: function () {
     return this.get('repos.isLoaded') && this.get('repos.length') === 0;
   }.property('repos.isLoaded', 'repos.length'),
 
-  statusImageUrl: function() {
+  statusImageUrl: function () {
     return statusImage(this.get('repo.slug'));
   }.property('repo.slug'),
 
-  showCurrentBuild: function() {
+  showCurrentBuild: function () {
     return this.get('repo.currentBuild.id') && this.get('repo.active');
   }.property('repo.currentBuild.id', 'repo.active'),
 
@@ -46,11 +46,11 @@ export default Ember.Controller.extend({
     }
   },
 
-  slug: function() {
+  slug: function () {
     return this.get('repo.slug');
   }.property('repo.slug'),
 
-  isLoading: function() {
+  isLoading: function () {
     return this.get('repo.isLoading');
   }.property('repo.isLoading'),
 
@@ -75,7 +75,7 @@ export default Ember.Controller.extend({
 
   activate(action) {
     this.stopObservingLastBuild();
-    return this[("view_" + action).camelize()]();
+    return this[('view_' + action).camelize()]();
   },
 
   viewIndex() {
@@ -134,7 +134,7 @@ export default Ember.Controller.extend({
 
   _currentBuildDidChange() {
     let currentBuild = this.get('repo.currentBuild');
-    if(currentBuild) {
+    if (currentBuild) {
       eventually(currentBuild, (build) => {
         this.set('build', build);
       });
@@ -155,7 +155,7 @@ export default Ember.Controller.extend({
     return this.set('tab', tab);
   },
 
-  urlGithub: function() {
+  urlGithub: function () {
     return githubRepo(this.get('repo.slug'));
   }.property('repo.slug')
 });

--- a/app/controllers/repos.js
+++ b/app/controllers/repos.js
@@ -5,7 +5,7 @@ import Repo from 'travis/models/repo';
 const { service, controller } = Ember.inject;
 const { alias } = Ember.computed;
 
-var sortCallback = function(repo1, repo2) {
+var sortCallback = function (repo1, repo2) {
   // this function could be made simpler, but I think it's clearer this way
   // what're we really trying to achieve
 
@@ -14,32 +14,32 @@ var sortCallback = function(repo1, repo2) {
   var finishedAt1 = repo1.get('currentBuild.finishedAt');
   var finishedAt2 = repo2.get('currentBuild.finishedAt');
 
-  if(!buildId1 && !buildId2) {
+  if (!buildId1 && !buildId2) {
     // if both repos lack builds, put newer repo first
     return repo1.get('id') > repo2.get('id') ? -1 : 1;
-  } else if(buildId1 && !buildId2) {
+  } else if (buildId1 && !buildId2) {
     // if only repo1 has a build, it goes first
     return -1;
-  } else if(buildId2 && !buildId1) {
+  } else if (buildId2 && !buildId1) {
     // if only repo2 has a build, it goes first
     return 1;
   }
 
 
-  if(finishedAt1) {
+  if (finishedAt1) {
     finishedAt1 = new Date(finishedAt1);
   }
-  if(finishedAt2) {
+  if (finishedAt2) {
     finishedAt2 = new Date(finishedAt2);
   }
 
-  if(finishedAt1 && finishedAt2) {
+  if (finishedAt1 && finishedAt2) {
     // if both builds finished, put newer first
     return finishedAt1.getTime() > finishedAt2.getTime() ? -1 : 1;
-  } else if(finishedAt1 && !finishedAt2) {
+  } else if (finishedAt1 && !finishedAt2) {
     // if repo1 finished, but repo2 didn't, put repo2 first
     return 1;
-  } else if(finishedAt2 && !finishedAt1) {
+  } else if (finishedAt2 && !finishedAt1) {
     // if repo2 finisher, but repo1 didn't, put repo1 first
     return -1;
   } else {
@@ -54,13 +54,13 @@ var Controller = Ember.Controller.extend({
   updateTimesService: service('updateTimes'),
 
   actions: {
-    activate: function(name) {
+    activate: function (name) {
       return this.activate(name);
     },
-    showRunningJobs: function() {
+    showRunningJobs: function () {
       return this.activate('running');
     },
-    showMyRepositories: function() {
+    showMyRepositories: function () {
       if (this.get('tab') === 'running') {
         return this.activate('owned');
       } else {
@@ -69,12 +69,12 @@ var Controller = Ember.Controller.extend({
     }
   },
 
-  tabOrIsLoadedDidChange: function() {
+  tabOrIsLoadedDidChange: function () {
     return this.possiblyRedirectToGettingStartedPage();
   }.observes('isLoaded', 'tab', 'repos.length'),
 
   possiblyRedirectToGettingStartedPage() {
-    return Ember.run.scheduleOnce('routerTransitions', this, function() {
+    return Ember.run.scheduleOnce('routerTransitions', this, function () {
       if (this.get('tab') === 'owned' && this.get('isLoaded') && this.get('repos.length') === 0) {
         return Ember.getOwner(this).lookup('router:main').send('redirectToGettingStarted');
       }
@@ -85,13 +85,13 @@ var Controller = Ember.Controller.extend({
   repoController: controller('repo'),
   currentUser: alias('auth.currentUser'),
 
-  selectedRepo: function() {
+  selectedRepo: function () {
     return this.get('repoController.repo.content') || this.get('repoController.repo');
   }.property('repoController.repo', 'repoController.repo.content'),
 
   startedJobsCount: Ember.computed.alias('runningJobs.length'),
 
-  allJobsCount: function() {
+  allJobsCount: function () {
     return this.get('startedJobsCount') + this.get('queuedJobs.length');
   }.property('startedJobsCount', 'queuedJobs.length'),
 
@@ -102,37 +102,37 @@ var Controller = Ember.Controller.extend({
     }
   },
 
-  runningJobs: function() {
-    if(!this.get('config.pro')) { return []; }
+  runningJobs: function () {
+    if (!this.get('config.pro')) { return []; }
     var result;
 
-    result = this.store.filter('job', {}, function(job) {
+    result = this.store.filter('job', {}, function (job) {
       return ['queued', 'started', 'received'].indexOf(job.get('state')) !== -1;
     });
     result.set('isLoaded', false);
-    result.then(function() {
+    result.then(function () {
       return result.set('isLoaded', true);
     });
 
     return result;
   }.property('config.pro'),
 
-  queuedJobs: function() {
-    if(!this.get('config.pro')) { return []; }
+  queuedJobs: function () {
+    if (!this.get('config.pro')) { return []; }
 
     var result;
-    result = this.get('store').filter('job', function(job) {
+    result = this.get('store').filter('job', function (job) {
       return ['created'].indexOf(job.get('state')) !== -1;
     });
     result.set('isLoaded', false);
-    result.then(function() {
+    result.then(function () {
       result.set('isLoaded', true);
     });
 
     return result;
   }.property('config.pro'),
 
-  recentRepos: function() {
+  recentRepos: function () {
     return [];
   }.property(),
 
@@ -150,7 +150,7 @@ var Controller = Ember.Controller.extend({
     this.set('tab', tab);
     // find the data based on tab
     // tab == 'owned' => viewOwned invoked
-    return this[("view_" + tab).camelize()](params);
+    return this[('view_' + tab).camelize()](params);
   },
 
   reset() {
@@ -178,7 +178,7 @@ var Controller = Ember.Controller.extend({
 
         let onError = () => this.set('fetchingOwnedRepos', false);
 
-        user.get('_rawPermissions').then( (data) => {
+        user.get('_rawPermissions').then((data) => {
           Repo.accessibleBy(this.store, data.pull).then(callback, onError);
         }, onError);
       }
@@ -190,13 +190,13 @@ var Controller = Ember.Controller.extend({
   viewSearch(phrase) {
     this.set('search', phrase);
     this.set('isLoaded', false);
-    Repo.search(this.store, this.get('ajax'), phrase).then( (reposRecordArray) => {
+    Repo.search(this.store, this.get('ajax'), phrase).then((reposRecordArray) => {
       this.set('isLoaded', true);
       this.set('_repos', reposRecordArray);
     });
   },
 
-  searchObserver: function() {
+  searchObserver: function () {
     var search;
     search = this.get('search');
     if (search) {
@@ -208,12 +208,12 @@ var Controller = Ember.Controller.extend({
     if (this.searchLater) {
       Ember.run.cancel(this.searchLater);
     }
-    this.searchLater = Ember.run.later(this, (function() {
+    this.searchLater = Ember.run.later(this, (function () {
       this.transitionToRoute('main.search', phrase.replace(/\//g, '%2F'));
     }), 500);
   },
 
-  noReposMessage: function() {
+  noReposMessage: function () {
     var tab;
     tab = this.get('tab');
     if (tab === 'owned') {
@@ -225,18 +225,18 @@ var Controller = Ember.Controller.extend({
     }
   }.property('tab'),
 
-  showRunningJobs: function() {
+  showRunningJobs: function () {
     return this.get('tab') === 'running';
   }.property('tab'),
 
-  repos: function() {
+  repos: function () {
     var repos = this.get('_repos');
 
-    if(repos && repos.toArray) {
+    if (repos && repos.toArray) {
       repos = repos.toArray();
     }
 
-    if(repos && repos.sort) {
+    if (repos && repos.sort) {
       let sorted = repos.sort(sortCallback);
       return sorted;
     } else {

--- a/app/controllers/requests.js
+++ b/app/controllers/requests.js
@@ -5,9 +5,9 @@ const { controller } = Ember.inject;
 export default Ember.Controller.extend({
   repoController: controller('repo'),
 
-  lintUrl: function() {
+  lintUrl: function () {
     var slug;
     slug = this.get('repoController.repo.slug');
-    return "https://lint.travis-ci.org/" + slug;
+    return 'https://lint.travis-ci.org/' + slug;
   }.property('repoController.repo.slug')
 });

--- a/app/controllers/requests.js
+++ b/app/controllers/requests.js
@@ -5,9 +5,9 @@ const { controller } = Ember.inject;
 export default Ember.Controller.extend({
   repoController: controller('repo'),
 
-  lintUrl: function () {
+  lintUrl: Ember.computed('repoController.repo.slug', function () {
     var slug;
     slug = this.get('repoController.repo.slug');
     return 'https://lint.travis-ci.org/' + slug;
-  }.property('repoController.repo.slug')
+  })
 });

--- a/app/controllers/settings.js
+++ b/app/controllers/settings.js
@@ -3,20 +3,20 @@ import Ember from 'ember';
 export default Ember.Controller.extend({
   envVars: Ember.computed.filterBy('model.envVars', 'isNew', false),
 
-  branchesWithoutCron: Ember.computed('model.cronJobs.jobs.@each', function() {
+  branchesWithoutCron: Ember.computed('model.cronJobs.jobs.@each', function () {
     var cronJobs = this.get('model.cronJobs.jobs');
-    var branches = this.get('model.branches').filter(function(branch) {
+    var branches = this.get('model.branches').filter(function (branch) {
       return branch.get('exists_on_github');
     });
-    return branches.filter(function(branch) {
+    return branches.filter(function (branch) {
       return ! cronJobs.any(cron => branch.get('name') === cron.get('branch.name'));
     });
   }),
 
-  sortedBranchesWithoutCron: Ember.computed.sort('branchesWithoutCron', function(a, b) {
-    if(a.get('defaultBranch')) {
+  sortedBranchesWithoutCron: Ember.computed.sort('branchesWithoutCron', function (a, b) {
+    if (a.get('defaultBranch')) {
       return -1;
-    } else if(b.get('defaultBranch')) {
+    } else if (b.get('defaultBranch')) {
       return 1;
     } else {
       return a.get('name') > b.get('name');

--- a/app/controllers/top.js
+++ b/app/controllers/top.js
@@ -102,7 +102,8 @@ export default Ember.Controller.extend({
       seenBroadcasts.push(id);
       this.get('storage').setItem('travis.seen_broadcasts', JSON.stringify(seenBroadcasts));
       this.get('broadcasts.content').removeObject(broadcast);
-      this.set('broadcasts.lastBroadcastStatus', this.defineTowerColor(this.get('broadcasts.content')));
+      let status = this.defineTowerColor(this.get('broadcasts.content'));
+      this.set('broadcasts.lastBroadcastStatus', status);
       return false;
     }
   },

--- a/app/controllers/top.js
+++ b/app/controllers/top.js
@@ -11,7 +11,7 @@ export default Ember.Controller.extend({
 
   user: alias('auth.currentUser'),
 
-  userName: function() {
+  userName: function () {
     return this.get('user.name') || this.get('user.login');
   }.property('user.login', 'user.name'),
 
@@ -32,7 +32,7 @@ export default Ember.Controller.extend({
     }
   },
 
-  broadcasts: function() {
+  broadcasts: function () {
     var apiEndpoint, broadcasts, options, seenBroadcasts;
     if (this.get('auth.signedIn')) {
       broadcasts = Ember.ArrayProxy.create({
@@ -44,7 +44,7 @@ export default Ember.Controller.extend({
       options = {};
       options.type = 'GET';
       options.headers = {
-        Authorization: "token " + (this.auth.token())
+        Authorization: 'token ' + (this.auth.token())
       };
       seenBroadcasts = this.get('storage').getItem('travis.seen_broadcasts');
       if (seenBroadcasts) {
@@ -52,16 +52,16 @@ export default Ember.Controller.extend({
       } else {
         seenBroadcasts = [];
       }
-      Ember.$.ajax(apiEndpoint + "/v3/broadcasts", options).then((response) => {
+      Ember.$.ajax(apiEndpoint + '/v3/broadcasts', options).then((response) => {
         var receivedBroadcasts;
         if (response.broadcasts.length) {
-          receivedBroadcasts = response.broadcasts.filter(function(broadcast) {
+          receivedBroadcasts = response.broadcasts.filter(function (broadcast) {
             if (!broadcast.expired) {
               if (seenBroadcasts.indexOf(broadcast.id.toString()) === -1) {
                 return broadcast;
               }
             }
-          }).map(function(broadcast) {
+          }).map(function (broadcast) {
             return Ember.Object.create(broadcast);
           }).reverse();
         }
@@ -106,11 +106,11 @@ export default Ember.Controller.extend({
       return false;
     }
   },
-  showCta: function() {
+  showCta: function () {
     return !this.get('auth.signedIn') && !this.get('config.pro') && !this.get('landingPage');
   }.property('auth.signedIn', 'landingPage'),
 
-  classProfile: function() {
+  classProfile: function () {
     var classes = ['profile menu'];
 
     if (this.get('tab') === 'profile') {

--- a/app/controllers/top.js
+++ b/app/controllers/top.js
@@ -11,9 +11,9 @@ export default Ember.Controller.extend({
 
   user: alias('auth.currentUser'),
 
-  userName: function () {
+  userName: Ember.computed('user.login', 'user.name', function () {
     return this.get('user.name') || this.get('user.login');
-  }.property('user.login', 'user.name'),
+  }),
 
   isDashboard: false,
 
@@ -32,7 +32,7 @@ export default Ember.Controller.extend({
     }
   },
 
-  broadcasts: function () {
+  broadcasts: Ember.computed('broadcasts', function () {
     var apiEndpoint, broadcasts, options, seenBroadcasts;
     if (this.get('auth.signedIn')) {
       broadcasts = Ember.ArrayProxy.create({
@@ -71,7 +71,7 @@ export default Ember.Controller.extend({
       });
       return broadcasts;
     }
-  }.property('broadcasts'),
+  }),
 
   actions: {
 
@@ -106,11 +106,11 @@ export default Ember.Controller.extend({
       return false;
     }
   },
-  showCta: function () {
+  showCta: Ember.computed('auth.signedIn', 'landingPage', function () {
     return !this.get('auth.signedIn') && !this.get('config.pro') && !this.get('landingPage');
-  }.property('auth.signedIn', 'landingPage'),
+  }),
 
-  classProfile: function () {
+  classProfile: Ember.computed('tab', 'auth.state', function () {
     var classes = ['profile menu'];
 
     if (this.get('tab') === 'profile') {
@@ -120,5 +120,5 @@ export default Ember.Controller.extend({
     classes.push(this.get('controller.auth.state') || 'signed-out');
 
     return classes.join(' ');
-  }.property('tab', 'auth.state')
+  })
 });

--- a/app/helpers/filter-input.js
+++ b/app/helpers/filter-input.js
@@ -10,7 +10,7 @@ var TextField = Ember.TextField.extend({
   }
 });
 
-export default function(params, hash, options, env) {
+export default function (params, hash, options, env) {
   var onEvent;
   Ember.assert('You can only pass attributes to the `input` helper, not arguments', params.length);
   onEvent = hash.on;

--- a/app/helpers/format-commit.js
+++ b/app/helpers/format-commit.js
@@ -1,7 +1,7 @@
 import { safe, formatCommit as formatCommitHelper } from 'travis/utils/helpers';
 import Ember from 'ember';
 
-export default Ember.Helper.helper(function(params) {
+export default Ember.Helper.helper(function (params) {
   var commit;
   commit = params[0];
   if (commit) {

--- a/app/helpers/format-config.js
+++ b/app/helpers/format-config.js
@@ -1,5 +1,5 @@
 import { safe, formatConfig as formatConfigHelper } from 'travis/utils/helpers';
 
-export default function(config) {
+export default function (config) {
   return safe(formatConfigHelper(config));
 }

--- a/app/helpers/format-duration.js
+++ b/app/helpers/format-duration.js
@@ -1,6 +1,6 @@
 import { timeInWords, safe } from 'travis/utils/helpers';
-import Ember from "ember";
+import Ember from 'ember';
 
-export default Ember.Helper.helper(function(params) {
+export default Ember.Helper.helper(function (params) {
   return safe(timeInWords(params[0]));
 });

--- a/app/helpers/format-message.js
+++ b/app/helpers/format-message.js
@@ -1,6 +1,6 @@
 import { formatMessage as _formatMessage, safe } from 'travis/utils/helpers';
-import Ember from "ember";
+import Ember from 'ember';
 
-export default Ember.Helper.helper(function(params, hash) {
+export default Ember.Helper.helper(function (params, hash) {
   return safe(_formatMessage(params[0], hash));
 });

--- a/app/helpers/format-sha.js
+++ b/app/helpers/format-sha.js
@@ -1,6 +1,6 @@
 import { formatSha as _formatSha, safe } from 'travis/utils/helpers';
-import Ember from "ember";
+import Ember from 'ember';
 
-export default Ember.Helper.helper(function(params) {
+export default Ember.Helper.helper(function (params) {
   return safe(_formatSha(params[0]));
 });

--- a/app/helpers/format-time.js
+++ b/app/helpers/format-time.js
@@ -1,6 +1,6 @@
 import { timeAgoInWords, safe } from 'travis/utils/helpers';
-import Ember from "ember";
+import Ember from 'ember';
 
-export default Ember.Helper.helper(function(params) {
+export default Ember.Helper.helper(function (params) {
   return safe(timeAgoInWords(params[0]) || '-');
 });

--- a/app/helpers/github-commit-link.js
+++ b/app/helpers/github-commit-link.js
@@ -2,7 +2,7 @@ import { formatCommit, safe } from 'travis/utils/helpers';
 import { githubCommit as githubCommitUrl } from 'travis/utils/urls';
 import Ember from 'ember';
 
-export default Ember.Helper.helper(function(params) {
+export default Ember.Helper.helper(function (params) {
   var commitSha, sha, slug, url;
 
   slug = params[0];

--- a/app/helpers/humanize-state.js
+++ b/app/helpers/humanize-state.js
@@ -1,6 +1,6 @@
-import Ember from "ember";
+import Ember from 'ember';
 
-export default Ember.Helper.helper(function(params) {
+export default Ember.Helper.helper(function (params) {
   var state = params[0];
   if (state === 'received') {
     return 'booting';

--- a/app/helpers/landing-page-last-build-time.js
+++ b/app/helpers/landing-page-last-build-time.js
@@ -1,6 +1,6 @@
 import { timeAgoInWords, safe } from 'travis/utils/helpers';
-import Ember from "ember";
+import Ember from 'ember';
 
-export default Ember.Helper.helper(function(params) {
+export default Ember.Helper.helper(function (params) {
   return safe(timeAgoInWords(params[0]) || 'currently running');
 });

--- a/app/helpers/pretty-date.js
+++ b/app/helpers/pretty-date.js
@@ -1,8 +1,8 @@
 /* global moment */
 import { safe } from 'travis/utils/helpers';
-import Ember from "ember";
+import Ember from 'ember';
 
-export default Ember.Helper.helper(function(params) {
+export default Ember.Helper.helper(function (params) {
   let date = new Date(params[0]);
   return safe(moment(date).format('MMMM D, YYYY H:mm:ss') || '-');
 });

--- a/app/helpers/short-compare-shas.js
+++ b/app/helpers/short-compare-shas.js
@@ -1,13 +1,13 @@
 import { pathFrom } from 'travis/utils/helpers';
-import Ember from "ember";
+import Ember from 'ember';
 
-export default Ember.Helper.helper(function(params) {
+export default Ember.Helper.helper(function (params) {
   var path, shas, url;
   url = params[0];
   path = pathFrom(url);
   if (path.indexOf('...') >= 0) {
     shas = path.split('...');
-    return shas[0].slice(0, 7) + ".." + shas[1].slice(0, 7);
+    return shas[0].slice(0, 7) + '..' + shas[1].slice(0, 7);
   } else {
     return path;
   }

--- a/app/helpers/travis-mb.js
+++ b/app/helpers/travis-mb.js
@@ -1,6 +1,6 @@
-import Ember from "ember";
+import Ember from 'ember';
 
-export default Ember.Helper.helper(function(size) {
+export default Ember.Helper.helper(function (size) {
   if (size) {
     return (size / 1024 / 1024).toFixed(2);
   }

--- a/app/initializers/app.js
+++ b/app/initializers/app.js
@@ -1,6 +1,6 @@
 var Initializer, initialize;
 
-initialize = function(app) {
+initialize = function (app) {
   if (typeof window !== 'undefined') {
     return window.Travis = app;
   }
@@ -11,6 +11,6 @@ Initializer = {
   initialize: initialize
 };
 
-export {initialize};
+export { initialize };
 
 export default Initializer;

--- a/app/initializers/auth.js
+++ b/app/initializers/auth.js
@@ -1,6 +1,6 @@
 var AuthInitializer, initialize;
 
-initialize = function(app) {
+initialize = function (app) {
   app.inject('route', 'auth', 'service:auth');
   app.inject('controller', 'auth', 'service:auth');
   app.inject('application', 'auth', 'service:auth');
@@ -14,6 +14,6 @@ AuthInitializer = {
   initialize: initialize
 };
 
-export {initialize};
+export { initialize };
 
 export default AuthInitializer;

--- a/app/initializers/config.js
+++ b/app/initializers/config.js
@@ -1,7 +1,7 @@
 import config from 'travis/config/environment';
 var ConfigInitializer, initialize;
 
-initialize = function(application) {
+initialize = function (application) {
   application.register('config:main', config, {
     instantiate: false
   });
@@ -15,6 +15,6 @@ ConfigInitializer = {
   initialize: initialize
 };
 
-export {initialize};
+export { initialize };
 
 export default ConfigInitializer;

--- a/app/initializers/configure-inflector.js
+++ b/app/initializers/configure-inflector.js
@@ -6,7 +6,7 @@ import config from 'travis/config/environment';
 const initializer = {
   name: 'inflector',
 
-  initialize: function() {
+  initialize: function () {
     const inflector = Ember.Inflector.inflector;
     inflector.uncountable('permissions');
     inflector.irregular('cache', 'caches');

--- a/app/initializers/google-analytics.js
+++ b/app/initializers/google-analytics.js
@@ -2,7 +2,7 @@
 import config from 'travis/config/environment';
 var GAInitializer, initialize;
 
-initialize = function(/*application*/) {
+initialize = function (/* application*/) {
   var ga, s;
   if (config.gaCode) {
     window._gaq = [];
@@ -21,6 +21,6 @@ GAInitializer = {
   initialize: initialize
 };
 
-export {initialize};
+export { initialize };
 
 export default GAInitializer;

--- a/app/initializers/location.js
+++ b/app/initializers/location.js
@@ -1,7 +1,7 @@
 import TravisLocation from 'travis/utils/location';
 var Initializer, initialize;
 
-initialize = function(application) {
+initialize = function (application) {
   return application.register('location:travis', TravisLocation);
 };
 

--- a/app/initializers/pusher.js
+++ b/app/initializers/pusher.js
@@ -1,6 +1,6 @@
 var PusherInitializer, initialize;
 
-initialize = function(/*application*/) {
+initialize = function (/* application*/) {
   return null;
 };
 
@@ -10,6 +10,6 @@ PusherInitializer = {
   initialize: initialize
 };
 
-export {initialize};
+export { initialize };
 
 export default PusherInitializer;

--- a/app/initializers/services.js
+++ b/app/initializers/services.js
@@ -3,7 +3,7 @@ import Tailing from 'travis/utils/tailing';
 import ToTop from 'travis/utils/to-top';
 var Initializer, initialize;
 
-initialize = function(application) {
+initialize = function (application) {
   application.tailing = new Tailing(Ember.$(window), '#tail', '#log');
   return application.toTop = new ToTop(Ember.$(window), '.to-top', '#log-container');
 };
@@ -13,6 +13,6 @@ Initializer = {
   initialize: initialize
 };
 
-export {initialize};
+export { initialize };
 
 export default Initializer;

--- a/app/initializers/stylesheets-manager.js
+++ b/app/initializers/stylesheets-manager.js
@@ -3,15 +3,15 @@ import Ember from 'ember';
 var StylesheetsManagerInitializer, initialize, stylesheetsManager;
 
 stylesheetsManager = Ember.Object.create({
-  enable: function(id) {
-    return Ember.$("#" + id).removeAttr('disabled');
+  enable: function (id) {
+    return Ember.$('#' + id).removeAttr('disabled');
   },
-  disable: function(id) {
-    return Ember.$("#" + id).attr('disabled', 'disabled');
+  disable: function (id) {
+    return Ember.$('#' + id).attr('disabled', 'disabled');
   }
 });
 
-initialize = function(application) {
+initialize = function (application) {
   application.register('stylesheetsManager:main', stylesheetsManager, {
     instantiate: false
   });
@@ -23,6 +23,6 @@ StylesheetsManagerInitializer = {
   initialize: initialize
 };
 
-export {initialize};
+export { initialize };
 
 export default StylesheetsManagerInitializer;

--- a/app/instance-initializers/pusher.js
+++ b/app/instance-initializers/pusher.js
@@ -2,7 +2,7 @@ import config from 'travis/config/environment';
 import TravisPusher from 'travis/utils/pusher';
 var PusherInitializer, initialize;
 
-initialize = function(applicationInstance) {
+initialize = function (applicationInstance) {
   const app = applicationInstance.application;
   if (config.pusher.key) {
     app.pusher = new TravisPusher(config.pusher, applicationInstance.lookup('service:ajax'));
@@ -21,6 +21,6 @@ PusherInitializer = {
   initialize: initialize
 };
 
-export {initialize};
+export { initialize };
 
 export default PusherInitializer;

--- a/app/instance-initializers/raven-release.js
+++ b/app/instance-initializers/raven-release.js
@@ -4,7 +4,7 @@ export function initialize(appInstance) {
   let sha;
   // this is Heroku-specific, will not work in other environments
   if (config.environment === 'production') {
-    sha = config.release.slice(0,7);
+    sha = config.release.slice(0, 7);
   } else {
     sha = appInstance.application.version.slice(6, -1);
   }

--- a/app/mixins/duration-calculations.js
+++ b/app/mixins/duration-calculations.js
@@ -2,16 +2,24 @@ import Ember from 'ember';
 import { durationFrom } from 'travis/utils/helpers';
 
 export default Ember.Mixin.create({
-  duration: function () {
-    let duration = this.get('_duration');
-    if (this.get('notStarted')) {
-      return null;
-    } else if (duration) {
-      return duration;
-    } else {
-      return durationFrom(this.get('startedAt'), this.get('finishedAt'));
+  duration: Ember.computed(
+    '_duration',
+    'finishedAt',
+    'startedAt',
+    'notStarted',
+    '_finishedAt',
+    '_startedAt',
+    function () {
+      let duration = this.get('_duration');
+      if (this.get('notStarted')) {
+        return null;
+      } else if (duration) {
+        return duration;
+      } else {
+        return durationFrom(this.get('startedAt'), this.get('finishedAt'));
+      }
     }
-  }.property('_duration', 'finishedAt', 'startedAt', 'notStarted', '_finishedAt', '_startedAt'),
+  ),
 
   updateTimes() {
     this.notifyPropertyChange('duration');

--- a/app/mixins/duration-calculations.js
+++ b/app/mixins/duration-calculations.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { durationFrom } from 'travis/utils/helpers';
 
 export default Ember.Mixin.create({
-  duration: function() {
+  duration: function () {
     let duration = this.get('_duration');
     if (this.get('notStarted')) {
       return null;

--- a/app/mixins/github-url-properties.js
+++ b/app/mixins/github-url-properties.js
@@ -2,11 +2,11 @@ import { githubCommit, githubPullRequest } from 'travis/utils/urls';
 import Ember from 'ember';
 
 export default Ember.Mixin.create({
-  urlGithubCommit: function() {
+  urlGithubCommit: function () {
     return githubCommit(this.get('repo.slug'), this.get('commit.sha'));
   }.property('repo.slug', 'commit.sha'),
 
-  urlGithubPullRequest: function() {
+  urlGithubPullRequest: function () {
     return githubPullRequest(this.get('repo.slug'), this.get('build.pullRequestNumber'));
   }.property('repo.slug', 'build.pullRequestNumber')
 });

--- a/app/mixins/github-url-properties.js
+++ b/app/mixins/github-url-properties.js
@@ -2,11 +2,11 @@ import { githubCommit, githubPullRequest } from 'travis/utils/urls';
 import Ember from 'ember';
 
 export default Ember.Mixin.create({
-  urlGithubCommit: function () {
+  urlGithubCommit: Ember.computed('repo.slug', 'commit.sha', function () {
     return githubCommit(this.get('repo.slug'), this.get('commit.sha'));
-  }.property('repo.slug', 'commit.sha'),
+  }),
 
-  urlGithubPullRequest: function () {
+  urlGithubPullRequest: Ember.computed('repo.slug', 'build.pullRequestNumber', function () {
     return githubPullRequest(this.get('repo.slug'), this.get('build.pullRequestNumber'));
-  }.property('repo.slug', 'build.pullRequestNumber')
+  })
 });

--- a/app/mixins/polling.js
+++ b/app/mixins/polling.js
@@ -27,9 +27,9 @@ export default Ember.Mixin.create({
 
   pollModel(property) {
     var model = this.get(property),
-        currentPollModels = this.get('currentPollModels');
+      currentPollModels = this.get('currentPollModels');
 
-    if(currentPollModels[property]) {
+    if (currentPollModels[property]) {
       this.get('polling').stopPolling(currentPollModels[property]);
     }
     currentPollModels[property] = model;
@@ -40,7 +40,7 @@ export default Ember.Mixin.create({
 
     if (model) {
       if (model.then) {
-        return model.then(function(resolved) {
+        return model.then(function (resolved) {
           return addToPolling(resolved);
         });
       } else {
@@ -63,7 +63,7 @@ export default Ember.Mixin.create({
       if (!Ember.isArray(pollModels)) {
         pollModels = [pollModels];
       }
-      pollModels.forEach( (property) => {
+      pollModels.forEach((property) => {
         this.pollModel(property);
         this.addObserver(property, this, 'pollModelDidChange');
       });
@@ -80,7 +80,7 @@ export default Ember.Mixin.create({
       if (!Ember.isArray(pollModels)) {
         pollModels = [pollModels];
       }
-      pollModels.forEach( (property) => {
+      pollModels.forEach((property) => {
         this.stopPollingModel(property);
         this.removeObserver(property, this, 'pollModelDidChange');
       });

--- a/app/mixins/repo-actions-item-component-mixin.js
+++ b/app/mixins/repo-actions-item-component-mixin.js
@@ -13,22 +13,22 @@ export default Ember.Mixin.create({
   restarting: false,
   cancelling: false,
 
-  userHasPermissionForRepo: function () {
+  userHasPermissionForRepo: Ember.computed('user.permissions.[]', 'repo', 'user', function () {
     var repo, user;
     repo = this.get('repo');
     user = this.get('user');
     if (user && repo) {
       return user.hasAccessToRepo(repo);
     }
-  }.property('user.permissions.[]', 'repo', 'user'),
+  }),
 
-  canCancel: function () {
+  canCancel: Ember.computed('userHasPermissionForRepo', 'item.canCancel', function () {
     return this.get('item.canCancel') && this.get('userHasPermissionForRepo');
-  }.property('userHasPermissionForRepo', 'item.canCancel'),
+  }),
 
-  canRestart: function () {
+  canRestart: Ember.computed('userHasPermissionForRepo', 'item.canRestart', function () {
     return this.get('item.canRestart') && this.get('userHasPermissionForRepo');
-  }.property('userHasPermissionForRepo', 'item.canRestart'),
+  }),
 
   displayFlashError(status, action) {
     let type = this.get('type');

--- a/app/mixins/repo-actions-item-component-mixin.js
+++ b/app/mixins/repo-actions-item-component-mixin.js
@@ -13,7 +13,7 @@ export default Ember.Mixin.create({
   restarting: false,
   cancelling: false,
 
-  userHasPermissionForRepo: function() {
+  userHasPermissionForRepo: function () {
     var repo, user;
     repo = this.get('repo');
     user = this.get('user');
@@ -22,11 +22,11 @@ export default Ember.Mixin.create({
     }
   }.property('user.permissions.[]', 'repo', 'user'),
 
-  canCancel: function() {
+  canCancel: function () {
     return this.get('item.canCancel') && this.get('userHasPermissionForRepo');
   }.property('userHasPermissionForRepo', 'item.canCancel'),
 
-  canRestart: function() {
+  canRestart: function () {
     return this.get('item.canRestart') && this.get('userHasPermissionForRepo');
   }.property('userHasPermissionForRepo', 'item.canRestart'),
 
@@ -45,7 +45,7 @@ export default Ember.Mixin.create({
   },
 
   actions: {
-    restart: function() {
+    restart: function () {
       if (this.get('restarting')) {
         return;
       }
@@ -63,7 +63,7 @@ export default Ember.Mixin.create({
       });
     },
 
-    cancel: function() {
+    cancel: function () {
       if (this.get('cancelling')) {
         return;
       }

--- a/app/mixins/scroll-reset.js
+++ b/app/mixins/scroll-reset.js
@@ -1,8 +1,8 @@
 import Ember from 'ember';
 
 export default Ember.Mixin.create({
-  beforeModel: function() {
+  beforeModel: function () {
     this._super(...arguments);
-    window.scrollTo(0,0);
+    window.scrollTo(0, 0);
   }
 });

--- a/app/models/branch.js
+++ b/app/models/branch.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 import { hasMany, belongsTo } from 'ember-data/relationships';
@@ -11,7 +12,7 @@ export default Model.extend({
   builds: hasMany('builds', { inverse: 'branch' }),
   repo: belongsTo('repo', { inverse: 'defaultBranch' }),
 
-  repoId: function () {
+  repoId: Ember.computed('id', function () {
     return this.get('id').split('/')[3];
-  }.property('id')
+  })
 });

--- a/app/models/branch.js
+++ b/app/models/branch.js
@@ -11,7 +11,7 @@ export default Model.extend({
   builds: hasMany('builds', { inverse: 'branch' }),
   repo: belongsTo('repo', { inverse: 'defaultBranch' }),
 
-  repoId: function() {
+  repoId: function () {
     return this.get('id').split('/')[3];
   }.property('id')
 });

--- a/app/models/build.js
+++ b/app/models/build.js
@@ -55,13 +55,15 @@ Build.reopen({
   }),
 
   isFinished: Ember.computed('state', function () {
-    var ref;
-    return (ref = this.get('state')) === 'passed' || ref === 'failed' || ref === 'errored' || ref === 'canceled';
+    let state = this.get('state');
+    let finishedStates = ['passed', 'failed', 'errored', 'canceled'];
+    return finishedStates.contains(state);
   }),
 
   notStarted: Ember.computed('state', function () {
-    var ref;
-    return (ref = this.get('state')) === 'queued' || ref === 'created' || ref === 'received';
+    let state = this.get('state');
+    let waitingStates = ['queued', 'created', 'received'];
+    return waitingStates.contains(state);
   }),
 
   startedAt: Ember.computed('_startedAt', 'notStarted', function () {

--- a/app/models/build.js
+++ b/app/models/build.js
@@ -33,7 +33,7 @@ Build.reopen({
   commit: belongsTo('commit', { async: false }),
   jobs: hasMany('job', { async: true }),
 
-  config: function() {
+  config: function () {
     let config = this.get('_config');
     if (config) {
       return compact(config);
@@ -46,53 +46,53 @@ Build.reopen({
     }
   }.property('_config'),
 
-  isPullRequest: function() {
+  isPullRequest: function () {
     return this.get('eventType') === 'pull_request' || this.get('pullRequest');
   }.property('eventType'),
 
-  isMatrix: function() {
+  isMatrix: function () {
     return this.get('jobs.length') > 1;
   }.property('jobs.length'),
 
-  isFinished: function() {
+  isFinished: function () {
     var ref;
     return (ref = this.get('state')) === 'passed' || ref === 'failed' || ref === 'errored' || ref === 'canceled';
   }.property('state'),
 
-  notStarted: function() {
+  notStarted: function () {
     var ref;
     return (ref = this.get('state')) === 'queued' || ref === 'created' || ref === 'received';
   }.property('state'),
 
-  startedAt: function() {
+  startedAt: function () {
     if (!this.get('notStarted')) {
       return this.get('_startedAt');
     }
   }.property('_startedAt', 'notStarted'),
 
-  finishedAt: function() {
+  finishedAt: function () {
     if (!this.get('notStarted')) {
       return this.get('_finishedAt');
     }
   }.property('_finishedAt', 'notStarted'),
 
-  requiredJobs: function() {
-    return this.get('jobs').filter(function(data) {
+  requiredJobs: function () {
+    return this.get('jobs').filter(function (data) {
       return !data.get('allowFailure');
     });
   }.property('jobs.@each.allowFailure'),
 
-  allowedFailureJobs: function() {
-    return this.get('jobs').filter(function(data) {
+  allowedFailureJobs: function () {
+    return this.get('jobs').filter(function (data) {
       return data.get('allowFailure');
     });
   }.property('jobs.@each.allowFailure'),
 
-  rawConfigKeys: function() {
+  rawConfigKeys: function () {
     var keys;
     keys = [];
-    this.get('jobs').forEach(function(job) {
-      return configKeys(job.get('config')).forEach(function(key) {
+    this.get('jobs').forEach(function (job) {
+      return configKeys(job.get('config')).forEach(function (key) {
         if (!keys.contains(key)) {
           return keys.pushObject(key);
         }
@@ -101,12 +101,12 @@ Build.reopen({
     return keys;
   }.property('config', 'jobs.@each.config'),
 
-  configKeys: function() {
+  configKeys: function () {
     var headers, keys;
     keys = this.get('rawConfigKeys');
     headers = ['Job', 'Duration', 'Finished'];
     // TODO: No need to use $.map over Ember's
-    return Ember.$.map(headers.concat(keys), function(key) {
+    return Ember.$.map(headers.concat(keys), function (key) {
       if (configKeysMap.hasOwnProperty(key)) {
         return configKeysMap[key];
       } else {
@@ -115,21 +115,21 @@ Build.reopen({
     });
   }.property('rawConfigKeys.length'),
 
-  canCancel: function() {
+  canCancel: function () {
     return this.get('jobs').filterBy('canCancel', true).length;
   }.property('jobs.@each.canCancel', 'jobs', 'jobs.[]'),
 
   canRestart: Ember.computed.alias('isFinished'),
 
   cancel() {
-    return this.get('ajax').post("/builds/" + (this.get('id')) + "/cancel");
+    return this.get('ajax').post('/builds/' + (this.get('id')) + '/cancel');
   },
 
   restart() {
     return this.get('ajax').post(`/builds/${this.get('id')}/restart`);
   },
 
-  formattedFinishedAt: function() {
+  formattedFinishedAt: function () {
     let finishedAt = this.get('finishedAt');
     if (finishedAt) {
       return moment(finishedAt).format('lll');

--- a/app/models/build.js
+++ b/app/models/build.js
@@ -33,7 +33,7 @@ Build.reopen({
   commit: belongsTo('commit', { async: false }),
   jobs: hasMany('job', { async: true }),
 
-  config: function () {
+  config: Ember.computed('_config', function () {
     let config = this.get('_config');
     if (config) {
       return compact(config);
@@ -44,51 +44,51 @@ Build.reopen({
       this.set('isFetchingConfig', true);
       return this.reload();
     }
-  }.property('_config'),
+  }),
 
-  isPullRequest: function () {
+  isPullRequest: Ember.computed('eventType', function () {
     return this.get('eventType') === 'pull_request' || this.get('pullRequest');
-  }.property('eventType'),
+  }),
 
-  isMatrix: function () {
+  isMatrix: Ember.computed('jobs.length', function () {
     return this.get('jobs.length') > 1;
-  }.property('jobs.length'),
+  }),
 
-  isFinished: function () {
+  isFinished: Ember.computed('state', function () {
     var ref;
     return (ref = this.get('state')) === 'passed' || ref === 'failed' || ref === 'errored' || ref === 'canceled';
-  }.property('state'),
+  }),
 
-  notStarted: function () {
+  notStarted: Ember.computed('state', function () {
     var ref;
     return (ref = this.get('state')) === 'queued' || ref === 'created' || ref === 'received';
-  }.property('state'),
+  }),
 
-  startedAt: function () {
+  startedAt: Ember.computed('_startedAt', 'notStarted', function () {
     if (!this.get('notStarted')) {
       return this.get('_startedAt');
     }
-  }.property('_startedAt', 'notStarted'),
+  }),
 
-  finishedAt: function () {
+  finishedAt: Ember.computed('_finishedAt', 'notStarted', function () {
     if (!this.get('notStarted')) {
       return this.get('_finishedAt');
     }
-  }.property('_finishedAt', 'notStarted'),
+  }),
 
-  requiredJobs: function () {
+  requiredJobs: Ember.computed('jobs.@each.allowFailure', function () {
     return this.get('jobs').filter(function (data) {
       return !data.get('allowFailure');
     });
-  }.property('jobs.@each.allowFailure'),
+  }),
 
-  allowedFailureJobs: function () {
+  allowedFailureJobs: Ember.computed('jobs.@each.allowFailure', function () {
     return this.get('jobs').filter(function (data) {
       return data.get('allowFailure');
     });
-  }.property('jobs.@each.allowFailure'),
+  }),
 
-  rawConfigKeys: function () {
+  rawConfigKeys: Ember.computed('config', 'jobs.@each.config', function () {
     var keys;
     keys = [];
     this.get('jobs').forEach(function (job) {
@@ -99,9 +99,9 @@ Build.reopen({
       });
     });
     return keys;
-  }.property('config', 'jobs.@each.config'),
+  }),
 
-  configKeys: function () {
+  configKeys: Ember.computed('rawConfigKeys.length', function () {
     var headers, keys;
     keys = this.get('rawConfigKeys');
     headers = ['Job', 'Duration', 'Finished'];
@@ -113,11 +113,11 @@ Build.reopen({
         return key;
       }
     });
-  }.property('rawConfigKeys.length'),
+  }),
 
-  canCancel: function () {
+  canCancel: Ember.computed('jobs.@each.canCancel', 'jobs', 'jobs.[]', function () {
     return this.get('jobs').filterBy('canCancel', true).length;
-  }.property('jobs.@each.canCancel', 'jobs', 'jobs.[]'),
+  }),
 
   canRestart: Ember.computed.alias('isFinished'),
 
@@ -129,12 +129,12 @@ Build.reopen({
     return this.get('ajax').post(`/builds/${this.get('id')}/restart`);
   },
 
-  formattedFinishedAt: function () {
+  formattedFinishedAt: Ember.computed('finishedAt', function () {
     let finishedAt = this.get('finishedAt');
     if (finishedAt) {
       return moment(finishedAt).format('lll');
     }
-  }.property('finishedAt')
+  })
 
 });
 

--- a/app/models/commit.js
+++ b/app/models/commit.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import Model from 'ember-data/model';
 import { gravatarImage } from 'travis/utils/urls';
 import attr from 'ember-data/attr';
@@ -18,11 +19,11 @@ export default Model.extend({
 
   build: belongsTo('build'),
 
-  subject: function () {
+  subject: Ember.computed('message', function () {
     return this.get('message').split('\n', 1)[0];
-  }.property('message'),
+  }),
 
-  body: function () {
+  body: Ember.computed('message', function () {
     var message;
     message = this.get('message');
     if (message.indexOf('\n') > 0) {
@@ -30,13 +31,19 @@ export default Model.extend({
     } else {
       return '';
     }
-  }.property('message'),
+  }),
 
-  authorIsCommitter: function () {
-    return this.get('authorName') === this.get('committerName') && this.get('authorEmail') === this.get('committerEmail');
-  }.property('authorName', 'authorEmail', 'committerName', 'committerEmail'),
+  authorIsCommitter: Ember.computed(
+    'authorName',
+    'authorEmail',
+    'committerName',
+    'committerEmail',
+    function () {
+      return this.get('authorName') === this.get('committerName') && this.get('authorEmail') === this.get('committerEmail');
+    }
+  ),
 
-  authorAvatarUrlOrGravatar: function () {
+  authorAvatarUrlOrGravatar: Ember.computed('authorEmail', 'authorAvatarUrl', function () {
     var url = this.get('authorAvatarUrl');
 
     if (!url) {
@@ -44,9 +51,9 @@ export default Model.extend({
     }
 
     return url;
-  }.property('authorEmail', 'authorAvatarUrl'),
+  }),
 
-  committerAvatarUrlOrGravatar: function () {
+  committerAvatarUrlOrGravatar: Ember.computed('committerEmail', 'committerAvatarUrl', function () {
     var url = this.get('committerAvatarUrl');
 
     if (!url) {
@@ -54,5 +61,5 @@ export default Model.extend({
     }
 
     return url;
-  }.property('committerEmail', 'committerAvatarUrl')
+  })
 });

--- a/app/models/commit.js
+++ b/app/models/commit.js
@@ -39,7 +39,9 @@ export default Model.extend({
     'committerName',
     'committerEmail',
     function () {
-      return this.get('authorName') === this.get('committerName') && this.get('authorEmail') === this.get('committerEmail');
+      let namesMatch = this.get('authorName') === this.get('committerName');
+      let emailsMatch = this.get('authorEmail') === this.get('committerEmail');
+      return namesMatch && emailsMatch;
     }
   ),
 

--- a/app/models/commit.js
+++ b/app/models/commit.js
@@ -18,38 +18,38 @@ export default Model.extend({
 
   build: belongsTo('build'),
 
-  subject: function() {
-    return this.get('message').split("\n", 1)[0];
+  subject: function () {
+    return this.get('message').split('\n', 1)[0];
   }.property('message'),
 
-  body: function() {
+  body: function () {
     var message;
     message = this.get('message');
-    if (message.indexOf("\n") > 0) {
-      return message.substr(message.indexOf("\n") + 1).trim();
+    if (message.indexOf('\n') > 0) {
+      return message.substr(message.indexOf('\n') + 1).trim();
     } else {
-      return "";
+      return '';
     }
   }.property('message'),
 
-  authorIsCommitter: function() {
+  authorIsCommitter: function () {
     return this.get('authorName') === this.get('committerName') && this.get('authorEmail') === this.get('committerEmail');
   }.property('authorName', 'authorEmail', 'committerName', 'committerEmail'),
 
-  authorAvatarUrlOrGravatar: function() {
+  authorAvatarUrlOrGravatar: function () {
     var url = this.get('authorAvatarUrl');
 
-    if(!url) {
+    if (!url) {
       url = gravatarImage(this.get('authorEmail'), 40);
     }
 
     return url;
   }.property('authorEmail', 'authorAvatarUrl'),
 
-  committerAvatarUrlOrGravatar: function() {
+  committerAvatarUrlOrGravatar: function () {
     var url = this.get('committerAvatarUrl');
 
-    if(!url) {
+    if (!url) {
       url = gravatarImage(this.get('committerEmail'), 40);
     }
 

--- a/app/models/env-var.js
+++ b/app/models/env-var.js
@@ -5,6 +5,6 @@ import { belongsTo } from 'ember-data/relationships';
 export default Model.extend({
   name: attr(),
   value: attr(),
-  "public": attr('boolean'),
+  'public': attr('boolean'),
   repo: belongsTo('repo', { async: true })
 });

--- a/app/models/hook.js
+++ b/app/models/hook.js
@@ -9,22 +9,22 @@ export default Model.extend({
   description: attr(),
   active: attr('boolean'),
   admin: attr('boolean'),
-  "private": attr('boolean'),
+  'private': attr('boolean'),
 
-  account: function() {
+  account: function () {
     return this.get('slug').split('/')[0];
   }.property('slug'),
 
-  slug: function() {
-    return (this.get('ownerName')) + "/" + (this.get('name'));
+  slug: function () {
+    return (this.get('ownerName')) + '/' + (this.get('name'));
   }.property('ownerName', 'name'),
 
-  urlGithub: function() {
-    return config.sourceEndpoint + "/" + (this.get('slug'));
+  urlGithub: function () {
+    return config.sourceEndpoint + '/' + (this.get('slug'));
   }.property(),
 
-  urlGithubAdmin: function() {
-    return config.sourceEndpoint + "/" + (this.get('slug')) + "/settings/hooks#travis_minibucket";
+  urlGithubAdmin: function () {
+    return config.sourceEndpoint + '/' + (this.get('slug')) + '/settings/hooks#travis_minibucket';
   }.property(),
 
   toggle() {

--- a/app/models/hook.js
+++ b/app/models/hook.js
@@ -11,21 +11,21 @@ export default Model.extend({
   admin: attr('boolean'),
   'private': attr('boolean'),
 
-  account: function () {
+  account: Ember.computed('slug', function () {
     return this.get('slug').split('/')[0];
-  }.property('slug'),
+  }),
 
-  slug: function () {
+  slug: Ember.computed('ownerName', 'name', function () {
     return (this.get('ownerName')) + '/' + (this.get('name'));
-  }.property('ownerName', 'name'),
+  }),
 
-  urlGithub: function () {
+  urlGithub: Ember.computed(function () {
     return config.sourceEndpoint + '/' + (this.get('slug'));
-  }.property(),
+  }),
 
-  urlGithubAdmin: function () {
+  urlGithubAdmin: Ember.computed(function () {
     return config.sourceEndpoint + '/' + (this.get('slug')) + '/settings/hooks#travis_minibucket';
-  }.property(),
+  }),
 
   toggle() {
     if (this.get('isSaving')) {

--- a/app/models/job.js
+++ b/app/models/job.js
@@ -71,13 +71,15 @@ export default Model.extend(DurationCalculations, {
   }),
 
   isFinished: Ember.computed('state', function () {
-    var ref;
-    return (ref = this.get('state')) === 'passed' || ref === 'failed' || ref === 'errored' || ref === 'canceled';
+    let state = this.get('state');
+    let finishedStates = ['passes', 'failed', 'errored', 'canceled'];
+    return finishedStates.contains(state);
   }),
 
   notStarted: Ember.computed('state', function () {
-    var ref;
-    return (ref = this.get('state')) === 'queued' || ref === 'created' || ref === 'received';
+    let state = this.get('state');
+    let waitingStates = ['queued', 'created', 'received'];
+    return waitingStates.contains(state);
   }),
 
   clearLog() {

--- a/app/models/job.js
+++ b/app/models/job.js
@@ -72,7 +72,7 @@ export default Model.extend(DurationCalculations, {
 
   isFinished: Ember.computed('state', function () {
     let state = this.get('state');
-    let finishedStates = ['passes', 'failed', 'errored', 'canceled'];
+    let finishedStates = ['passed', 'failed', 'errored', 'canceled'];
     return finishedStates.contains(state);
   }),
 

--- a/app/models/job.js
+++ b/app/models/job.js
@@ -33,7 +33,7 @@ export default Model.extend(DurationCalculations, {
   pullRequestNumber: Ember.computed.alias('build.pullRequestNumber'),
   pullRequestTitle: Ember.computed.alias('build.pullRequestTitle'),
 
-  log: function() {
+  log: function () {
     this.set('isLogAccessed', true);
     return Log.create({
       job: this,
@@ -41,23 +41,23 @@ export default Model.extend(DurationCalculations, {
     });
   }.property(),
 
-  startedAt: function() {
+  startedAt: function () {
     if (!this.get('notStarted')) {
       return this.get('_startedAt');
     }
   }.property('_startedAt', 'notStarted'),
 
-  finishedAt: function() {
+  finishedAt: function () {
     if (!this.get('notStarted')) {
       return this.get('_finishedAt');
     }
   }.property('_finishedAt', 'notStarted'),
 
-  repoSlug: function() {
+  repoSlug: function () {
     return this.get('repositorySlug');
   }.property('repositorySlug'),
 
-  config: function() {
+  config: function () {
     let config = this.get('_config');
     if (config) {
       return compact(config);
@@ -70,12 +70,12 @@ export default Model.extend(DurationCalculations, {
     }
   }.property('_config'),
 
-  isFinished: function() {
+  isFinished: function () {
     var ref;
     return (ref = this.get('state')) === 'passed' || ref === 'failed' || ref === 'errored' || ref === 'canceled';
   }.property('state'),
 
-  notStarted: function() {
+  notStarted: function () {
     var ref;
     return (ref = this.get('state')) === 'queued' || ref === 'created' || ref === 'received';
   }.property('state'),
@@ -86,12 +86,12 @@ export default Model.extend(DurationCalculations, {
     }
   },
 
-  configValues: function() {
+  configValues: function () {
     var config, keys;
     config = this.get('config');
     keys = this.get('build.rawConfigKeys');
     if (config && keys) {
-      return keys.map(function(key) {
+      return keys.map(function (key) {
         return config[key];
       });
     } else {
@@ -99,18 +99,18 @@ export default Model.extend(DurationCalculations, {
     }
   }.property('config', 'build.rawConfigKeys.length'),
 
-  canCancel: function() {
+  canCancel: function () {
     return !this.get('isFinished');
   }.property('isFinished'),
 
   canRestart: Ember.computed.alias('isFinished'),
 
   cancel() {
-    return this.get('ajax').post("/jobs/" + (this.get('id')) + "/cancel");
+    return this.get('ajax').post('/jobs/' + (this.get('id')) + '/cancel');
   },
 
   removeLog() {
-    return this.get('ajax').patch("/jobs/" + (this.get('id')) + "/log").then(() => {
+    return this.get('ajax').patch('/jobs/' + (this.get('id')) + '/log').then(() => {
       return this.reloadLog();
     });
   },
@@ -121,7 +121,7 @@ export default Model.extend(DurationCalculations, {
   },
 
   restart() {
-    return this.get('ajax').post("/jobs/" + (this.get('id')) + "/restart");
+    return this.get('ajax').post('/jobs/' + (this.get('id')) + '/restart');
   },
 
   appendLog(part) {
@@ -134,7 +134,7 @@ export default Model.extend(DurationCalculations, {
     }
     this.set('subscribed', true);
     if (Travis.pusher) {
-      return Travis.pusher.subscribe("job-" + (this.get('id')));
+      return Travis.pusher.subscribe('job-' + (this.get('id')));
     }
   },
 
@@ -144,38 +144,38 @@ export default Model.extend(DurationCalculations, {
     }
     this.set('subscribed', false);
     if (Travis.pusher) {
-      return Travis.pusher.unsubscribe("job-" + (this.get('id')));
+      return Travis.pusher.unsubscribe('job-' + (this.get('id')));
     }
   },
 
-  onStateChange: function() {
+  onStateChange: function () {
     if (this.get('state') === 'finished' && Travis.pusher) {
       return this.unsubscribe();
     }
   }.observes('state'),
 
-  formattedFinishedAt: function() {
+  formattedFinishedAt: function () {
     let finishedAt = this.get('finishedAt');
     if (finishedAt) {
       return moment(finishedAt).format('lll');
     }
   }.property('finishedAt'),
 
-  canRemoveLog: function() {
+  canRemoveLog: function () {
     return !this.get('log.removed');
   }.property('log.removed'),
 
-  slug: function() {
-    return (this.get('repo.slug')) + " #" + (this.get('number'));
-  } .property(),
+  slug: function () {
+    return (this.get('repo.slug')) + ' #' + (this.get('number'));
+  }.property(),
 
-  isLegacyInfrastructure: function() {
+  isLegacyInfrastructure: function () {
     if (this.get('queue') === 'builds.linux') {
       return true;
     }
   }.property('queue'),
 
-  displayGceNotice: function() {
+  displayGceNotice: function () {
     if (this.get('queue') === 'builds.gce' && this.get('config.dist') === 'precise') {
       return true;
     } else {

--- a/app/models/job.js
+++ b/app/models/job.js
@@ -33,31 +33,31 @@ export default Model.extend(DurationCalculations, {
   pullRequestNumber: Ember.computed.alias('build.pullRequestNumber'),
   pullRequestTitle: Ember.computed.alias('build.pullRequestTitle'),
 
-  log: function () {
+  log: Ember.computed(function () {
     this.set('isLogAccessed', true);
     return Log.create({
       job: this,
       ajax: this.get('ajax')
     });
-  }.property(),
+  }),
 
-  startedAt: function () {
+  startedAt: Ember.computed('_startedAt', 'notStarted', function () {
     if (!this.get('notStarted')) {
       return this.get('_startedAt');
     }
-  }.property('_startedAt', 'notStarted'),
+  }),
 
-  finishedAt: function () {
+  finishedAt: Ember.computed('_finishedAt', 'notStarted', function () {
     if (!this.get('notStarted')) {
       return this.get('_finishedAt');
     }
-  }.property('_finishedAt', 'notStarted'),
+  }),
 
-  repoSlug: function () {
+  repoSlug: Ember.computed('repositorySlug', function () {
     return this.get('repositorySlug');
-  }.property('repositorySlug'),
+  }),
 
-  config: function () {
+  config: Ember.computed('_config', function () {
     let config = this.get('_config');
     if (config) {
       return compact(config);
@@ -68,17 +68,17 @@ export default Model.extend(DurationCalculations, {
       this.set('isFetchingConfig', true);
       return this.reload();
     }
-  }.property('_config'),
+  }),
 
-  isFinished: function () {
+  isFinished: Ember.computed('state', function () {
     var ref;
     return (ref = this.get('state')) === 'passed' || ref === 'failed' || ref === 'errored' || ref === 'canceled';
-  }.property('state'),
+  }),
 
-  notStarted: function () {
+  notStarted: Ember.computed('state', function () {
     var ref;
     return (ref = this.get('state')) === 'queued' || ref === 'created' || ref === 'received';
-  }.property('state'),
+  }),
 
   clearLog() {
     if (this.get('isLogAccessed')) {
@@ -86,7 +86,7 @@ export default Model.extend(DurationCalculations, {
     }
   },
 
-  configValues: function () {
+  configValues: Ember.computed('config', 'build.rawConfigKeys.length', function () {
     var config, keys;
     config = this.get('config');
     keys = this.get('build.rawConfigKeys');
@@ -97,11 +97,11 @@ export default Model.extend(DurationCalculations, {
     } else {
       return [];
     }
-  }.property('config', 'build.rawConfigKeys.length'),
+  }),
 
-  canCancel: function () {
+  canCancel: Ember.computed('isFinished', function () {
     return !this.get('isFinished');
-  }.property('isFinished'),
+  }),
 
   canRestart: Ember.computed.alias('isFinished'),
 
@@ -148,38 +148,38 @@ export default Model.extend(DurationCalculations, {
     }
   },
 
-  onStateChange: function () {
+  onStateChange: Ember.observer('state', function () {
     if (this.get('state') === 'finished' && Travis.pusher) {
       return this.unsubscribe();
     }
-  }.observes('state'),
+  }),
 
-  formattedFinishedAt: function () {
+  formattedFinishedAt: Ember.computed('finishedAt', function () {
     let finishedAt = this.get('finishedAt');
     if (finishedAt) {
       return moment(finishedAt).format('lll');
     }
-  }.property('finishedAt'),
+  }),
 
-  canRemoveLog: function () {
+  canRemoveLog: Ember.computed('log.removed', function () {
     return !this.get('log.removed');
-  }.property('log.removed'),
+  }),
 
-  slug: function () {
+  slug: Ember.computed(function () {
     return (this.get('repo.slug')) + ' #' + (this.get('number'));
-  }.property(),
+  }),
 
-  isLegacyInfrastructure: function () {
+  isLegacyInfrastructure: Ember.computed('queue', function () {
     if (this.get('queue') === 'builds.linux') {
       return true;
     }
-  }.property('queue'),
+  }),
 
-  displayGceNotice: function () {
+  displayGceNotice: Ember.computed('queue', 'config.dist', function () {
     if (this.get('queue') === 'builds.gce' && this.get('config.dist') === 'precise') {
       return true;
     } else {
       return false;
     }
-  }.property('queue', 'config.dist')
+  })
 });

--- a/app/models/log.js
+++ b/app/models/log.js
@@ -96,11 +96,11 @@ var LogModel = Ember.Object.extend({
     });
   },
 
-  parts: function () {
+  parts: Ember.computed(function () {
     return Ember.ArrayProxy.create({
       content: []
     });
-  }.property(),
+  }),
 
   clearParts() {
     var parts;

--- a/app/models/log.js
+++ b/app/models/log.js
@@ -8,11 +8,11 @@ var Request = Ember.Object.extend({
   },
 
   run() {
-    return this.get('ajax').ajax("/jobs/" + this.id + "/log?cors_hax=true", 'GET', {
+    return this.get('ajax').ajax('/jobs/' + this.id + '/log?cors_hax=true', 'GET', {
       dataType: 'text',
       headers: this.HEADERS,
       success: (body, status, xhr) => {
-        return Ember.run(this, function() {
+        return Ember.run(this, function () {
           return this.handle(body, status, xhr);
         });
       }
@@ -28,13 +28,13 @@ var Request = Ember.Object.extend({
         url: this.redirectTo(xhr),
         type: 'GET',
         success: (body) => {
-          Ember.run(this, function() { this.handlers.text(body); });
+          Ember.run(this, function () { this.handlers.text(body); });
         }
       });
     } else if (this.isJson(xhr)) {
-      return Ember.run(this, function() { this.handlers.json(body); });
+      return Ember.run(this, function () { this.handlers.json(body); });
     } else {
-      return Ember.run(this, function() { this.handlers.text(body); });
+      return Ember.run(this, function () { this.handlers.text(body); });
     }
   },
 
@@ -71,15 +71,15 @@ var LogModel = Ember.Object.extend({
     if (after) {
       data['after'] = after;
     }
-    return this.get('ajax').ajax("/jobs/" + (this.get('job.id')) + "/log", 'GET', {
+    return this.get('ajax').ajax('/jobs/' + (this.get('job.id')) + '/log', 'GET', {
       dataType: 'json',
       headers: {
         accept: 'application/json; chunked=true; version=2'
       },
       data: data,
-      success: (function(_this) {
-        return function(body) {
-          return Ember.run(_this, function() {
+      success: (function (_this) {
+        return function (body) {
+          return Ember.run(_this, function () {
             var i, len, part, results;
             let { parts } = body.log;
             if (parts) {
@@ -96,7 +96,7 @@ var LogModel = Ember.Object.extend({
     });
   },
 
-  parts: function() {
+  parts: function () {
     return Ember.ArrayProxy.create({
       content: []
     });
@@ -113,16 +113,16 @@ var LogModel = Ember.Object.extend({
     this.debug('log model: fetching log');
     this.clearParts();
     handlers = {
-      json: (function(_this) {
-        return function(json) {
+      json: (function (_this) {
+        return function (json) {
           if (json['log']['removed_at']) {
             _this.set('removed', true);
           }
           return _this.loadParts(json['log']['parts']);
         };
       })(this),
-      text: (function(_this) {
-        return function(text) {
+      text: (function (_this) {
+        return function (text) {
           return _this.loadText(text);
         };
       })(this)

--- a/app/models/log.js
+++ b/app/models/log.js
@@ -45,7 +45,6 @@ var Request = Ember.Object.extend({
   },
 
   isJson(xhr) {
-
     // Firefox can't see the Content-Type header on the xhr response due to the wrong
     // status code 204. Should be some redirect code but that doesn't work with CORS.
     var type = xhr.getResponseHeader('Content-Type') || '';

--- a/app/models/repo.js
+++ b/app/models/repo.js
@@ -51,7 +51,8 @@ const Repo = Model.extend({
       event_type: ['push', 'api', 'cron'],
       repository_id: id
     }, function (b) {
-      return b.get('repo.id') + '' === id + '' && (b.get('eventType') === 'push' || b.get('eventType') === 'api' || b.get('eventType') === 'cron');
+      let eventTypes = ['push', 'api', 'cron'];
+      return b.get('repo.id') + '' === id + '' && eventTypes.include(b.get('eventType'));
     });
     array = ExpandableRecordArray.create({
       type: 'build',

--- a/app/models/repo.js
+++ b/app/models/repo.js
@@ -34,7 +34,7 @@ const Repo = Model.extend({
     return this.store.recordForId('ssh_key', this.get('id'));
   },
 
-  envVars: function () {
+  envVars: Ember.computed(function () {
     var id;
     id = this.get('id');
     return this.store.filter('env_var', {
@@ -42,9 +42,9 @@ const Repo = Model.extend({
     }, function (v) {
       return v.get('repo.id') === id;
     });
-  }.property(),
+  }),
 
-  builds: function () {
+  builds: Ember.computed(function () {
     var array, builds, id;
     id = this.get('id');
     builds = this.store.filter('build', {
@@ -60,9 +60,9 @@ const Repo = Model.extend({
     array.load(builds);
     array.observe(builds);
     return array;
-  }.property(),
+  }),
 
-  pullRequests: function () {
+  pullRequests: Ember.computed(function () {
     var array, builds, id;
     id = this.get('id');
     builds = this.store.filter('build', {
@@ -79,9 +79,9 @@ const Repo = Model.extend({
     id = this.get('id');
     array.observe(builds);
     return array;
-  }.property(),
+  }),
 
-  crons: function () {
+  crons: Ember.computed(function () {
     var array, builds, id;
     id = this.get('id');
     builds = this.store.filter('build', {
@@ -98,42 +98,42 @@ const Repo = Model.extend({
     id = this.get('id');
     array.observe(builds);
     return array;
-  }.property(),
+  }),
 
-  branches: function () {
+  branches: Ember.computed(function () {
     var id = this.get('id');
     return this.store.filter('branch', {
       repository_id: id
     }, function (b) {
       return b.get('repoId') === id;
     });
-  }.property(),
+  }),
 
-  cronJobs: function () {
+  cronJobs: Ember.computed(function () {
     var id = this.get('id');
     return this.store.filter('cron', {
       repository_id: id
     }, function (cron) {
       return cron.get('branch.repoId') === id;
     });
-  }.property(),
+  }),
 
-  owner: function () {
+  owner: Ember.computed('slug', function () {
     return (this.get('slug') || '').split('/')[0];
-  }.property('slug'),
+  }),
 
-  name: function () {
+  name: Ember.computed('slug', function () {
     return (this.get('slug') || '').split('/')[1];
-  }.property('slug'),
+  }),
 
-  stats: function () {
+  stats: Ember.computed('slug', function () {
     if (this.get('slug')) {
       return this.get('_stats') || Ember.$.get('https://api.github.com/repos/' + this.get('slug'), (data) => {
         this.set('_stats', data);
         return this.notifyPropertyChange('stats');
       }) && {};
     }
-  }.property('slug'),
+  }),
 
   updateTimes() {
     let currentBuild = this.get('currentBuild');

--- a/app/models/repo.js
+++ b/app/models/repo.js
@@ -10,7 +10,7 @@ const Repo = Model.extend({
   ajax: service(),
   slug: attr(),
   description: attr(),
-  "private": attr('boolean'),
+  'private': attr('boolean'),
   githubLanguage: attr(),
   active: attr(),
 
@@ -24,33 +24,33 @@ const Repo = Model.extend({
   currentBuildId: Ember.computed.oneWay('currentBuild.id'),
 
   withLastBuild() {
-    return this.filter(function(repo) {
+    return this.filter(function (repo) {
       return repo.get('lastBuildId');
     });
   },
 
-  sshKey: function() {
+  sshKey: function () {
     this.store.find('ssh_key', this.get('id'));
     return this.store.recordForId('ssh_key', this.get('id'));
   },
 
-  envVars: function() {
+  envVars: function () {
     var id;
     id = this.get('id');
     return this.store.filter('env_var', {
       repository_id: id
-    }, function(v) {
+    }, function (v) {
       return v.get('repo.id') === id;
     });
   }.property(),
 
-  builds: function() {
+  builds: function () {
     var array, builds, id;
     id = this.get('id');
     builds = this.store.filter('build', {
       event_type: ['push', 'api', 'cron'],
       repository_id: id
-    }, function(b) {
+    }, function (b) {
       return b.get('repo.id') + '' === id + '' && (b.get('eventType') === 'push' || b.get('eventType') === 'api' || b.get('eventType') === 'cron');
     });
     array = ExpandableRecordArray.create({
@@ -62,13 +62,13 @@ const Repo = Model.extend({
     return array;
   }.property(),
 
-  pullRequests: function() {
+  pullRequests: function () {
     var array, builds, id;
     id = this.get('id');
     builds = this.store.filter('build', {
       event_type: 'pull_request',
       repository_id: id
-    }, function(b) {
+    }, function (b) {
       return b.get('repo.id') + '' === id + '' && b.get('eventType') === 'pull_request';
     });
     array = ExpandableRecordArray.create({
@@ -81,13 +81,13 @@ const Repo = Model.extend({
     return array;
   }.property(),
 
-  crons: function() {
+  crons: function () {
     var array, builds, id;
     id = this.get('id');
     builds = this.store.filter('build', {
       event_type: 'cron',
       repository_id: id
-    }, function(b) {
+    }, function (b) {
       return b.get('repo.id') + '' === id + '' && b.get('eventType') === 'cron';
     });
     array = ExpandableRecordArray.create({
@@ -100,35 +100,35 @@ const Repo = Model.extend({
     return array;
   }.property(),
 
-  branches: function() {
+  branches: function () {
     var id = this.get('id');
     return this.store.filter('branch', {
       repository_id: id
-    }, function(b) {
+    }, function (b) {
       return b.get('repoId') === id;
     });
   }.property(),
 
-  cronJobs: function() {
+  cronJobs: function () {
     var id = this.get('id');
     return this.store.filter('cron', {
       repository_id: id
-    }, function(cron) {
+    }, function (cron) {
       return cron.get('branch.repoId') === id;
     });
   }.property(),
 
-  owner: function() {
+  owner: function () {
     return (this.get('slug') || '').split('/')[0];
   }.property('slug'),
 
-  name: function() {
+  name: function () {
     return (this.get('slug') || '').split('/')[1];
   }.property('slug'),
 
-  stats: function() {
+  stats: function () {
     if (this.get('slug')) {
-      return this.get('_stats') || Ember.$.get("https://api.github.com/repos/" + this.get('slug'), (data) => {
+      return this.get('_stats') || Ember.$.get('https://api.github.com/repos/' + this.get('slug'), (data) => {
         this.set('_stats', data);
         return this.notifyPropertyChange('stats');
       }) && {};
@@ -149,7 +149,7 @@ const Repo = Model.extend({
   fetchSettings() {
     return this.get('ajax').ajax('/repos/' + this.get('id') + '/settings', 'get', {
       forceAuth: true
-    }).then(function(data) {
+    }).then(function (data) {
       return data['settings'];
     });
   },
@@ -171,18 +171,18 @@ Repo.reopenClass({
   accessibleBy(store, reposIdsOrlogin) {
     var promise, repos, reposIds;
     reposIds = reposIdsOrlogin;
-    repos = store.filter('repo', function(repo) {
+    repos = store.filter('repo', function (repo) {
       let repoId = parseInt(repo.get('id'));
       return reposIds.contains(repoId);
     });
-    promise = new Ember.RSVP.Promise(function(resolve, reject) {
+    promise = new Ember.RSVP.Promise(function (resolve, reject) {
       return store.query('repo', {
         'repository.active': 'true',
         sort_by: 'current_build:desc',
         limit: 30
-      }).then(function() {
+      }).then(function () {
         return resolve(repos);
-      }, function() {
+      }, function () {
         return reject();
       });
     });
@@ -196,19 +196,19 @@ Repo.reopenClass({
       orderBy: 'name',
       limit: 5
     });
-    promise = ajax.ajax("/repos?" + queryString, 'get');
+    promise = ajax.ajax('/repos?' + queryString, 'get');
     result = Ember.ArrayProxy.create({
       content: []
     });
-    return promise.then(function(data) {
-      let promises = data.repos.map(function(repoData) {
-        return store.findRecord('repo', repoData.id).then(function(record) {
+    return promise.then(function (data) {
+      let promises = data.repos.map(function (repoData) {
+        return store.findRecord('repo', repoData.id).then(function (record) {
           result.pushObject(record);
           result.set('isLoaded', true);
           return record;
         });
       });
-      return Ember.RSVP.allSettled(promises).then(function() {
+      return Ember.RSVP.allSettled(promises).then(function () {
         return result;
       });
     });
@@ -216,10 +216,10 @@ Repo.reopenClass({
 
   withLastBuild(store) {
     var repos;
-    repos = store.filter('repo', {}, function(build) {
+    repos = store.filter('repo', {}, function (build) {
       return build.get('lastBuildId');
     });
-    repos.then(function() {
+    repos.then(function () {
       return repos.set('isLoaded', true);
     });
     return repos;
@@ -234,7 +234,7 @@ Repo.reopenClass({
       promise = null;
       adapter = store.adapterFor('repo');
       modelClass = store.modelFor('repo');
-      promise = adapter.findRecord(store, modelClass, slug).then(function(payload) {
+      promise = adapter.findRecord(store, modelClass, slug).then(function (payload) {
         var i, len, record, ref, repo, result, serializer;
         serializer = store.serializerFor('repo');
         modelClass = store.modelFor('repo');
@@ -251,7 +251,7 @@ Repo.reopenClass({
         }
         return repo;
       });
-      return promise["catch"](function() {
+      return promise['catch'](function () {
         var error;
         error = new Error('repo not found');
         error.slug = slug;

--- a/app/models/repo.js
+++ b/app/models/repo.js
@@ -52,7 +52,7 @@ const Repo = Model.extend({
       repository_id: id
     }, function (b) {
       let eventTypes = ['push', 'api', 'cron'];
-      return b.get('repo.id') + '' === id + '' && eventTypes.include(b.get('eventType'));
+      return b.get('repo.id') + '' === id + '' && eventTypes.contains(b.get('eventType'));
     });
     array = ExpandableRecordArray.create({
       type: 'build',

--- a/app/models/request.js
+++ b/app/models/request.js
@@ -18,14 +18,14 @@ export default Model.extend({
   commit: belongsTo('commit', { async: true }),
   build: belongsTo('build', { async: true }),
 
-  isAccepted: function() {
+  isAccepted: function () {
     // For some reason some of the requests have a null result beside the fact that
     // the build was created. We need to look into it, but for now we can just assume
     // that if build was created, the request was accepted
     return this.get('result') === 'accepted' || this.get('build.id');
   }.property('result'),
 
-  isPullRequest: function() {
+  isPullRequest: function () {
     return this.get('event_type') === 'pull_request';
   }.property('event_type')
 });

--- a/app/models/request.js
+++ b/app/models/request.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 import { belongsTo } from 'ember-data/relationships';
@@ -18,14 +19,14 @@ export default Model.extend({
   commit: belongsTo('commit', { async: true }),
   build: belongsTo('build', { async: true }),
 
-  isAccepted: function () {
+  isAccepted: Ember.computed('result', function () {
     // For some reason some of the requests have a null result beside the fact that
     // the build was created. We need to look into it, but for now we can just assume
     // that if build was created, the request was accepted
     return this.get('result') === 'accepted' || this.get('build.id');
-  }.property('result'),
+  }),
 
-  isPullRequest: function () {
+  isPullRequest: Ember.computed('event_type', function () {
     return this.get('event_type') === 'pull_request';
-  }.property('event_type')
+  })
 });

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -22,27 +22,27 @@ export default Model.extend({
   syncedAt: attr(),
   repoCount: attr('number'),
 
-  fullName: function () {
+  fullName: Ember.computed('name', 'login', function () {
     return this.get('name') || this.get('login');
-  }.property('name', 'login'),
+  }),
 
-  isSyncingDidChange: function () {
+  isSyncingDidChange: Ember.observer('isSyncing', function () {
     return Ember.run.next(this, function () {
       if (this.get('isSyncing')) {
         return this.poll();
       }
     });
-  }.observes('isSyncing'),
+  }),
 
-  urlGithub: function () {
+  urlGithub: Ember.computed(function () {
     return config.sourceEndpoint + '/' + (this.get('login'));
-  }.property(),
+  }),
 
-  _rawPermissions: function () {
+  _rawPermissions: Ember.computed(function () {
     return this.get('ajax').get('/users/permissions');
-  }.property(),
+  }),
 
-  permissions: function () {
+  permissions: Ember.computed(function () {
     var permissions;
     permissions = Ember.ArrayProxy.create({
       content: []
@@ -51,9 +51,9 @@ export default Model.extend({
       return permissions.set('content', data.permissions);
     });
     return permissions;
-  }.property(),
+  }),
 
-  adminPermissions: function () {
+  adminPermissions: Ember.computed(function () {
     var permissions;
     permissions = Ember.ArrayProxy.create({
       content: []
@@ -62,9 +62,9 @@ export default Model.extend({
       return permissions.set('content', data.admin);
     });
     return permissions;
-  }.property(),
+  }),
 
-  pullPermissions: function () {
+  pullPermissions: Ember.computed(function () {
     var permissions;
     permissions = Ember.ArrayProxy.create({
       content: []
@@ -73,9 +73,9 @@ export default Model.extend({
       return permissions.set('content', data.pull);
     });
     return permissions;
-  }.property(),
+  }),
 
-  pushPermissions: function () {
+  pushPermissions: Ember.computed(function () {
     var permissions;
     permissions = Ember.ArrayProxy.create({
       content: []
@@ -84,13 +84,13 @@ export default Model.extend({
       return permissions.set('content', data.push);
     });
     return permissions;
-  }.property(),
+  }),
 
-  pushPermissionsPromise: function () {
+  pushPermissionsPromise: Ember.computed(function () {
     return this.get('_rawPermissions').then((data) => {
       return data.pull;
     });
-  }.property(),
+  }),
 
   hasAccessToRepo(repo) {
     let id = repo.get ? repo.get('id') : repo;
@@ -100,9 +100,9 @@ export default Model.extend({
     }
   },
 
-  type: function () {
+  type: Ember.computed(function () {
     return 'user';
-  }.property(),
+  }),
 
   sync() {
     var self;
@@ -137,7 +137,7 @@ export default Model.extend({
     return this.get('sessionStorage').setItem('travis.user', JSON.stringify(user));
   },
 
-  avatarUrl: function () {
+  avatarUrl: Ember.computed('email', function () {
     return gravatarImage(this.get('email'), 36);
-  }.property('email')
+  })
 });

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -22,27 +22,27 @@ export default Model.extend({
   syncedAt: attr(),
   repoCount: attr('number'),
 
-  fullName: function() {
+  fullName: function () {
     return this.get('name') || this.get('login');
   }.property('name', 'login'),
 
-  isSyncingDidChange: function() {
-    return Ember.run.next(this, function() {
+  isSyncingDidChange: function () {
+    return Ember.run.next(this, function () {
       if (this.get('isSyncing')) {
         return this.poll();
       }
     });
   }.observes('isSyncing'),
 
-  urlGithub: function() {
-    return config.sourceEndpoint + "/" + (this.get('login'));
+  urlGithub: function () {
+    return config.sourceEndpoint + '/' + (this.get('login'));
   }.property(),
 
-  _rawPermissions: function() {
+  _rawPermissions: function () {
     return this.get('ajax').get('/users/permissions');
   }.property(),
 
-  permissions: function() {
+  permissions: function () {
     var permissions;
     permissions = Ember.ArrayProxy.create({
       content: []
@@ -53,7 +53,7 @@ export default Model.extend({
     return permissions;
   }.property(),
 
-  adminPermissions: function() {
+  adminPermissions: function () {
     var permissions;
     permissions = Ember.ArrayProxy.create({
       content: []
@@ -64,7 +64,7 @@ export default Model.extend({
     return permissions;
   }.property(),
 
-  pullPermissions: function() {
+  pullPermissions: function () {
     var permissions;
     permissions = Ember.ArrayProxy.create({
       content: []
@@ -75,7 +75,7 @@ export default Model.extend({
     return permissions;
   }.property(),
 
-  pushPermissions: function() {
+  pushPermissions: function () {
     var permissions;
     permissions = Ember.ArrayProxy.create({
       content: []
@@ -86,7 +86,7 @@ export default Model.extend({
     return permissions;
   }.property(),
 
-  pushPermissionsPromise: function() {
+  pushPermissionsPromise: function () {
     return this.get('_rawPermissions').then((data) => {
       return data.pull;
     });
@@ -100,14 +100,14 @@ export default Model.extend({
     }
   },
 
-  type: function() {
+  type: function () {
     return 'user';
   }.property(),
 
   sync() {
     var self;
     self = this;
-    return this.get('ajax').post('/users/sync', {}, function() {
+    return this.get('ajax').post('/users/sync', {}, function () {
       return self.setWithSession('isSyncing', true);
     });
   },
@@ -117,7 +117,7 @@ export default Model.extend({
       var self;
       if (data.user.is_syncing) {
         self = this;
-        return setTimeout(function() {
+        return setTimeout(function () {
           return self.poll();
         }, 3000);
       } else {
@@ -137,7 +137,7 @@ export default Model.extend({
     return this.get('sessionStorage').setItem('travis.user', JSON.stringify(user));
   },
 
-  avatarUrl: function() {
+  avatarUrl: function () {
     return gravatarImage(this.get('email'), 36);
   }.property('email')
 });

--- a/app/router.js
+++ b/app/router.js
@@ -4,7 +4,7 @@ import config from './config/environment';
 import Location from 'travis/utils/location';
 
 var Router = Ember.Router.extend({
-  location: function() {
+  location: function () {
     if (Ember.testing) {
       return 'none';
     } else {
@@ -39,17 +39,17 @@ var Router = Ember.Router.extend({
   }
 });
 
-Router.map(function() {
-  this.route('dashboard', { resetNamespace: true }, function() {
+Router.map(function () {
+  this.route('dashboard', { resetNamespace: true }, function () {
     this.route('repositories', { path: '/' });
   });
-  this.route('main', { path: '/', resetNamespace: true }, function() {
+  this.route('main', { path: '/', resetNamespace: true }, function () {
     this.route('getting_started', { resetNamespace: true });
     this.route('recent');
     this.route('repositories');
     this.route('my_repositories');
     this.route('search', { path: '/search/:phrase' });
-    this.route('repo', { path: '/:owner/:name', resetNamespace: true }, function() {
+    this.route('repo', { path: '/:owner/:name', resetNamespace: true }, function () {
       this.route('index', { path: '/' });
       this.route('branches', { path: '/branches', resetNamespace: true });
       this.route('build', { path: '/builds/:build_id', resetNamespace: true });
@@ -62,9 +62,9 @@ Router.map(function() {
         this.route('caches', { path: '/caches', resetNamespace: true });
       }
       this.route('request', { path: '/requests/:request_id', resetNamespace: true });
-      this.route('settings', { resetNamespace: true }, function() {
+      this.route('settings', { resetNamespace: true }, function () {
         this.route('index', { path: '/' });
-        this.route('env_vars', { resetNamespace: true }, function() {
+        this.route('env_vars', { resetNamespace: true }, function () {
           this.route('new');
         });
         if (config.endpoints.sshKey) {
@@ -83,13 +83,13 @@ Router.map(function() {
   this.route('plans', { path: '/plans' });
   this.route('team', { path: '/about' });
   this.route('logo', { path: '/logo' });
-  this.route('profile', { path: '/profile', resetNamespace: true }, function() {
-    this.route('accounts', { path: '/', resetNamespace: true }, function() {
+  this.route('profile', { path: '/profile', resetNamespace: true }, function () {
+    this.route('accounts', { path: '/', resetNamespace: true }, function () {
       this.route('account', { path: '/:login', resetNamespace: true });
       this.route('info', { path: '/info' });
     });
   });
-  this.route('owner', { path: '/:owner', resetNamespace: true }, function() {
+  this.route('owner', { path: '/:owner', resetNamespace: true }, function () {
     this.route('repositories', { path: '/' });
   });
   this.route('error404', { path: '/404' });

--- a/app/router.js
+++ b/app/router.js
@@ -4,7 +4,7 @@ import config from './config/environment';
 import Location from 'travis/utils/location';
 
 var Router = Ember.Router.extend({
-  location: function () {
+  location: Ember.computed(function () {
     if (Ember.testing) {
       return 'none';
     } else {
@@ -18,7 +18,7 @@ var Router = Ember.Router.extend({
         auth: Ember.getOwner(this).lookup('service:auth')
       });
     }
-  }.property(),
+  }),
 
   generate() {
     var url;

--- a/app/routes/abstract-builds.js
+++ b/app/routes/abstract-builds.js
@@ -1,7 +1,7 @@
 import TravisRoute from 'travis/routes/basic';
 
 export default TravisRoute.extend({
-  titleToken(/*model*/) {
+  titleToken(/* model*/) {
     return this.get('contentType').replace('_', ' ').capitalize();
   },
 
@@ -27,9 +27,9 @@ export default TravisRoute.extend({
     return this.controllerFor('builds').set('model', this.controllerFor('repo').get(path));
   },
 
-  path: function() {
+  path: function () {
     var type;
     type = this.get('contentType');
-    return "repo." + (type.camelize());
+    return 'repo.' + (type.camelize());
   }.property('contentType')
 });

--- a/app/routes/abstract-builds.js
+++ b/app/routes/abstract-builds.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import TravisRoute from 'travis/routes/basic';
 
 export default TravisRoute.extend({
@@ -27,9 +28,9 @@ export default TravisRoute.extend({
     return this.controllerFor('builds').set('model', this.controllerFor('repo').get(path));
   },
 
-  path: function () {
+  path: Ember.computed('contentType', function () {
     var type;
     type = this.get('contentType');
     return 'repo.' + (type.camelize());
-  }.property('contentType')
+  })
 });

--- a/app/routes/account.js
+++ b/app/routes/account.js
@@ -9,13 +9,13 @@ export default TravisRoute.extend({
     }
   },
 
-  setupController(/*controller, account*/) {
+  setupController(/* controller, account*/) {
     this._super(...arguments);
     return this.controllerFor('profile').activate('hooks');
   },
 
   model(params) {
-    return this.modelFor('accounts').find(function(account) {
+    return this.modelFor('accounts').find(function (account) {
       return account.get('login') === params.login;
     });
   },

--- a/app/routes/accounts/index.js
+++ b/app/routes/accounts/index.js
@@ -1,13 +1,13 @@
 import TravisRoute from 'travis/routes/basic';
 
 export default TravisRoute.extend({
-  redirect: function() {
+  redirect: function () {
     // TODO: setting accounts model in ProfileRoute is wrong, but
     //       at this stage it's better than what we had before
     var account, accounts, login;
     accounts = this.modelFor('accounts');
     login = this.controllerFor('currentUser').get('model.login');
-    account = accounts.find(function(account) {
+    account = accounts.find(function (account) {
       return account.get('login') === login;
     });
     return this.transitionTo('account', account);

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -12,10 +12,10 @@ export default TravisRoute.extend(BuildFaviconMixin, {
   beforeModel() {
     this._super(...arguments);
     // TODO Remove this entire method if we only call super
-    //this.get('auth').refreshUserData()
+    // this.get('auth').refreshUserData()
   },
 
-  renderTemplate: function() {
+  renderTemplate: function () {
     if (this.get('config').pro) {
       Ember.$('body').addClass('pro');
     }
@@ -47,9 +47,9 @@ export default TravisRoute.extend(BuildFaviconMixin, {
     });
   },
 
-  subscribeToRepo: function(repo) {
+  subscribeToRepo: function (repo) {
     if (this.pusher) {
-      return this.pusher.subscribe("repo-" + (repo.get('id')));
+      return this.pusher.subscribe('repo-' + (repo.get('id')));
     }
   },
 

--- a/app/routes/basic.js
+++ b/app/routes/basic.js
@@ -25,8 +25,8 @@ export default Ember.Route.extend({
     return this.controllerFor('currentUser').get('model');
   },
 
-  needsAuth: function () {
+  needsAuth: Ember.computed(function () {
     // on pro, we need to auth on every route
     return config.pro;
-  }.property()
+  })
 });

--- a/app/routes/basic.js
+++ b/app/routes/basic.js
@@ -15,7 +15,7 @@ export default Ember.Route.extend({
     }
     if (!this.signedIn() && this.get('needsAuth')) {
       this.auth.set('afterSignInTransition', transition);
-      return Ember.RSVP.reject("needs-auth");
+      return Ember.RSVP.reject('needs-auth');
     } else {
       return this._super(...arguments);
     }
@@ -25,7 +25,7 @@ export default Ember.Route.extend({
     return this.controllerFor('currentUser').get('model');
   },
 
-  needsAuth: function() {
+  needsAuth: function () {
     // on pro, we need to auth on every route
     return config.pro;
   }.property()

--- a/app/routes/branches.js
+++ b/app/routes/branches.js
@@ -16,7 +16,7 @@ export default TravisRoute.extend({
     }
 
     let path = `${apiEndpoint}/v3/repo/${repoId}/branches`;
-    let includes = `include=build.commit&limit=100`;
+    let includes = 'include=build.commit&limit=100';
     let url = `${path}?include=${includes}`;
 
     return Ember.$.ajax(url, options).then(function (response) {

--- a/app/routes/branches.js
+++ b/app/routes/branches.js
@@ -16,7 +16,7 @@ export default TravisRoute.extend({
     }
 
     let path = `${apiEndpoint}/v3/repo/${repoId}/branches`;
-    let includes = 'include=build.commit&limit=100';
+    let includes = 'build.commit&limit=100';
     let url = `${path}?include=${includes}`;
 
     return Ember.$.ajax(url, options).then(function (response) {

--- a/app/routes/branches.js
+++ b/app/routes/branches.js
@@ -3,7 +3,7 @@ import TravisRoute from 'travis/routes/basic';
 import config from 'travis/config/environment';
 
 export default TravisRoute.extend({
-  model(/*params*/) {
+  model(/* params*/) {
     var allTheBranches, apiEndpoint, options, repoId;
     apiEndpoint = config.apiEndpoint;
     repoId = this.modelFor('repo').get('id');
@@ -11,10 +11,10 @@ export default TravisRoute.extend({
     options = {};
     if (this.get('auth.signedIn')) {
       options.headers = {
-        Authorization: "token " + (this.auth.token())
+        Authorization: 'token ' + (this.auth.token())
       };
     }
-    return Ember.$.ajax(apiEndpoint + "/v3/repo/" + repoId + "/branches?include=build.commit&limit=100", options).then(function(response) {
+    return Ember.$.ajax(apiEndpoint + '/v3/repo/' + repoId + '/branches?include=build.commit&limit=100', options).then(function (response) {
       allTheBranches = response.branches;
       return allTheBranches;
     });

--- a/app/routes/branches.js
+++ b/app/routes/branches.js
@@ -14,7 +14,12 @@ export default TravisRoute.extend({
         Authorization: 'token ' + (this.auth.token())
       };
     }
-    return Ember.$.ajax(apiEndpoint + '/v3/repo/' + repoId + '/branches?include=build.commit&limit=100', options).then(function (response) {
+
+    let path = `${apiEndpoint}/v3/repo/${repoId}/branches`;
+    let includes = `include=build.commit&limit=100`;
+    let url = `${path}?include=${includes}`;
+
+    return Ember.$.ajax(url, options).then(function (response) {
       allTheBranches = response.branches;
       return allTheBranches;
     });

--- a/app/routes/build.js
+++ b/app/routes/build.js
@@ -2,10 +2,10 @@ import TravisRoute from 'travis/routes/basic';
 
 export default TravisRoute.extend({
   titleToken(model) {
-    return "Build #" + (model.get('number'));
+    return 'Build #' + (model.get('number'));
   },
 
-  serialize(model/*, params*/) {
+  serialize(model/* , params*/) {
     var id;
     id = model.get ? model.get('id') : model;
     return {

--- a/app/routes/caches.js
+++ b/app/routes/caches.js
@@ -7,7 +7,7 @@ export default TravisRoute.extend({
   ajax: service(),
   needsAuth: true,
 
-  setupController(/*controller*/) {
+  setupController(/* controller*/) {
     this._super(...arguments);
     return this.controllerFor('repo').activate('caches');
   },
@@ -15,10 +15,10 @@ export default TravisRoute.extend({
   model() {
     var repo;
     repo = this.modelFor('repo');
-    return this.get('ajax').get("/repos/" + (repo.get('id')) + "/caches").then(function(data) {
+    return this.get('ajax').get('/repos/' + (repo.get('id')) + '/caches').then(function (data) {
       var branch, cache, caches, pullRequests, pushes;
       caches = {};
-      data["caches"].forEach(function(cacheData) {
+      data['caches'].forEach(function (cacheData) {
         var branch, cache;
         branch = cacheData.branch;
         cache = caches[branch];
@@ -36,10 +36,10 @@ export default TravisRoute.extend({
       for (branch in caches) {
         cache = caches[branch];
         if (/PR./.test(branch)) {
-          cache.type = "pull_request";
+          cache.type = 'pull_request';
           pullRequests.push(cache);
         } else {
-          cache.type = "push";
+          cache.type = 'push';
           pushes.push(cache);
         }
       }

--- a/app/routes/dashboard/repositories.js
+++ b/app/routes/dashboard/repositories.js
@@ -12,7 +12,7 @@ export default TravisRoute.extend({
   model() {
     var apiEndpoint;
     apiEndpoint = config.apiEndpoint;
-    let queryParams = `?repository.active=true&include=repository.default_branch,build.commit`;
+    let queryParams = '?repository.active=true&include=repository.default_branch,build.commit';
     let url = `${apiEndpoint}/v3/repos${queryParams}`;
     return Ember.$.ajax(url, {
       headers: {

--- a/app/routes/dashboard/repositories.js
+++ b/app/routes/dashboard/repositories.js
@@ -16,12 +16,12 @@ export default TravisRoute.extend({
       headers: {
         Authorization: 'token ' + this.auth.token()
       }
-    }).then(function(response) {
-      return response.repositories.filter(function(repo) {
+    }).then(function (response) {
+      return response.repositories.filter(function (repo) {
         if (repo) {
           return repo.current_build;
         }
-      }).map(function(repo) {
+      }).map(function (repo) {
         return Ember.Object.create(repo);
       });
     });

--- a/app/routes/dashboard/repositories.js
+++ b/app/routes/dashboard/repositories.js
@@ -29,5 +29,3 @@ export default TravisRoute.extend({
     });
   }
 });
-
-

--- a/app/routes/dashboard/repositories.js
+++ b/app/routes/dashboard/repositories.js
@@ -12,7 +12,9 @@ export default TravisRoute.extend({
   model() {
     var apiEndpoint;
     apiEndpoint = config.apiEndpoint;
-    return Ember.$.ajax(apiEndpoint + '/v3/repos?repository.active=true&include=repository.default_branch,build.commit', {
+    let queryParams = `?repository.active=true&include=repository.default_branch,build.commit`;
+    let url = `${apiEndpoint}/v3/repos${queryParams}`;
+    return Ember.$.ajax(url, {
       headers: {
         Authorization: 'token ' + this.auth.token()
       }

--- a/app/routes/error.js
+++ b/app/routes/error.js
@@ -1,7 +1,7 @@
 import TravisRoute from 'travis/routes/basic';
 
 export default TravisRoute.extend({
-  resetController(controller, isExiting/*, transition*/) {
+  resetController(controller, isExiting/* , transition*/) {
     if (isExiting) {
       controller.set('message', null);
       controller.set('layoutName', null);

--- a/app/routes/first-sync.js
+++ b/app/routes/first-sync.js
@@ -19,16 +19,16 @@ export default SimpleLayoutRoute.extend({
     controller = this.controllerFor('firstSync');
     if (!controller.get('isSyncing')) {
       self = this;
-      return Ember.run.later(this, function() {
+      return Ember.run.later(this, function () {
         return this.store.query('repo', {
           member: this.get('controller.user.login')
-        }).then(function(repos) {
+        }).then(function (repos) {
           if (repos.get('length')) {
             return self.transitionTo('main');
           } else {
             return self.transitionTo('profile');
           }
-        }).then(null, function(e) {
+        }).then(null, function (e) {
           // eslint-disable-next-line
           return console.log('There was a problem while redirecting from first sync', e);
         });
@@ -37,7 +37,7 @@ export default SimpleLayoutRoute.extend({
   },
 
   actions: {
-    redirectToGettingStarted: function() {
+    redirectToGettingStarted: function () {
       // do nothing, we are showing first sync, so it's normal that there is
       // no owned repos
     }

--- a/app/routes/getting-started.js
+++ b/app/routes/getting-started.js
@@ -2,13 +2,13 @@ import TravisRoute from 'travis/routes/basic';
 import Ember from 'ember';
 
 export default TravisRoute.extend({
-  beforeModel(/*transition*/) {
+  beforeModel(/* transition*/) {
     if (!Ember.isEmpty(this.store.peekAll('repo'))) {
       this.transitionTo('/');
     }
   },
 
-  setupController(/*controller*/) {
+  setupController(/* controller*/) {
     // TODO: Simply use controllerFor here.
     return Ember.getOwner(this).lookup('controller:repos').activate('owned');
   }

--- a/app/routes/home.js
+++ b/app/routes/home.js
@@ -10,7 +10,7 @@ export default BasicRoute.extend({
     return this.controllerFor('top').set('landingPage', false);
   },
 
-  setupController(controller/*, model*/) {
+  setupController(controller/* , model*/) {
     return controller.set('repos', this.get('repos'));
   }
 });

--- a/app/routes/job.js
+++ b/app/routes/job.js
@@ -2,10 +2,10 @@ import TravisRoute from 'travis/routes/basic';
 
 export default TravisRoute.extend({
   titleToken(model) {
-    return "Job #" + (model.get('number'));
+    return 'Job #' + (model.get('number'));
   },
 
-  serialize(model/*, params*/) {
+  serialize(model/* , params*/) {
     let id = model.get ? model.get('id') : model;
     return {
       job_id: id
@@ -25,7 +25,7 @@ export default TravisRoute.extend({
     model.get('repo');
     let buildPromise = model.get('build');
     if (buildPromise) {
-      buildPromise.then( (build) => {
+      buildPromise.then((build) => {
         build = this.store.recordForId('build', build.get('id'));
         return buildController.set('build', build);
       });

--- a/app/routes/main/my-repositories.js
+++ b/app/routes/main/my-repositories.js
@@ -2,6 +2,6 @@ import TravisRoute from 'travis/routes/basic';
 
 export default TravisRoute.extend({
   redirect() {
-    return this.transitionTo("main.repositories");
+    return this.transitionTo('main.repositories');
   }
 });

--- a/app/routes/owner.js
+++ b/app/routes/owner.js
@@ -30,7 +30,7 @@ export default TravisRoute.extend({
 
     error(error, /* transition, originRoute*/) {
       let is404 = error.status === 404;
-      let errorText = 'There was an error while loading data, please try again.'
+      let errorText = 'There was an error while loading data, please try again.';
       let message = is404 ? this.transitionTo('error404') : errorText;
       this.controllerFor('error').set('layoutName', 'simple');
       this.controllerFor('error').set('message', message);

--- a/app/routes/owner.js
+++ b/app/routes/owner.js
@@ -15,7 +15,11 @@ export default TravisRoute.extend({
         Authorization: 'token ' + (this.auth.token())
       };
     }
-    return Ember.$.ajax(config.apiEndpoint + ('/v3/owner/' + params.owner + '?include=organization.repositories,repository.default_branch,build.commit'), options);
+    let { owner } = params;
+    let { apiEndpoint } = config;
+    let includes = '?include=organization.repositories,repository.default_branch,build.commit';
+    let url = `${apiEndpoint}/v3/owner/${owner}${includes}`;
+    return Ember.$.ajax(url, options);
   },
 
   beforeModel() {
@@ -25,7 +29,9 @@ export default TravisRoute.extend({
   actions: {
 
     error(error, /* transition, originRoute*/) {
-      let message = error.status === 404 ? this.transitionTo('error404') : 'There was an error while loading data, please try again.';
+      let is404 = error.status === 404;
+      let errorText = 'There was an error while loading data, please try again.'
+      let message = is404 ? this.transitionTo('error404') : errorText;
       this.controllerFor('error').set('layoutName', 'simple');
       this.controllerFor('error').set('message', message);
       return true;

--- a/app/routes/owner.js
+++ b/app/routes/owner.js
@@ -12,10 +12,10 @@ export default TravisRoute.extend({
     options = {};
     if (this.get('auth.signedIn')) {
       options.headers = {
-        Authorization: "token " + (this.auth.token())
+        Authorization: 'token ' + (this.auth.token())
       };
     }
-    return Ember.$.ajax(config.apiEndpoint + ("/v3/owner/" + params.owner + "?include=organization.repositories,repository.default_branch,build.commit"), options);
+    return Ember.$.ajax(config.apiEndpoint + ('/v3/owner/' + params.owner + '?include=organization.repositories,repository.default_branch,build.commit'), options);
   },
 
   beforeModel() {
@@ -24,8 +24,8 @@ export default TravisRoute.extend({
   },
   actions: {
 
-    error(error, /*transition, originRoute*/) {
-      let message = error.status === 404 ? this.transitionTo('error404') : "There was an error while loading data, please try again.";
+    error(error, /* transition, originRoute*/) {
+      let message = error.status === 404 ? this.transitionTo('error404') : 'There was an error while loading data, please try again.';
       this.controllerFor('error').set('layoutName', 'simple');
       this.controllerFor('error').set('message', message);
       return true;

--- a/app/routes/owner/repositories.js
+++ b/app/routes/owner/repositories.js
@@ -16,11 +16,11 @@ export default TravisRoute.extend({
 
     if (this.get('auth.signedIn')) {
       options.headers = {
-        Authorization: "token " + (this.auth.token())
+        Authorization: 'token ' + (this.auth.token())
       };
     }
 
-    return Ember.$.ajax(config.apiEndpoint + ("/v3/owner/" + transition.params.owner.owner + "?include=owner.repositories,repository.default_branch,build.commit,repository.current_build"), options).then(function(response) {
+    return Ember.$.ajax(config.apiEndpoint + ('/v3/owner/' + transition.params.owner.owner + '?include=owner.repositories,repository.default_branch,build.commit,repository.current_build'), options).then(function (response) {
       return response;
     });
   }

--- a/app/routes/owner/repositories.js
+++ b/app/routes/owner/repositories.js
@@ -20,8 +20,10 @@ export default TravisRoute.extend({
       };
     }
 
-    return Ember.$.ajax(config.apiEndpoint + ('/v3/owner/' + transition.params.owner.owner + '?include=owner.repositories,repository.default_branch,build.commit,repository.current_build'), options).then(function (response) {
-      return response;
-    });
+    let includes = `?include=owner.repositories,repository.default_branch,
+      build.commit,repository.current_build`;
+    let { owner } = transition.params.owner;
+    let url = `${config.apiEndpoint}/v3/owner/${owner}${includes}`;
+    return Ember.$.get(url, options);
   }
 });

--- a/app/routes/owner/running.js
+++ b/app/routes/owner/running.js
@@ -6,10 +6,10 @@ export default TravisRoute.extend({
   needsAuth: false,
 
   titleToken(model) {
-    return "" + model.name;
+    return '' + model.name;
   },
 
   model(params, transition) {
-    return Ember.$.get(config.apiEndpoint + ("/v3/owner/" + transition.params.owner.owner + "?include=user.repositories,organization.repositories,build.commit,repository.active"));
+    return Ember.$.get(config.apiEndpoint + ('/v3/owner/' + transition.params.owner.owner + '?include=user.repositories,organization.repositories,build.commit,repository.active'));
   }
 });

--- a/app/routes/owner/running.js
+++ b/app/routes/owner/running.js
@@ -10,6 +10,9 @@ export default TravisRoute.extend({
   },
 
   model(params, transition) {
-    return Ember.$.get(config.apiEndpoint + ('/v3/owner/' + transition.params.owner.owner + '?include=user.repositories,organization.repositories,build.commit,repository.active'));
+    let includes =
+      '?include=user.repositories,organization.repositories,build.commit,repository.active';
+    let { owner } = transition.params.owner;
+    return Ember.$.get(`${config.apiEndpoint}/v3/owner/${owner}${includes}`);
   }
 });

--- a/app/routes/repo.js
+++ b/app/routes/repo.js
@@ -42,7 +42,7 @@ export default TravisRoute.extend(ScrollResetMixin, {
 
   model(params) {
     var slug;
-    slug = params.owner + "/" + params.name;
+    slug = params.owner + '/' + params.name;
     return Repo.fetchBySlug(this.get('store'), slug);
   },
 

--- a/app/routes/repo/index.js
+++ b/app/routes/repo/index.js
@@ -34,9 +34,9 @@ export default TravisRoute.extend({
   renderTemplate() {
     let controller = this.controllerFor('repo');
 
-    if(!controller.get('repo.active')) {
+    if (!controller.get('repo.active')) {
       this.render('repo/not-active');
-    } else if(!controller.get('repo.currentBuildId')) {
+    } else if (!controller.get('repo.currentBuildId')) {
       this.render('repo/no-build');
     } else {
       this.render('build');

--- a/app/routes/settings.js
+++ b/app/routes/settings.js
@@ -8,7 +8,7 @@ export default TravisRoute.extend({
   ajax: service(),
   needsAuth: true,
 
-  setupController: function(controller, model) {
+  setupController: function (controller, model) {
     this._super(...arguments);
     controller.set('repo', this.modelFor('repo'));
     this.controllerFor('repo').activate('settings');
@@ -25,12 +25,12 @@ export default TravisRoute.extend({
     var repo = this.modelFor('repo');
     var apiEndpoint = config.apiEndpoint;
 
-    return Ember.$.ajax(apiEndpoint + "/v3/repo/" + repo.get('id'), {
+    return Ember.$.ajax(apiEndpoint + '/v3/repo/' + repo.get('id'), {
       headers: {
         Authorization: 'token ' + this.auth.token()
       }
-    }).then(function(response) {
-      if(response["@permissions"]["create_cron"]) {
+    }).then(function (response) {
+      if (response['@permissions']['create_cron']) {
         return Ember.Object.create({
           enabled: true,
           jobs: repo.get('cronJobs')
@@ -54,11 +54,11 @@ export default TravisRoute.extend({
   fetchCustomSshKey() {
     var repo;
     repo = this.modelFor('repo');
-    return this.store.find('ssh_key', repo.get('id')).then((function(result) {
+    return this.store.find('ssh_key', repo.get('id')).then((function (result) {
       if (!result.get('isNew')) {
         return result;
       }
-    }), function(xhr) {
+    }), function (xhr) {
       if (xhr.status === 404) {
         return false;
       }
@@ -68,7 +68,7 @@ export default TravisRoute.extend({
   fetchSshKey() {
     var repo;
     repo = this.modelFor('repo');
-    return this.get('ajax').get("/repos/" + (repo.get('id')) + "/key", (data) => {
+    return this.get('ajax').get('/repos/' + (repo.get('id')) + '/key', (data) => {
       return Ember.Object.create({
         fingerprint: data.fingerprint
       });
@@ -79,11 +79,11 @@ export default TravisRoute.extend({
     var apiEndpoint, repoId;
     repoId = this.modelFor('repo').get('id');
     apiEndpoint = config.apiEndpoint;
-    return Ember.$.ajax(apiEndpoint + "/v3/repo/" + repoId, {
+    return Ember.$.ajax(apiEndpoint + '/v3/repo/' + repoId, {
       headers: {
         Authorization: 'token ' + this.auth.token()
       }
-    }).then(function(response) {
+    }).then(function (response) {
       return response.active;
     });
   },
@@ -91,8 +91,8 @@ export default TravisRoute.extend({
   hasPushAccess() {
     var repoId;
     repoId = parseInt(this.modelFor('repo').get('id'));
-    return this.auth.get('currentUser').get('pushPermissionsPromise').then(function(permissions) {
-      return permissions.filter(function(item) {
+    return this.auth.get('currentUser').get('pushPermissionsPromise').then(function (permissions) {
+      return permissions.filter(function (item) {
         return item === repoId;
       });
     });

--- a/app/routes/settings.js
+++ b/app/routes/settings.js
@@ -42,7 +42,6 @@ export default TravisRoute.extend({
         });
       }
     });
-
   },
 
   fetchBranches() {

--- a/app/routes/settings/index.js
+++ b/app/routes/settings/index.js
@@ -6,7 +6,7 @@ export default TravisRoute.extend({
   model() {
     var repo;
     repo = this.modelFor('repo');
-    return repo.fetchSettings().then(function(settings) {
+    return repo.fetchSettings().then(function (settings) {
       return repo.set('settings', settings);
     });
   }

--- a/app/routes/signin.js
+++ b/app/routes/signin.js
@@ -10,12 +10,10 @@ export default TravisRoute.extend({
   },
 
   activate() {
-
     if (this.auth.get('signedIn')) {
       this.transitionTo('main');
     } else {
       this.auth.signIn();
     }
   }
-
 });

--- a/app/routes/simple-layout.js
+++ b/app/routes/simple-layout.js
@@ -2,12 +2,12 @@ import Ember from 'ember';
 import TravisRoute from 'travis/routes/basic';
 
 export default TravisRoute.extend({
-  setupController: function() {
+  setupController: function () {
     Ember.$('body').attr('id', 'simple');
     this.controllerFor('repos').activate('owned');
     return this._super(...arguments);
   },
-  renderTemplate: function() {
+  renderTemplate: function () {
     return this._super(...arguments);
   }
 });

--- a/app/routes/team.js
+++ b/app/routes/team.js
@@ -212,7 +212,7 @@ export default TravisRoute.extend({
         nationality: 'usa',
         country: 'germany',
         image: 'curtis'
-      },{
+      }, {
         name: 'Joe Corcoran',
         title: 'Bulldozer',
         handle: 'josephcorcoran',

--- a/app/serializers/.eslintrc.js
+++ b/app/serializers/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  rules: {
+    // disable camelCase requirements as we interact with external API's
+    'camelcase': 0,
+  }
+}

--- a/app/serializers/build.js
+++ b/app/serializers/build.js
@@ -9,11 +9,11 @@ var Serializer = V2FallbackSerializer.extend({
     _duration: { key: 'duration' }
   },
 
-  extractRelationships: function(modelClass, resourceHash) {
+  extractRelationships: function (modelClass, resourceHash) {
     return this._super(modelClass, resourceHash);
   },
 
-  normalizeSingleResponse: function(store, primaryModelClass, payload/*, id, requestType*/) {
+  normalizeSingleResponse: function (store, primaryModelClass, payload/* , id, requestType*/) {
     if (payload.commit) {
       payload.build.commit = payload.commit;
       delete payload.build.commit_id;
@@ -21,10 +21,10 @@ var Serializer = V2FallbackSerializer.extend({
     return this._super(...arguments);
   },
 
-  normalizeArrayResponse: function(store, primaryModelClass, payload/*, id, requestType*/) {
+  normalizeArrayResponse: function (store, primaryModelClass, payload/* , id, requestType*/) {
     if (payload.commits) {
-      payload.builds.forEach(function(build) {
-        let commit = payload.commits.findBy('id', build.commit_id)
+      payload.builds.forEach(function (build) {
+        let commit = payload.commits.findBy('id', build.commit_id);
         if (commit) {
           build.commit = commit;
           return delete build.commit_id;
@@ -34,8 +34,8 @@ var Serializer = V2FallbackSerializer.extend({
     return this._super(...arguments);
   },
 
-  keyForV2Relationship: function(key/*, typeClass, method*/) {
-    if(key === 'jobs') {
+  keyForV2Relationship: function (key/* , typeClass, method*/) {
+    if (key === 'jobs') {
       return 'job_ids';
     } else if (key === 'repo') {
       return 'repository_id';
@@ -46,7 +46,7 @@ var Serializer = V2FallbackSerializer.extend({
     }
   },
 
-  keyForRelationship(key/*, typeClass, method*/) {
+  keyForRelationship(key/* , typeClass, method*/) {
     if (key === 'repo') {
       return 'repository';
     } else {
@@ -54,25 +54,25 @@ var Serializer = V2FallbackSerializer.extend({
     }
   },
 
-  normalize: function(modelClass, resourceHash) {
+  normalize: function (modelClass, resourceHash) {
     // TODO: remove this after switching to V3 entirely
-    if(!resourceHash['@type'] && resourceHash.commit && resourceHash.commit.hasOwnProperty('branch_is_default')) {
+    if (!resourceHash['@type'] && resourceHash.commit && resourceHash.commit.hasOwnProperty('branch_is_default')) {
       let build = resourceHash.build,
-          commit = resourceHash.commit;
+        commit = resourceHash.commit;
       let branch = {
         name: commit.branch,
         default_branch: commit.branch_is_default,
-        "@href": `/repo/${build.repository_id}/branch/${commit.branch}`
+        '@href': `/repo/${build.repository_id}/branch/${commit.branch}`
       };
       resourceHash.build.branch = branch;
     }
 
     // fix pusher payload, it doesn't include a branch record:
-    if(!resourceHash['@type'] && resourceHash.build &&
+    if (!resourceHash['@type'] && resourceHash.build &&
        resourceHash.repository && resourceHash.repository.default_branch) {
       let branchName = resourceHash.build.branch,
-          repository = resourceHash.repository,
-          defaultBranchName = repository.default_branch.name;
+        repository = resourceHash.repository,
+        defaultBranchName = repository.default_branch.name;
 
       resourceHash.build.branch = {
         name: branchName,

--- a/app/serializers/build.js
+++ b/app/serializers/build.js
@@ -56,7 +56,9 @@ var Serializer = V2FallbackSerializer.extend({
 
   normalize: function (modelClass, resourceHash) {
     // TODO: remove this after switching to V3 entirely
-    if (!resourceHash['@type'] && resourceHash.commit && resourceHash.commit.hasOwnProperty('branch_is_default')) {
+    let type = resourceHash['@type'];
+    let commit = resourceHash.commit;
+    if (!type && commit && commit.hasOwnProperty('branch_is_default')) {
       let build = resourceHash.build,
         commit = resourceHash.commit;
       let branch = {

--- a/app/serializers/commit.js
+++ b/app/serializers/commit.js
@@ -2,11 +2,11 @@ import V2FallbackSerializer from 'travis/serializers/v2_fallback';
 
 export default V2FallbackSerializer.extend({
   normalize(modelClass, resourceHash) {
-    if(resourceHash.author && resourceHash.author.name) {
+    if (resourceHash.author && resourceHash.author.name) {
       resourceHash.author_name = resourceHash.author.name;
       resourceHash.author_avatar_url = resourceHash.author.avatar_url;
     }
-    if(resourceHash.committer && resourceHash.committer.name) {
+    if (resourceHash.committer && resourceHash.committer.name) {
       resourceHash.committer_name = resourceHash.author.name;
       resourceHash.committer_avatar_url  = resourceHash.author.avatar_url;
     }

--- a/app/serializers/hook.js
+++ b/app/serializers/hook.js
@@ -1,7 +1,7 @@
 import ApplicationSerializer from 'travis/serializers/application';
 
 export default ApplicationSerializer.extend({
-  serialize(/*snapshot, options*/) {
+  serialize(/* snapshot, options*/) {
     return { hook: this._super(...arguments) };
   }
 });

--- a/app/serializers/job.js
+++ b/app/serializers/job.js
@@ -5,7 +5,7 @@ export default V2FallbackSerializer.extend({
   attrs: {
     _config: { key: 'config' },
     _finishedAt: { key: 'finished_at' },
-    _startedAt:  { key: 'started_at' }
+    _startedAt: { key: 'started_at' }
   },
 
   keyForV2Relationship(key/* , typeClass, method*/) {

--- a/app/serializers/job.js
+++ b/app/serializers/job.js
@@ -8,7 +8,7 @@ export default V2FallbackSerializer.extend({
     _startedAt:  { key: 'started_at' }
   },
 
-  keyForV2Relationship(key/*, typeClass, method*/) {
+  keyForV2Relationship(key/* , typeClass, method*/) {
     if (key === 'repo') {
       return 'repository_id';
     } else {
@@ -24,7 +24,7 @@ export default V2FallbackSerializer.extend({
     return this._super(modelClass, resourceHash);
   },
 
-  normalizeSingleResponse: function(store, primaryModelClass, payload/*, id, requestType*/) {
+  normalizeSingleResponse: function (store, primaryModelClass, payload/* , id, requestType*/) {
     if (payload.commit) {
       payload.job.commit = payload.commit;
       delete payload.job.commit_id;
@@ -32,10 +32,10 @@ export default V2FallbackSerializer.extend({
     return this._super(...arguments);
   },
 
-  normalizeArrayResponse: function(store, primaryModelClass, payload/*, id, requestType*/) {
+  normalizeArrayResponse: function (store, primaryModelClass, payload/* , id, requestType*/) {
     if (payload.commits) {
-      payload.jobs.forEach(function(job) {
-        let commit = payload.commits.findBy('id', job.commit_id)
+      payload.jobs.forEach(function (job) {
+        let commit = payload.commits.findBy('id', job.commit_id);
         if (commit) {
           job.commit = commit;
           return delete job.commit_id;

--- a/app/serializers/repo.js
+++ b/app/serializers/repo.js
@@ -12,7 +12,7 @@ var Serializer = V2FallbackSerializer.extend(EmbeddedRecordsMixin, {
   // },
 
   normalizeResponse(store, primaryModelClass, payload, id, requestType) {
-    if(!id && requestType === 'findRecord') {
+    if (!id && requestType === 'findRecord') {
       id = payload.id;
     }
 

--- a/app/serializers/request.js
+++ b/app/serializers/request.js
@@ -3,7 +3,7 @@ import V2FallbackSerializer from 'travis/serializers/v2_fallback';
 var Serializer = V2FallbackSerializer.extend({
   isNewSerializerAPI: true,
 
-  keyForV2Relationship: function(key/*, typeClass, method*/) {
+  keyForV2Relationship: function (key/* , typeClass, method*/) {
     if (key === 'repo') {
       return 'repository_id';
     } else {
@@ -11,10 +11,10 @@ var Serializer = V2FallbackSerializer.extend({
     }
   },
 
-  normalizeArrayResponse: function(store, primaryModelClass, payload/*, id, requestType*/) {
+  normalizeArrayResponse: function (store, primaryModelClass, payload/* , id, requestType*/) {
     if (payload.commits) {
-      payload.requests.forEach(function(request) {
-        let commit = commit = payload.commits.findBy('id', request.commit_id)
+      payload.requests.forEach(function (request) {
+        let commit = commit = payload.commits.findBy('id', request.commit_id);
         if (commit) {
           request.commit = commit;
           return delete request.commit_id;

--- a/app/serializers/ssh_key.js
+++ b/app/serializers/ssh_key.js
@@ -1,7 +1,7 @@
 import ApplicationSerializer from 'travis/serializers/application';
 
 export default ApplicationSerializer.extend({
-  serialize(/*snapshot, options*/) {
+  serialize(/* snapshot, options*/) {
     return { ssh_key: this._super(...arguments) };
   },
 

--- a/app/serializers/v2_fallback.js
+++ b/app/serializers/v2_fallback.js
@@ -4,7 +4,7 @@ export default V3Serializer.extend({
   isNewSerializerAPI: true,
 
   extractRelationships(modelClass, resourceHash) {
-    if(resourceHash['@type']) {
+    if (resourceHash['@type']) {
       return this._super(...arguments);
     } else {
       let relationships = {};
@@ -36,13 +36,13 @@ export default V3Serializer.extend({
   },
 
   normalize(modelClass, resourceHash) {
-    if(resourceHash['@type']) {
+    if (resourceHash['@type']) {
       return this._super(...arguments);
     } else {
       var modelKey = modelClass.modelName;
       var attributes = resourceHash[modelKey];
-      if(attributes) {
-        for(var key in attributes) {
+      if (attributes) {
+        for (var key in attributes) {
           resourceHash[key] = attributes[key];
         }
 
@@ -51,33 +51,33 @@ export default V3Serializer.extend({
       }
 
       let { data, included } = this._super(...arguments);
-      if(!included) {
+      if (!included) {
         included = [];
       }
       let store = this.store;
 
-      if(data.relationships) {
+      if (data.relationships) {
         Object.keys(data.relationships).forEach(function (key) {
           let relationship = data.relationships[key];
-          let process = function(data) {
-            if(Object.keys(data).sort()+'' !== 'id,type' || (data['@href'] && data.type === 'branch')) {
+          let process = function (data) {
+            if (Object.keys(data).sort() + '' !== 'id,type' || (data['@href'] && data.type === 'branch')) {
               // no need to add records if they have only id and type
               let type = key === 'defaultBranch' ? 'branch' : key.singularize();
               let serializer = store.serializerFor(type);
               let modelClass = store.modelFor(type);
               let normalized = serializer.normalize(modelClass, data);
               included.push(normalized.data);
-              if(normalized.included) {
-                normalized.included.forEach(function(item) {
+              if (normalized.included) {
+                normalized.included.forEach(function (item) {
                   included.push(item);
                 });
               }
             }
           };
 
-          if(Array.isArray(relationship.data)) {
+          if (Array.isArray(relationship.data)) {
             relationship.data.forEach(process);
-          } else if(relationship && relationship.data) {
+          } else if (relationship && relationship.data) {
             process(relationship.data);
           }
         });
@@ -87,7 +87,7 @@ export default V3Serializer.extend({
     }
   },
 
-  keyForV2Relationship(key/*, typeClass, method*/) {
+  keyForV2Relationship(key/* , typeClass, method*/) {
     return key.underscore() + '_id';
   }
 });

--- a/app/serializers/v2_fallback.js
+++ b/app/serializers/v2_fallback.js
@@ -25,7 +25,7 @@ export default V3Serializer.extend({
             data = this.extractRelationship(relationshipMeta.type, relationshipHash);
           } else if (relationshipMeta.kind === 'hasMany') {
             data = relationshipHash.map((item) => {
-              return this.extractRelationship(relationshipMeta.type, item)
+              return this.extractRelationship(relationshipMeta.type, item);
             });
           }
           relationship = { data };

--- a/app/serializers/v3.js
+++ b/app/serializers/v3.js
@@ -78,7 +78,11 @@ export default JSONSerializer.extend({
 
     let meta = this.extractMeta(store, primaryModelClass, payload);
     if (meta) {
-      Ember.assert('The `meta` returned from `extractMeta` has to be an object, not "' + Ember.typeOf(meta) + '".', Ember.typeOf(meta) === 'object');
+      let metaType = Ember.typeOf(meta);
+      let metaIsObject = metaType == 'object';
+      let errorMessage =
+        `The 'meta' returned from 'extractMeta' has to be an object, not ${metaType}.`;
+      Ember.assert(errorMessage, metaIsObject);
       documentHash.meta = meta;
     }
 

--- a/app/serializers/v3.js
+++ b/app/serializers/v3.js
@@ -1,22 +1,22 @@
 import Ember from 'ember';
 import JSONSerializer from 'ember-data/serializers/json';
 
-var traverse = function(object, callback) {
-  if(!object) {
+var traverse = function (object, callback) {
+  if (!object) {
     return;
   }
 
-  if(typeof(object) === 'object' && !Ember.isArray(object)) {
+  if (typeof(object) === 'object' && !Ember.isArray(object)) {
     callback(object);
   }
 
-  if(Ember.isArray(object)) {
-    for(let item of object) {
+  if (Ember.isArray(object)) {
+    for (let item of object) {
       traverse(item, callback);
     }
-  } else if(typeof object === 'object') {
-    for(let key in object) {
-      if(object.hasOwnProperty(key)) {
+  } else if (typeof object === 'object') {
+    for (let key in object) {
+      if (object.hasOwnProperty(key)) {
         let item = object[key];
         traverse(item, callback);
       }
@@ -28,14 +28,14 @@ export default JSONSerializer.extend({
   isNewSerializerAPI: true,
 
   extractRelationship(type, hash) {
-    if(hash && !hash.id && hash['@href']) {
+    if (hash && !hash.id && hash['@href']) {
       hash.id = hash['@href'];
     }
 
     let relationshipHash = this._super(...arguments);
-    if(relationshipHash && relationshipHash['@type']) {
+    if (relationshipHash && relationshipHash['@type']) {
       relationshipHash.type = relationshipHash['@type'];
-    } else if(relationshipHash && !relationshipHash.type) {
+    } else if (relationshipHash && !relationshipHash.type) {
       relationshipHash.type = type;
     }
     return relationshipHash;
@@ -46,18 +46,18 @@ export default JSONSerializer.extend({
     return relationships;
   },
 
-  keyForRelationship(key/*, typeClass, method*/) {
-    if(key && key.underscore) {
+  keyForRelationship(key/* , typeClass, method*/) {
+    if (key && key.underscore) {
       return key.underscore();
     } else {
       return key;
     }
   },
 
-  extractAttributes(/*modelClass,resourceHash*/) {
+  extractAttributes(/* modelClass,resourceHash*/) {
     let attributes = this._super(...arguments);
-    for(let key in attributes) {
-      if(key.startsWith('@')) {
+    for (let key in attributes) {
+      if (key.startsWith('@')) {
         delete attributes.key;
       }
     }
@@ -65,12 +65,12 @@ export default JSONSerializer.extend({
     return attributes;
   },
 
-  normalizeResponse(store, primaryModelClass, payload/*, id, requestType*/) {
+  normalizeResponse(store, primaryModelClass, payload/* , id, requestType*/) {
     this._fixReferences(payload);
     return this._super(...arguments);
   },
 
-  normalizeArrayResponse(store, primaryModelClass, payload/*, id, requestType*/) {
+  normalizeArrayResponse(store, primaryModelClass, payload/* , id, requestType*/) {
     let documentHash = {
       data: null,
       included: []
@@ -84,7 +84,7 @@ export default JSONSerializer.extend({
 
     let items;
     let type = payload['@type'];
-    if(type) {
+    if (type) {
       items = payload[type];
     } else {
       items = payload[primaryModelClass.modelName.underscore() + 's'];
@@ -101,18 +101,18 @@ export default JSONSerializer.extend({
     return documentHash;
   },
 
-  normalize(/*modelClass, resourceHash*/) {
+  normalize(/* modelClass, resourceHash*/) {
     let { data, included } = this._super(...arguments);
-    if(!included) {
+    if (!included) {
       included = [];
     }
     let store = this.store;
 
-    if(data.relationships) {
+    if (data.relationships) {
       Object.keys(data.relationships).forEach(function (key) {
         let relationship = data.relationships[key];
-        let process = function(data) {
-          if(data['@representation'] !== 'standard') {
+        let process = function (data) {
+          if (data['@representation'] !== 'standard') {
             return;
           }
           let type = data['@type'];
@@ -120,16 +120,16 @@ export default JSONSerializer.extend({
           let modelClass = store.modelFor(type);
           let normalized = serializer.normalize(modelClass, data);
           included.push(normalized.data);
-          if(normalized.included) {
-            normalized.included.forEach(function(item) {
+          if (normalized.included) {
+            normalized.included.forEach(function (item) {
               included.push(item);
             });
           }
         };
 
-        if(Array.isArray(relationship.data)) {
+        if (Array.isArray(relationship.data)) {
           relationship.data.forEach(process);
-        } else if(relationship && relationship.data) {
+        } else if (relationship && relationship.data) {
           process(relationship.data);
         }
       });
@@ -144,7 +144,7 @@ export default JSONSerializer.extend({
 
   _fixReferences(payload) {
     let byHref = {}, records;
-    if(payload['@type']) {
+    if (payload['@type']) {
       // API V3 doesn't return all of the objects in a full representation
       // If an object is present in one place in the response, all of the
       // other occurences will be just references of a kind - they will just
@@ -156,9 +156,9 @@ export default JSONSerializer.extend({
       // First we need to group all of the items in the response by href:
       traverse(payload, (item) => {
         let href = item['@href'];
-        if(href) {
+        if (href) {
           let records = byHref[href];
-          if(records) {
+          if (records) {
             records.push(item);
           } else {
             byHref[href] = [item];
@@ -168,13 +168,13 @@ export default JSONSerializer.extend({
 
       // Then we can choose a record with an id for each href and put the id
       // in all of the other occurences.
-      for(let href in byHref) {
+      for (let href in byHref) {
         records = byHref[href];
-        let recordWithAnId = records.find( (record) => record.id );
-        if(recordWithAnId) {
-          for(let record of records) {
+        let recordWithAnId = records.find((record) => record.id);
+        if (recordWithAnId) {
+          for (let record of records) {
             record.id = recordWithAnId.id;
-            //record['@type'] = recordWithAnId['@type'];
+            // record['@type'] = recordWithAnId['@type'];
           }
         }
       }

--- a/app/services/ajax.js
+++ b/app/services/ajax.js
@@ -1,11 +1,11 @@
 /* global jQuery */
 import Ember from 'ember';
 import config from 'travis/config/environment';
-var default_options;
+var defaultOptions;
 
 jQuery.support.cors = true;
 
-default_options = {
+defaultOptions = {
   accepts: {
     json: 'application/json; version=2'
   }
@@ -75,7 +75,7 @@ export default Ember.Service.extend({
       return error.call(this, data, status, xhr);
     };
 
-    options = Ember.$.extend(options, default_options);
+    options = Ember.$.extend(options, defaultOptions);
 
     if (options.data && (method === 'GET' || method === 'HEAD')) {
       params = jQuery.param(options.data);

--- a/app/services/ajax.js
+++ b/app/services/ajax.js
@@ -43,18 +43,18 @@ export default Ember.Service.extend({
 
   ajax(url, method, options) {
     var accepts, data, delimeter, endpoint, error, key, name, params, promise, ref, ref1, ref2, reject, resolve, success, token, value, xhr;
-    method = method || "GET";
+    method = method || 'GET';
     method = method.toUpperCase();
     endpoint = config.apiEndpoint || '';
     options = options || {};
     token = Ember.get(this, 'auth').token();
     if (token && (this.needsAuth(method, url) || options.forceAuth)) {
       options.headers = options.headers || {};
-      if(!options.headers['Authorization']) {
-        options.headers['Authorization'] = "token " + token;
+      if (!options.headers['Authorization']) {
+        options.headers['Authorization'] = 'token ' + token;
       }
     }
-    options.url = url = "" + endpoint + url;
+    options.url = url = '' + endpoint + url;
     options.type = method;
     options.dataType = options.dataType || 'json';
     options.context = this;
@@ -64,11 +64,11 @@ export default Ember.Service.extend({
     if (method !== 'GET' && method !== 'HEAD') {
       options.contentType = options.contentType || 'application/json; charset=utf-8';
     }
-    success = options.success || (function() {});
-    options.success = function(data, status, xhr) {
+    success = options.success || (function () {});
+    options.success = function (data, status, xhr) {
       return success.call(this, data, status, xhr);
     };
-    error = options.error || function() {};
+    error = options.error || function () {};
     options.error = (data, status, xhr) => {
       //eslint-disable-next-line
       console.log("[ERROR] API responded with an error (" + status + "): " + (JSON.stringify(data)));
@@ -77,7 +77,7 @@ export default Ember.Service.extend({
 
     options = Ember.$.extend(options, default_options);
 
-    if (options.data && (method === "GET" || method === "HEAD")) {
+    if (options.data && (method === 'GET' || method === 'HEAD')) {
       params = jQuery.param(options.data);
       delimeter = url.indexOf('?') === -1 ? '?' : '&';
       url = url + delimeter + params;
@@ -105,15 +105,15 @@ export default Ember.Service.extend({
     }
     resolve = null;
     reject = null;
-    promise = new Ember.RSVP.Promise(function(_resolve, _reject) {
+    promise = new Ember.RSVP.Promise(function (_resolve, _reject) {
       resolve = _resolve;
       return reject = _reject;
     });
-    xhr.onreadystatechange = function() {
+    xhr.onreadystatechange = function () {
       var contentType, data;
       if (xhr.readyState === 4) {
         contentType = xhr.getResponseHeader('Content-Type');
-        data = (function() {
+        data = (function () {
           if (contentType && contentType.match(/application\/json/)) {
             try {
               return jQuery.parseJSON(xhr.responseText);
@@ -135,7 +135,7 @@ export default Ember.Service.extend({
       }
     };
     data = options.data;
-    if (typeof options.data === "object" && (Ember.isNone(options.contentType) || options.contentType.match(/application\/json/))) {
+    if (typeof options.data === 'object' && (Ember.isNone(options.contentType) || options.contentType.match(/application\/json/))) {
       data = JSON.stringify(data);
     }
     if (data) {

--- a/app/services/ajax.js
+++ b/app/services/ajax.js
@@ -42,9 +42,9 @@ export default Ember.Service.extend({
   },
 
   ajax(url, method, options) {
-    var accepts, data, delimeter, endpoint, error, key, name, params, promise, ref, ref1, ref2, reject, resolve, success, token, value, xhr;
-    method = method || 'GET';
-    method = method.toUpperCase();
+    var accepts, data, delimeter, endpoint, error, key, name, params,
+      promise, ref, ref1, ref2, reject, resolve, success, token, value, xhr;
+    method = (method || 'GET').toUpperCase();
     endpoint = config.apiEndpoint || '';
     options = options || {};
     token = Ember.get(this, 'auth').token();
@@ -135,7 +135,9 @@ export default Ember.Service.extend({
       }
     };
     data = options.data;
-    if (typeof options.data === 'object' && (Ember.isNone(options.contentType) || options.contentType.match(/application\/json/))) {
+    let contentType = options.contentType;
+    let isJSON = Ember.isNone(contentType) || contentType.match(/application\/json/);
+    if (typeof options.data === 'object' && isJSON) {
       data = JSON.stringify(data);
     }
     if (data) {

--- a/app/services/auth.js
+++ b/app/services/auth.js
@@ -66,7 +66,8 @@ export default Ember.Service.extend({
         // so log the user out. Also log the user out if the response is 401
         // or 403
         if (!xhr || (xhr.status === 401 || xhr.status === 403)) {
-          this.get('flashes').error("You've been signed out, because your access token has expired.");
+          let errorText = "You've been signed out, because your access token has expired."
+          this.get('flashes').error(errorText);
           this.signOut();
         }
       });
@@ -135,7 +136,8 @@ export default Ember.Service.extend({
 
   refreshUserData(user) {
     if (!user) {
-      let data = this.userDataFrom(this.get('sessionStorage')) || this.userDataFrom(this.get('storage'));
+      let data = this.userDataFrom(this.get('sessionStorage')) ||
+                 this.userDataFrom(this.get('storage'));
       if (data) {
         user = data.user;
       }
@@ -193,7 +195,8 @@ export default Ember.Service.extend({
   receiveMessage(event) {
     if (event.origin === this.expectedOrigin()) {
       if (event.data === 'redirect') {
-        return window.location = (this.get('endpoint')) + '/auth/handshake?redirect_uri=' + location;
+        let endpoint = this.get('endpoint');
+        window.location = `${endpoint}/auth/handshake?redirect_uri=${location}`;
       } else if (event.data.user != null) {
         if (event.data.travis_token) {
           event.data.user.token = event.data.travis_token;
@@ -241,7 +244,8 @@ export default Ember.Service.extend({
   }),
 
   gravatarUrl: Ember.computed('currentUser.gravatarId', function () {
-    return location.protocol + '//www.gravatar.com/avatar/' + (this.get('currentUser.gravatarId')) + '?s=48&d=mm';
+    let gravatarId = this.get('currentUser.gravatarId');
+    return `${location.protocol}//www.gravatar.com/avatar/${gravatarId}?s=48&d=mm`;
   }),
 
   permissions: Ember.computed.alias('currentUser.permissions')

--- a/app/services/auth.js
+++ b/app/services/auth.js
@@ -23,9 +23,9 @@ export default Ember.Service.extend({
     return this.get('sessionStorage').getItem('travis.token');
   },
 
-  endpoint: function () {
+  endpoint: Ember.computed(function () {
     return config.authEndpoint || config.apiEndpoint;
-  }.property(),
+  }),
 
   signOut: function () {
     this.get('sessionStorage').clear();
@@ -161,17 +161,17 @@ export default Ember.Service.extend({
     }
   },
 
-  signedIn: function () {
+  signedIn: Ember.computed('state', function () {
     return this.get('state') === 'signed-in';
-  }.property('state'),
+  }),
 
-  signedOut: function () {
+  signedOut: Ember.computed('state', function () {
     return this.get('state') === 'signed-out';
-  }.property('state'),
+  }),
 
-  signingIn: function () {
+  signingIn: Ember.computed('state', function () {
     return this.get('state') === 'signing-in';
-  }.property('state'),
+  }),
 
   storeData(data, storage) {
     if (data.token) {
@@ -236,13 +236,13 @@ export default Ember.Service.extend({
     }
   },
 
-  userName: function () {
+  userName: Ember.computed('currentUser.login', 'currentUser.name', function () {
     return this.get('currentUser.name') || this.get('currentUser.login');
-  }.property('currentUser.login', 'currentUser.name'),
+  }),
 
-  gravatarUrl: function () {
+  gravatarUrl: Ember.computed('currentUser.gravatarId', function () {
     return location.protocol + '//www.gravatar.com/avatar/' + (this.get('currentUser.gravatarId')) + '?s=48&d=mm';
-  }.property('currentUser.gravatarId'),
+  }),
 
   permissions: Ember.computed.alias('currentUser.permissions')
 });

--- a/app/services/auth.js
+++ b/app/services/auth.js
@@ -66,7 +66,7 @@ export default Ember.Service.extend({
         // so log the user out. Also log the user out if the response is 401
         // or 403
         if (!xhr || (xhr.status === 401 || xhr.status === 403)) {
-          let errorText = "You've been signed out, because your access token has expired."
+          let errorText = "You've been signed out, because your access token has expired.";
           this.get('flashes').error(errorText);
           this.signOut();
         }

--- a/app/services/auth.js
+++ b/app/services/auth.js
@@ -10,10 +10,10 @@ export default Ember.Service.extend({
   storage: service(),
   sessionStorage: service(),
   ajax: service(),
-  state: "signed-out",
-  receivingEnd: location.protocol + "//" + location.host,
+  state: 'signed-out',
+  receivingEnd: location.protocol + '//' + location.host,
 
-  init: function() {
+  init: function () {
     return window.addEventListener('message', (e) => {
       return this.receiveMessage(e);
     });
@@ -23,11 +23,11 @@ export default Ember.Service.extend({
     return this.get('sessionStorage').getItem('travis.token');
   },
 
-  endpoint: function() {
+  endpoint: function () {
     return config.authEndpoint || config.apiEndpoint;
   }.property(),
 
-  signOut: function() {
+  signOut: function () {
     this.get('sessionStorage').clear();
     this.get('storage').clear();
     this.set('state', 'signed-out');
@@ -47,25 +47,25 @@ export default Ember.Service.extend({
       this.autoSignIn(data);
     } else {
       this.set('state', 'signing-in');
-      url = (this.get('endpoint')) + "/auth/post_message?origin=" + this.receivingEnd;
+      url = (this.get('endpoint')) + '/auth/post_message?origin=' + this.receivingEnd;
       return Ember.$('<iframe id="auth-frame" />').hide().appendTo('body').attr('src', url);
     }
   },
 
   autoSignIn(data) {
-    if(!data) {
+    if (!data) {
       data = this.userDataFrom(this.get('sessionStorage')) ||
              this.userDataFrom(this.get('storage'));
     }
 
     if (data) {
       this.setData(data);
-      this.refreshUserData().then( () => {
+      this.refreshUserData().then(() => {
       }, (xhr) => {
         // if xhr is not defined it means that scopes are not correct,
         // so log the user out. Also log the user out if the response is 401
         // or 403
-        if(!xhr || (xhr.status === 401 || xhr.status === 403)) {
+        if (!xhr || (xhr.status === 401 || xhr.status === 403)) {
           this.get('flashes').error("You've been signed out, because your access token has expired.");
           this.signOut();
         }
@@ -105,8 +105,8 @@ export default Ember.Service.extend({
     if (config.pro) {
       fieldsToValidate.push('channels');
     }
-    return fieldsToValidate.every((function(_this) {
-      return function(field) {
+    return fieldsToValidate.every((function (_this) {
+      return function (field) {
         return _this.validateHas(field, user);
       };
     })(this)) && (isTravisBecome || user.correct_scopes);
@@ -141,7 +141,7 @@ export default Ember.Service.extend({
       }
     }
     if (user) {
-      return this.get('ajax').get("/users/" + user.id).then( (data) => {
+      return this.get('ajax').get('/users/' + user.id).then((data) => {
         var userRecord;
         if (data.user.correct_scopes) {
           userRecord = this.loadUser(data.user);
@@ -161,15 +161,15 @@ export default Ember.Service.extend({
     }
   },
 
-  signedIn: function() {
+  signedIn: function () {
     return this.get('state') === 'signed-in';
   }.property('state'),
 
-  signedOut: function() {
+  signedOut: function () {
     return this.get('state') === 'signed-out';
   }.property('state'),
 
-  signingIn: function() {
+  signingIn: function () {
     return this.get('state') === 'signing-in';
   }.property('state'),
 
@@ -182,9 +182,9 @@ export default Ember.Service.extend({
 
   loadUser(user) {
     var store = this.get('store'),
-        userClass = store.modelFor('user'),
-        serializer = store.serializerFor('user'),
-        normalized = serializer.normalizeResponse(store, userClass, user, null, 'findRecord');
+      userClass = store.modelFor('user'),
+      serializer = store.serializerFor('user'),
+      normalized = serializer.normalizeResponse(store, userClass, user, null, 'findRecord');
 
     store.push(normalized);
     return store.recordForId('user', user.id);
@@ -193,7 +193,7 @@ export default Ember.Service.extend({
   receiveMessage(event) {
     if (event.origin === this.expectedOrigin()) {
       if (event.data === 'redirect') {
-        return window.location = (this.get('endpoint')) + "/auth/handshake?redirect_uri=" + location;
+        return window.location = (this.get('endpoint')) + '/auth/handshake?redirect_uri=' + location;
       } else if (event.data.user != null) {
         if (event.data.travis_token) {
           event.data.user.token = event.data.travis_token;
@@ -236,12 +236,12 @@ export default Ember.Service.extend({
     }
   },
 
-  userName: function() {
+  userName: function () {
     return this.get('currentUser.name') || this.get('currentUser.login');
   }.property('currentUser.login', 'currentUser.name'),
 
-  gravatarUrl: function() {
-    return location.protocol + "//www.gravatar.com/avatar/" + (this.get('currentUser.gravatarId')) + "?s=48&d=mm";
+  gravatarUrl: function () {
+    return location.protocol + '//www.gravatar.com/avatar/' + (this.get('currentUser.gravatarId')) + '?s=48&d=mm';
   }.property('currentUser.gravatarId'),
 
   permissions: Ember.computed.alias('currentUser.permissions')

--- a/app/services/flashes.js
+++ b/app/services/flashes.js
@@ -22,7 +22,7 @@ export default Ember.Service.extend({
     }));
   },
 
-  messages: function () {
+  messages: Ember.computed('flashes.[]', 'flashes.length', function () {
     var flashes, model;
 
     flashes = this.get('flashes');
@@ -31,7 +31,7 @@ export default Ember.Service.extend({
       model.pushObjects(flashes.toArray().reverse());
     }
     return model.uniq();
-  }.property('flashes.[]', 'flashes.length'),
+  }),
 
   // TODO: when we rewrite all of the place where we use `loadFlashes` we could
   // rewrite this class and make the implementation better, because right now

--- a/app/services/flashes.js
+++ b/app/services/flashes.js
@@ -22,7 +22,7 @@ export default Ember.Service.extend({
     }));
   },
 
-  messages: function() {
+  messages: function () {
     var flashes, model;
 
     flashes = this.get('flashes');
@@ -75,7 +75,7 @@ export default Ember.Service.extend({
   },
 
   display(type, message) {
-    if(!['error', 'notice', 'success'].contains(type)) {
+    if (!['error', 'notice', 'success'].contains(type)) {
       // eslint-disable-next-line
       console.warn("WARNING: <service:flashes> display(type, message) function can only handle 'error', 'notice' and 'success' types");
     }

--- a/app/services/permissions.js
+++ b/app/services/permissions.js
@@ -18,8 +18,8 @@ export default Ember.Service.extend({
   all: Ember.computed('currentUser.permissions', 'currentUser.permissions.[]',
          'currentUser.pushPermissions', 'currentUser.pushPermissions.[]',
          'currentUser.adminPermissions', 'currentUser.adminPermissions.[]',
-         function() {
-            return;
+         function () {
+           return;
          }),
 
   hasPermission(repo) {
@@ -37,7 +37,7 @@ export default Ember.Service.extend({
   checkPermission(repo, permissionsType) {
     let id = isNaN(repo) ? repo.get('id') : repo;
     let currentUser = this.get('currentUser');
-    if(currentUser) {
+    if (currentUser) {
       return currentUser.get(permissionsType).contains(parseInt(id));
     } else {
       return false;

--- a/app/services/polling.js
+++ b/app/services/polling.js
@@ -57,16 +57,16 @@ export default Ember.Service.extend({
   },
 
   poll() {
-    this.get('watchedModels').forEach(function(model) {
+    this.get('watchedModels').forEach(function (model) {
       return model.reload();
     });
 
-    return this.get('sources').forEach( (source) => {
-     if (Ember.get(source, 'isDestroyed')) {
-       return this.get('sources').removeObject(source);
-     } else {
-       return source.pollHook();
-     }
+    return this.get('sources').forEach((source) => {
+      if (Ember.get(source, 'isDestroyed')) {
+        return this.get('sources').removeObject(source);
+      } else {
+        return source.pollHook();
+      }
     });
   }
 });

--- a/app/services/popup.js
+++ b/app/services/popup.js
@@ -4,9 +4,9 @@ export default Ember.Service.extend({
   open(name) {
     var ref;
     this.close();
-    name = (typeof event !== "undefined" && event !== null ? (ref = event.target) != null ? ref.name : void 0 : void 0) || name;
+    name = (typeof event !== 'undefined' && event !== null ? (ref = event.target) != null ? ref.name : void 0 : void 0) || name;
     this.set('popupName', name);
-    Ember.$("#" + name).toggleClass('display');
+    Ember.$('#' + name).toggleClass('display');
   },
 
   close() {

--- a/app/services/popup.js
+++ b/app/services/popup.js
@@ -2,9 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Service.extend({
   open(name) {
-    var ref;
     this.close();
-    name = (typeof event !== 'undefined' && event !== null ? (ref = event.target) != null ? ref.name : void 0 : void 0) || name;
     this.set('popupName', name);
     Ember.$('#' + name).toggleClass('display');
   },

--- a/app/services/session-storage.js
+++ b/app/services/session-storage.js
@@ -2,7 +2,7 @@ import StorageService from 'travis/services/storage';
 import Storage from 'travis/utils/hash-storage';
 
 export default StorageService.extend({
-  init: function() {
+  init: function () {
     let storage;
     try {
       // firefox will not throw error on access for sessionStorage var,

--- a/app/services/storage.js
+++ b/app/services/storage.js
@@ -2,10 +2,10 @@ import Ember from 'ember';
 import Storage from 'travis/utils/hash-storage';
 
 export default Ember.Service.extend({
-  init: function() {
+  init: function () {
     let storage;
     try {
-      storage = window.localStorage || (function() {
+      storage = window.localStorage || (function () {
         throw 'no storage';
       })();
     } catch (error) {
@@ -13,16 +13,16 @@ export default Ember.Service.extend({
     }
     return this.set('storage', storage);
   },
-  getItem: function(key) {
-    return this.get("storage").getItem(key);
+  getItem: function (key) {
+    return this.get('storage').getItem(key);
   },
-  setItem: function(key, value) {
-    return this.get("storage").setItem(key, value);
+  setItem: function (key, value) {
+    return this.get('storage').setItem(key, value);
   },
-  removeItem: function(key) {
-    return this.get("storage").removeItem(key);
+  removeItem: function (key) {
+    return this.get('storage').removeItem(key);
   },
-  clear: function() {
-    return this.get("storage").clear();
+  clear: function () {
+    return this.get('storage').clear();
   }
 });

--- a/app/services/store.js
+++ b/app/services/store.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import DS from 'ember-data';
 import Ember from 'ember';
 

--- a/app/services/store.js
+++ b/app/services/store.js
@@ -106,12 +106,12 @@ export default DS.Store.extend({
       // we need to get it here, if it's not already in the store. In the future
       // we may decide to make this relationship async, but I don't want to
       // change the code at the moment
-      let lastBuild = this.peekRecord('build', last_build_id)
+      let lastBuild = this.peekRecord('build', last_build_id);
       if (!last_build_id || lastBuild) {
         return this.push(this.normalize('repo', data));
       } else {
-        return this.findRecord('build', last_build_id).then((function(_this) {
-          return function() {
+        return this.findRecord('build', last_build_id).then((function (_this) {
+          return function () {
             return _this.push(_this.normalize('repo', data));
           };
         })(this));

--- a/app/services/update-times.js
+++ b/app/services/update-times.js
@@ -1,6 +1,6 @@
 /* global Visibility */
 import Ember from 'ember';
-import Config from 'travis/config/environment';
+import config from 'travis/config/environment';
 import eventually from 'travis/utils/eventually';
 
 export default Ember.Service.extend({
@@ -8,8 +8,16 @@ export default Ember.Service.extend({
   allowFinishedBuilds: false,
 
   init() {
-    this.set('visibilityId', Visibility.every(Config.intervals.updateTimes, this.updateTimes.bind(this)));
-    this.set('intervalId', setInterval(this.resetAllowFinishedBuilds.bind(this), 60000));
+    let visibilityId = Visibility.every(
+      config.intervals.updateTimes,
+      this.updateTimes.bind(this)
+    );
+    this.set('visibilityId', visibilityId);
+    let intervalId = setInterval(
+      this.resetAllowFinishedBuilds.bind(this),
+      60000
+    );
+    this.set('intervalId', intervalId);
 
     return this._super(...arguments);
   },

--- a/app/services/update-times.js
+++ b/app/services/update-times.js
@@ -30,8 +30,8 @@ export default Ember.Service.extend({
     records.filter((record) => {
       return this.get('allowFinishedBuilds') || !record.get('isFinished');
     }).forEach((record) => {
-      eventually(record, function(resolvedRecord) {
-        if(resolvedRecord) {
+      eventually(record, function (resolvedRecord) {
+        if (resolvedRecord) {
           resolvedRecord.updateTimes();
         }
       });
@@ -39,7 +39,7 @@ export default Ember.Service.extend({
 
     this.set('records', []);
 
-    if(this.get('allowFinishedBuilds')) {
+    if (this.get('allowFinishedBuilds')) {
       this.set('allowFinishedBuilds', false);
     }
   },
@@ -47,16 +47,16 @@ export default Ember.Service.extend({
   pushObject(record) {
     let records = this.get('records');
 
-    if(!records.contains(record)) {
+    if (!records.contains(record)) {
       records.pushObject(record);
     }
   },
 
   push(model) {
-    if(!model) { return; }
+    if (!model) { return; }
 
-    if(model.forEach) {
-      model.forEach( (element) => {
+    if (model.forEach) {
+      model.forEach((element) => {
         this.pushObject(element);
       });
     } else {

--- a/app/transforms/object.js
+++ b/app/transforms/object.js
@@ -1,10 +1,10 @@
 import DS from 'ember-data';
 
 export default DS.Transform.extend({
-  deserialize: function(serialized) {
+  deserialize: function (serialized) {
     return serialized;
   },
-  serialize: function(deserialized) {
+  serialize: function (deserialized) {
     return deserialized;
   }
 });

--- a/app/utils/.eslintrc.js
+++ b/app/utils/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  rules: {
+    // disable func-names for utils as they are mainly a collection
+    // of vanilla JS functions. Not sure how to fix yet.
+    'func-names': 0,
+  }
+}

--- a/app/utils/.eslintrc.js
+++ b/app/utils/.eslintrc.js
@@ -3,5 +3,8 @@ module.exports = {
     // disable func-names for utils as they are mainly a collection
     // of vanilla JS functions. Not sure how to fix yet.
     'func-names': 0,
+    // disable function length checks for the time being. These all
+    // need refactoring anyway (at some point).
+    'max-len': 0
   }
 }

--- a/app/utils/computed-limit.js
+++ b/app/utils/computed-limit.js
@@ -1,9 +1,9 @@
 import Ember from 'ember';
 
-var limit = function(dependentKey, limitKey) {
-  return Ember.computed(dependentKey, dependentKey + ".[]", function() {
+var limit = function (dependentKey, limitKey) {
+  return Ember.computed(dependentKey, dependentKey + '.[]', function () {
     var limit = Ember.get(this, limitKey),
-        array = this.get(dependentKey);
+      array = this.get(dependentKey);
 
     return array.toArray().slice(0, limit);
   });

--- a/app/utils/eventually.js
+++ b/app/utils/eventually.js
@@ -1,6 +1,6 @@
-export default function(anObjectOrAPromise, callback) {
-  if(anObjectOrAPromise.then) {
-    anObjectOrAPromise.then(function(result) {
+export default function (anObjectOrAPromise, callback) {
+  if (anObjectOrAPromise.then) {
+    anObjectOrAPromise.then(function (result) {
       callback(result);
     });
   } else {

--- a/app/utils/expandable-record-array.js
+++ b/app/utils/expandable-record-array.js
@@ -4,12 +4,12 @@ export default Ember.ArrayProxy.extend({
   isLoaded: false,
   isLoading: false,
 
-  promise: function() {
+  promise: function () {
     var self;
     self = this;
-    return new Ember.RSVP.Promise(function(resolve) {
+    return new Ember.RSVP.Promise(function (resolve) {
       var observer;
-      observer = function() {
+      observer = function () {
         if (self.get('isLoaded')) {
           resolve(self);
           self.removeObserver('isLoaded', observer);
@@ -24,9 +24,9 @@ export default Ember.ArrayProxy.extend({
 
   load(array) {
     this.set('isLoading', true);
-    return array.then((function(_this) {
-      return function() {
-        array.forEach(function(record) {
+    return array.then((function (_this) {
+      return function () {
+        array.forEach(function (record) {
           if (!_this.contains(record)) {
             return _this.pushObject(record);
           }

--- a/app/utils/expandable-record-array.js
+++ b/app/utils/expandable-record-array.js
@@ -4,7 +4,7 @@ export default Ember.ArrayProxy.extend({
   isLoaded: false,
   isLoading: false,
 
-  promise: function () {
+  promise: Ember.computed(function () {
     var self;
     self = this;
     return new Ember.RSVP.Promise(function (resolve) {
@@ -20,7 +20,7 @@ export default Ember.ArrayProxy.extend({
         return self.addObserver('isLoaded', observer);
       }
     });
-  }.property(),
+  }),
 
   load(array) {
     this.set('isLoading', true);

--- a/app/utils/favicon-data-uris.js
+++ b/app/utils/favicon-data-uris.js
@@ -1,4 +1,4 @@
-var __inlineImageDataUri__ = function() {}; // in case image inliner doesn't run
+var __inlineImageDataUri__ = function () {}; // in case image inliner doesn't run
 
 var uris = {
   default: __inlineImageDataUri__('favicon.png'),
@@ -8,6 +8,6 @@ var uris = {
   yellow: __inlineImageDataUri__('favicon-yellow.png')
 };
 
-export default function(type) {
+export default function (type) {
   return uris[type] || uris.default;
 }

--- a/app/utils/favicon-manager.js
+++ b/app/utils/favicon-manager.js
@@ -1,21 +1,21 @@
-var manager = function(headTag) {
+var manager = function (headTag) {
   if (headTag) {
     this.headTag = headTag;
   }
   return this;
 };
 
-manager.prototype.getHeadTag = function() {
+manager.prototype.getHeadTag = function () {
   return this.headTag || document.getElementsByTagName('head')[0];
 };
 
-manager.prototype.setFavicon = function(href) {
+manager.prototype.setFavicon = function (href) {
   var head, link, oldLink;
   head = this.getHeadTag();
   oldLink = this.getLinkTag();
   link = this.createLinkTag();
   head.appendChild(link);
-  setTimeout(function() {
+  setTimeout(function () {
     return link.setAttribute('href', href);
   }, 10);
   if (oldLink) {
@@ -23,7 +23,7 @@ manager.prototype.setFavicon = function(href) {
   }
 };
 
-manager.prototype.getLinkTag = function() {
+manager.prototype.getLinkTag = function () {
   var i, len, link, links;
   links = this.getHeadTag().getElementsByTagName('link');
   if (links.length) {
@@ -36,7 +36,7 @@ manager.prototype.getLinkTag = function() {
   }
 };
 
-manager.prototype.createLinkTag = function() {
+manager.prototype.createLinkTag = function () {
   var link;
   link = document.createElement('link');
   link.setAttribute('rel', 'icon');

--- a/app/utils/hash-storage.js
+++ b/app/utils/hash-storage.js
@@ -1,22 +1,22 @@
 import Ember from 'ember';
 
 export default Ember.Object.extend({
-  init: function() {
+  init: function () {
     return this.set('storage', {});
   },
-  key: function(key) {
-    return "__" + (key.replace('.', '__'));
+  key: function (key) {
+    return '__' + (key.replace('.', '__'));
   },
-  getItem: function(k) {
-    return this.get("storage." + (this.key(k)));
+  getItem: function (k) {
+    return this.get('storage.' + (this.key(k)));
   },
-  setItem: function(k, v) {
-    return this.set("storage." + (this.key(k)), v);
+  setItem: function (k, v) {
+    return this.set('storage.' + (this.key(k)), v);
   },
-  removeItem: function(k) {
+  removeItem: function (k) {
     return this.setItem(k, null);
   },
-  clear: function() {
+  clear: function () {
     return this.set('storage', {});
   }
 });

--- a/app/utils/helpers.js
+++ b/app/utils/helpers.js
@@ -6,24 +6,24 @@ import config from 'travis/config/environment';
 import Ember from 'ember';
 
 var _emojize, _escape, _githubCommitReferenceLink, _githubCommitReferenceRegexp,
-    _githubReferenceLink, _githubReferenceRegexp, _githubUserLink, _githubUserRegexp,
-    _normalizeDateString, _nowUtc, _toUtc, colorForState, colors, compact, configKeys,
-    durationFrom, formatCommit, formatConfig, formatMessage, formatSha, githubify,
-    intersect, mapObject, only, pathFrom, safe, timeAgoInWords, timeInWords, timeago;
+  _githubReferenceLink, _githubReferenceRegexp, _githubUserLink, _githubUserRegexp,
+  _normalizeDateString, _nowUtc, _toUtc, colorForState, colors, compact, configKeys,
+  durationFrom, formatCommit, formatConfig, formatMessage, formatSha, githubify,
+  intersect, mapObject, only, pathFrom, safe, timeAgoInWords, timeInWords, timeago;
 
 timeago = Ember.$.timeago;
 
 mapObject = Ember.$.map;
 
 colors = {
-  "default": 'yellow',
+  'default': 'yellow',
   passed: 'green',
   failed: 'red',
   errored: 'red',
   canceled: 'gray'
 };
 
-mapObject = function(elems, callback, arg) {
+mapObject = function (elems, callback, arg) {
   var key, ret, value;
   value = void 0;
   key = void 0;
@@ -37,7 +37,7 @@ mapObject = function(elems, callback, arg) {
   return ret.concat.apply([], ret);
 };
 
-only = function(object) {
+only = function (object) {
   var key, keys, result;
   keys = Array.prototype.slice.apply(arguments);
   object = (typeof keys[0] === 'object' ? keys.shift() : this);
@@ -50,13 +50,13 @@ only = function(object) {
   return result;
 };
 
-intersect = function(array, other) {
-  return array.filter(function(element) {
+intersect = function (array, other) {
+  return array.filter(function (element) {
     return other.indexOf(element) !== -1;
   });
 };
 
-compact = function(object) {
+compact = function (object) {
   var key, ref, result, value;
   result = {};
   ref = object || {};
@@ -69,29 +69,29 @@ compact = function(object) {
   return result;
 };
 
-safe = function(string) {
+safe = function (string) {
   return new Ember.Handlebars.SafeString(string);
 };
 
-colorForState = function(state) {
+colorForState = function (state) {
   return colors[state] || colors['default'];
 };
 
-formatCommit = function(sha, branch) {
-  return formatSha(sha) + (branch ? " (" + branch + ")" : '');
+formatCommit = function (sha, branch) {
+  return formatSha(sha) + (branch ? ' (' + branch + ')' : '');
 };
 
-formatSha = function(sha) {
+formatSha = function (sha) {
   return (sha || '').substr(0, 7);
 };
 
-formatConfig = function(config) {
+formatConfig = function (config) {
   var values;
   config = only(config, Object.keys(configKeysMap));
-  values = mapObject(config, function(value, key) {
+  values = mapObject(config, function (value, key) {
     value = (value && value.join ? value.join(', ') : value) || '';
-    if (key === 'rvm' && ("" + value).match(/^\d+$/)) {
-      value = value + ".0";
+    if (key === 'rvm' && ('' + value).match(/^\d+$/)) {
+      value = value + '.0';
     }
     return '%@: %@'.fmt(configKeysMap[key], value);
   });
@@ -102,7 +102,7 @@ formatConfig = function(config) {
   }
 };
 
-formatMessage = function(message, options) {
+formatMessage = function (message, options) {
   message = message || '';
   if (options.short) {
     message = message.split(/\n/)[0];
@@ -117,13 +117,13 @@ formatMessage = function(message, options) {
   return message;
 };
 
-timeAgoInWords = function(date) {
+timeAgoInWords = function (date) {
   if (date) {
     return timeago(date);
   }
 };
 
-durationFrom = function(started, finished) {
+durationFrom = function (started, finished) {
   started = started && _toUtc(new Date(_normalizeDateString(started)));
   finished = finished ? _toUtc(new Date(_normalizeDateString(finished))) : _nowUtc();
   if (started && finished) {
@@ -133,7 +133,7 @@ durationFrom = function(started, finished) {
   }
 };
 
-timeInWords = function(duration) {
+timeInWords = function (duration) {
   var days, hours, minutes, result, seconds;
   days = Math.floor(duration / 86400);
   hours = Math.floor(duration % 86400 / 3600);
@@ -163,8 +163,8 @@ timeInWords = function(duration) {
   }
 };
 
-githubify = function(text, owner, repo) {
-  text = text.replace(_githubReferenceRegexp, function(reference, matchedOwner, matchedRepo, matchedNumber) {
+githubify = function (text, owner, repo) {
+  text = text.replace(_githubReferenceRegexp, function (reference, matchedOwner, matchedRepo, matchedNumber) {
     return _githubReferenceLink(reference, {
       owner: owner,
       repo: repo
@@ -174,10 +174,10 @@ githubify = function(text, owner, repo) {
       number: matchedNumber
     });
   });
-  text = text.replace(_githubUserRegexp, function(reference, username) {
+  text = text.replace(_githubUserRegexp, function (reference, username) {
     return _githubUserLink(reference, username);
   });
-  text = text.replace(_githubCommitReferenceRegexp, function(reference, matchedOwner, matchedRepo, matchedSHA) {
+  text = text.replace(_githubCommitReferenceRegexp, function (reference, matchedOwner, matchedRepo, matchedSHA) {
     return _githubCommitReferenceLink(reference, {
       owner: owner,
       repo: repo
@@ -190,32 +190,32 @@ githubify = function(text, owner, repo) {
   return text;
 };
 
-_githubReferenceRegexp = new RegExp("([\\w-]+)?\\/?([\\w-]+)?(?:#|gh-)(\\d+)", 'g');
+_githubReferenceRegexp = new RegExp('([\\w-]+)?\\/?([\\w-]+)?(?:#|gh-)(\\d+)', 'g');
 
-_githubReferenceLink = function(reference, current, matched) {
+_githubReferenceLink = function (reference, current, matched) {
   var owner, repo;
   owner = matched.owner || current.owner;
   repo = matched.repo || current.repo;
-  return "<a href=\"" + config.sourceEndpoint + "/" + owner + "/" + repo + "/issues/" + matched.number + "\">" + reference + "</a>";
+  return '<a href="' + config.sourceEndpoint + '/' + owner + '/' + repo + '/issues/' + matched.number + '">' + reference + '</a>';
 };
 
-_githubUserRegexp = new RegExp("\\B@([\\w-]+)", 'g');
+_githubUserRegexp = new RegExp('\\B@([\\w-]+)', 'g');
 
-_githubUserLink = function(reference, username) {
-  return "<a href=\"" + config.sourceEndpoint + "/" + username + "\">" + reference + "</a>";
+_githubUserLink = function (reference, username) {
+  return '<a href="' + config.sourceEndpoint + '/' + username + '">' + reference + '</a>';
 };
 
-_githubCommitReferenceRegexp = new RegExp("([\\w-]+)?\\/([\\w-]+)?@([0-9A-Fa-f]+)", 'g');
+_githubCommitReferenceRegexp = new RegExp('([\\w-]+)?\\/([\\w-]+)?@([0-9A-Fa-f]+)', 'g');
 
-_githubCommitReferenceLink = function(reference, current, matched) {
+_githubCommitReferenceLink = function (reference, current, matched) {
   var owner, repo, url;
   owner = matched.owner || current.owner;
   repo = matched.repo || current.repo;
-  url = "" + (githubCommitUrl(owner + "/" + repo, matched.sha));
-  return "<a href=\"" + url + "\">" + reference + "</a>";
+  url = '' + (githubCommitUrl(owner + '/' + repo, matched.sha));
+  return '<a href="' + url + '">' + reference + '</a>';
 };
 
-_normalizeDateString = function(string) {
+_normalizeDateString = function (string) {
   if (window.JHW) {
     string = string.replace('T', ' ').replace(/-/g, '/');
     string = string.replace('Z', '').replace(/\..*$/, '');
@@ -223,21 +223,21 @@ _normalizeDateString = function(string) {
   return string;
 };
 
-_nowUtc = function() {
+_nowUtc = function () {
   // TODO: we overwrite Travis.currentDate in tests, so we need to leave this
   // global usage as it is for now, but it should be removed at some point
   return _toUtc(Travis.currentDate());
 };
 
-_toUtc = function(date) {
+_toUtc = function (date) {
   return Date.UTC(date.getFullYear(), date.getMonth(), date.getDate(), date.getHours(), date.getMinutes(), date.getSeconds(), date.getMilliseconds());
 };
 
-_emojize = function(text) {
+_emojize = function (text) {
   var emojis;
   emojis = text.match(/:\S+?:/g);
   if (emojis !== null) {
-    emojis.uniq().forEach(function(emoji) {
+    emojis.uniq().forEach(function (emoji) {
       var image, strippedEmoji;
       strippedEmoji = emoji.substring(1, emoji.length - 1);
       if (emojiDictionary.indexOf(strippedEmoji) !== -1) {
@@ -249,18 +249,18 @@ _emojize = function(text) {
   return text;
 };
 
-_escape = function(text) {
+_escape = function (text) {
   return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 };
 
-configKeys = function(config) {
+configKeys = function (config) {
   if (!config) {
     return [];
   }
   return intersect(Object.keys(config), Object.keys(configKeysMap));
 };
 
-pathFrom = function(url) {
+pathFrom = function (url) {
   return (url || '').split('/').pop();
 };
 

--- a/app/utils/init-hs-beacon.js
+++ b/app/utils/init-hs-beacon.js
@@ -1,4 +1,4 @@
-/* global HS */
+/* eslint-disable */
 export default function initHsBeacon() {
   !function (e, o, n) { window.HSCW = o, window.HS = n, n.beacon = n.beacon || {}; var t = n.beacon; t.userConfig = {}, t.readyQueue = [], t.config = function (e) { this.userConfig = e; }, t.ready = function (e) { this.readyQueue.push(e); }, o.config = { docs:{ enabled:!1, baseUrl:'' }, contact:{ enabled:!0, formId:'f48f821c-fb20-11e5-a329-0ee2467769ff' } }; var r = e.getElementsByTagName('script')[0], c = e.createElement('script'); c.type = 'text/javascript', c.async = !0, c.src = 'https://djtflbt20bdde.cloudfront.net/', r.parentNode.insertBefore(c, r); }(document, window.HSCW || {}, window.HS || {});
 

--- a/app/utils/init-hs-beacon.js
+++ b/app/utils/init-hs-beacon.js
@@ -1,6 +1,6 @@
 /* global HS */
 export default function initHsBeacon() {
-  !function(e,o,n){window.HSCW=o,window.HS=n,n.beacon=n.beacon||{};var t=n.beacon;t.userConfig={},t.readyQueue=[],t.config=function(e){this.userConfig=e},t.ready=function(e){this.readyQueue.push(e)},o.config={docs:{enabled:!1,baseUrl:""},contact:{enabled:!0,formId:"f48f821c-fb20-11e5-a329-0ee2467769ff"}};var r=e.getElementsByTagName("script")[0],c=e.createElement("script");c.type="text/javascript",c.async=!0,c.src="https://djtflbt20bdde.cloudfront.net/",r.parentNode.insertBefore(c,r)}(document,window.HSCW||{},window.HS||{});
+  !function (e, o, n) { window.HSCW = o, window.HS = n, n.beacon = n.beacon || {}; var t = n.beacon; t.userConfig = {}, t.readyQueue = [], t.config = function (e) { this.userConfig = e; }, t.ready = function (e) { this.readyQueue.push(e); }, o.config = { docs:{ enabled:!1, baseUrl:'' }, contact:{ enabled:!0, formId:'f48f821c-fb20-11e5-a329-0ee2467769ff' } }; var r = e.getElementsByTagName('script')[0], c = e.createElement('script'); c.type = 'text/javascript', c.async = !0, c.src = 'https://djtflbt20bdde.cloudfront.net/', r.parentNode.insertBefore(c, r); }(document, window.HSCW || {}, window.HS || {});
 
   HS.beacon.config({
     modal: true,

--- a/app/utils/limited-array.js
+++ b/app/utils/limited-array.js
@@ -8,11 +8,11 @@ export default Ember.ArrayProxy.extend({
   isLoaded: alias('content.isLoaded'),
   arrangedContent: limit('content', 'limit'),
 
-  totalLength: function() {
+  totalLength: function () {
     return this.get('content.length');
   }.property('content.length'),
 
-  leftLength: function() {
+  leftLength: function () {
     var left, limit, totalLength;
     totalLength = this.get('totalLength');
     limit = this.get('limit');
@@ -24,7 +24,7 @@ export default Ember.ArrayProxy.extend({
     }
   }.property('totalLength', 'limit'),
 
-  isMore: function() {
+  isMore: function () {
     return this.get('leftLength') > 0;
   }.property('leftLength'),
 

--- a/app/utils/limited-array.js
+++ b/app/utils/limited-array.js
@@ -8,11 +8,11 @@ export default Ember.ArrayProxy.extend({
   isLoaded: alias('content.isLoaded'),
   arrangedContent: limit('content', 'limit'),
 
-  totalLength: function () {
+  totalLength: Ember.computed('content.length', function () {
     return this.get('content.length');
-  }.property('content.length'),
+  }),
 
-  leftLength: function () {
+  leftLength: Ember.computed('totalLength', 'limit', function () {
     var left, limit, totalLength;
     totalLength = this.get('totalLength');
     limit = this.get('limit');
@@ -22,11 +22,11 @@ export default Ember.ArrayProxy.extend({
     } else {
       return left;
     }
-  }.property('totalLength', 'limit'),
+  }),
 
-  isMore: function () {
+  isMore: Ember.computed('leftLength', function () {
     return this.get('leftLength') > 0;
-  }.property('leftLength'),
+  }),
 
   showAll() {
     return this.set('limit', Infinity);

--- a/app/utils/lines-selector.js
+++ b/app/utils/lines-selector.js
@@ -91,17 +91,17 @@ export default (function () {
   };
 
   LinesSelector.prototype.setHashValueWithLine = function (line, multiple) {
-    var hash, line_number, lines;
-    line_number = this.getLineNumberFromElement(line);
+    var hash, lineNumber, lines;
+    lineNumber = this.getLineNumberFromElement(line);
     if (multiple && (this.last_selected_line != null)) {
-      lines = [line_number, this.last_selected_line].sort(function (a, b) {
+      lines = [lineNumber, this.last_selected_line].sort(function (a, b) {
         return a - b;
       });
       hash = '#L' + lines[0] + '-L' + lines[1];
     } else {
-      hash = '#L' + line_number;
+      hash = '#L' + lineNumber;
     }
-    this.last_selected_line = line_number;
+    this.last_selected_line = lineNumber;
     return this.location.setHash(hash);
   };
 

--- a/app/utils/lines-selector.js
+++ b/app/utils/lines-selector.js
@@ -1,13 +1,13 @@
 import Ember from 'ember';
 
-export default (function() {
+export default (function () {
   LinesSelector.prototype.Location = {
-    getHash: function() {
+    getHash: function () {
       return window.location.hash;
     },
-    setHash: function(hash) {
+    setHash: function (hash) {
       var path;
-      path = "" + window.location.pathname + hash;
+      path = '' + window.location.pathname + hash;
       return window.history.pushState({
         path: path
       }, null, path);
@@ -29,13 +29,13 @@ export default (function() {
     this.scroll = scroll;
     this.folder = folder;
     this.location = location || this.Location;
-    Ember.run.scheduleOnce('afterRender', this, function() {
+    Ember.run.scheduleOnce('afterRender', this, function () {
       var ref;
       this.last_selected_line = (ref = this.getSelectedLines()) != null ? ref.first : void 0;
       return this.highlightLines();
     });
-    this.element.on('click', 'a', (function(_this) {
-      return function(event) {
+    this.element.on('click', 'a', (function (_this) {
+      return function (event) {
         var element;
         element = Ember.$(event.target).parent('p');
         _this.loadLineNumbers(element, event.shiftKey);
@@ -45,17 +45,17 @@ export default (function() {
     })(this));
   }
 
-  LinesSelector.prototype.willDestroy = function() {
+  LinesSelector.prototype.willDestroy = function () {
     this.location.setHash('');
     return this.destroyed = true;
   };
 
-  LinesSelector.prototype.loadLineNumbers = function(element, multiple) {
+  LinesSelector.prototype.loadLineNumbers = function (element, multiple) {
     this.setHashValueWithLine(element, multiple);
     return this.highlightLines();
   };
 
-  LinesSelector.prototype.highlightLines = function(tries) {
+  LinesSelector.prototype.highlightLines = function (tries) {
     tries = tries || 0;
     this.removeAllHighlights();
     let lines = this.getSelectedLines();
@@ -64,7 +64,7 @@ export default (function() {
       if (elements.length) {
         elements.addClass('highlight');
       } else if (tries < 4) {
-        Ember.run.later(this, (function() {
+        Ember.run.later(this, (function () {
           if (!this.destroyed) {
             return this.highlightLines(tries + 1);
           }
@@ -76,7 +76,7 @@ export default (function() {
     return this.unfoldLines();
   };
 
-  LinesSelector.prototype.unfoldLines = function() {
+  LinesSelector.prototype.unfoldLines = function () {
     var index, l, line, results;
     let lines = this.getSelectedLines();
     if (lines) {
@@ -90,30 +90,30 @@ export default (function() {
     }
   };
 
-  LinesSelector.prototype.setHashValueWithLine = function(line, multiple) {
+  LinesSelector.prototype.setHashValueWithLine = function (line, multiple) {
     var hash, line_number, lines;
     line_number = this.getLineNumberFromElement(line);
     if (multiple && (this.last_selected_line != null)) {
-      lines = [line_number, this.last_selected_line].sort(function(a, b) {
+      lines = [line_number, this.last_selected_line].sort(function (a, b) {
         return a - b;
       });
-      hash = "#L" + lines[0] + "-L" + lines[1];
+      hash = '#L' + lines[0] + '-L' + lines[1];
     } else {
-      hash = "#L" + line_number;
+      hash = '#L' + line_number;
     }
     this.last_selected_line = line_number;
     return this.location.setHash(hash);
   };
 
-  LinesSelector.prototype.getLineNumberFromElement = function(element) {
+  LinesSelector.prototype.getLineNumberFromElement = function (element) {
     return this.element.find('p:visible').index(element) + 1;
   };
 
-  LinesSelector.prototype.removeAllHighlights = function() {
+  LinesSelector.prototype.removeAllHighlights = function () {
     return this.element.find('p.highlight').removeClass('highlight');
   };
 
-  LinesSelector.prototype.getSelectedLines = function() {
+  LinesSelector.prototype.getSelectedLines = function () {
     let match = this.location.getHash().match(/#L(\d+)(-L(\d+))?$/);
     if (match) {
       let first = match[1];

--- a/app/utils/lines-selector.js
+++ b/app/utils/lines-selector.js
@@ -126,5 +126,4 @@ export default (function () {
   };
 
   return LinesSelector;
-
 })();

--- a/app/utils/location.js
+++ b/app/utils/location.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import config from 'travis/config/environment';
 
 export default Ember.HistoryLocation.extend({
-  init: function() {
+  init: function () {
     this._super(...arguments);
 
     var auth = this.get('auth');
@@ -16,7 +16,7 @@ export default Ember.HistoryLocation.extend({
     }
   },
 
-  getURL: function() {
+  getURL: function () {
     var url;
     url = this._super(...arguments);
     if (location.pathname === '/' && !config.enterprise) {
@@ -39,7 +39,7 @@ export default Ember.HistoryLocation.extend({
     return url;
   },
 
-  formatURL: function(logicalPath) {
+  formatURL: function (logicalPath) {
     if (!config.enterprise && (logicalPath === '/repositories' || logicalPath === '/home' || logicalPath === '/home-pro')) {
       return '/';
     } else {

--- a/app/utils/location.js
+++ b/app/utils/location.js
@@ -40,7 +40,8 @@ export default Ember.HistoryLocation.extend({
   },
 
   formatURL: function (logicalPath) {
-    if (!config.enterprise && (logicalPath === '/repositories' || logicalPath === '/home' || logicalPath === '/home-pro')) {
+    let rootRedirects = ['/repositories', '/home', 'home-pro'];
+    if (!config.enterprise && rootRedirects.contains(logicalPath)) {
       return '/';
     } else {
       return this._super(...arguments);

--- a/app/utils/log-chunks.js
+++ b/app/utils/log-chunks.js
@@ -42,7 +42,9 @@ var LogChunks = Ember.ArrayProxy.extend({
       existing = content.mapBy('number');
       all = (function () {
         results = [];
-        for (var i = 1, ref = last.number; 1 <= ref ? i <= ref : i >= ref; 1 <= ref ? i++ : i--) { results.push(i); }
+        for (var i = 1, ref = last.number; 1 <= ref ? i <= ref : i >= ref; 1 <= ref ? i++ : i--) {
+          results.push(i);
+        }
         return results;
       }).apply(this);
       missing = all.removeObjects(existing);

--- a/app/utils/log-chunks.js
+++ b/app/utils/log-chunks.js
@@ -55,7 +55,7 @@ var LogChunks = Ember.ArrayProxy.extend({
     return callback(missing, after);
   },
 
-  last: function () {
+  last: Ember.computed('content.[]', 'final', function () {
     var i, last, len, max, part, ref;
     max = -1;
     last = null;
@@ -68,11 +68,11 @@ var LogChunks = Ember.ArrayProxy.extend({
       }
     }
     return last;
-  }.property('content.[]', 'final'),
+  }),
 
-  final: function () {
+  final: Ember.computed(function () {
     return this.get('content').findBy('final', true);
-  }.property(),
+  }),
 
   tryFinalizing: function () {
     var content, last;

--- a/app/utils/log-chunks.js
+++ b/app/utils/log-chunks.js
@@ -2,22 +2,22 @@ import Ember from 'ember';
 
 var LogChunks = Ember.ArrayProxy.extend({
   timeout: 30000,
-  init: function() {
+  init: function () {
     this.setTimeout();
     return this._super(...arguments);
   },
 
-  resetTimeout: function() {
+  resetTimeout: function () {
     var id;
     id = this.get('timeoutId');
     clearTimeout(id);
     return this.setTimeout();
   },
 
-  setTimeout: function() {
+  setTimeout: function () {
     var id;
-    id = setTimeout((function(_this) {
-      return function() {
+    id = setTimeout((function (_this) {
+      return function () {
         if (_this.get('finalized') || _this.get('isDestroyed')) {
           return;
         }
@@ -28,7 +28,7 @@ var LogChunks = Ember.ArrayProxy.extend({
     return this.set('timeoutId', id);
   },
 
-  triggerMissingParts: function() {
+  triggerMissingParts: function () {
     var after, all, callback, content, existing, last, missing, results;
     callback = this.get('missingPartsCallback');
     if (!callback) {
@@ -40,9 +40,9 @@ var LogChunks = Ember.ArrayProxy.extend({
     after = null;
     if (last) {
       existing = content.mapBy('number');
-      all = (function() {
+      all = (function () {
         results = [];
-        for (var i = 1, ref = last.number; 1 <= ref ? i <= ref : i >= ref; 1 <= ref ? i++ : i--){ results.push(i); }
+        for (var i = 1, ref = last.number; 1 <= ref ? i <= ref : i >= ref; 1 <= ref ? i++ : i--) { results.push(i); }
         return results;
       }).apply(this);
       missing = all.removeObjects(existing);
@@ -55,7 +55,7 @@ var LogChunks = Ember.ArrayProxy.extend({
     return callback(missing, after);
   },
 
-  last: function() {
+  last: function () {
     var i, last, len, max, part, ref;
     max = -1;
     last = null;
@@ -70,11 +70,11 @@ var LogChunks = Ember.ArrayProxy.extend({
     return last;
   }.property('content.[]', 'final'),
 
-  final: function() {
+  final: function () {
     return this.get('content').findBy('final', true);
   }.property(),
 
-  tryFinalizing: function() {
+  tryFinalizing: function () {
     var content, last;
     content = this.get('content');
     last = this.get('last');
@@ -83,7 +83,7 @@ var LogChunks = Ember.ArrayProxy.extend({
     }
   },
 
-  contentArrayDidChange: function(array, index, removedCount, addedCount) {
+  contentArrayDidChange: function (array, index, removedCount, addedCount) {
     var addedObjects, i, len, part;
     this._super(...arguments);
     if (addedCount) {
@@ -94,8 +94,8 @@ var LogChunks = Ember.ArrayProxy.extend({
           this.notifyPropertyChange('final');
         }
       }
-      return Ember.run(this, function() {
-        return Ember.run.once(this, function() {
+      return Ember.run(this, function () {
+        return Ember.run.once(this, function () {
           this.tryFinalizing();
           return this.resetTimeout();
         });

--- a/app/utils/log-folder.js
+++ b/app/utils/log-folder.js
@@ -1,10 +1,10 @@
 import Ember from 'ember';
 
-export default (function() {
+export default (function () {
   function LogFolder(element) {
     this.element = element;
-    this.element.on('click', '.fold', (function(_this) {
-      return function(event) {
+    this.element.on('click', '.fold', (function (_this) {
+      return function (event) {
         var folder;
         folder = _this.getFolderFromLine(Ember.$(event.target));
         _this.toggle(folder);
@@ -14,7 +14,7 @@ export default (function() {
     })(this));
   }
 
-  LogFolder.prototype.fold = function(line) {
+  LogFolder.prototype.fold = function (line) {
     var folder;
     folder = this.getFolderFromLine(line);
     if (folder.hasClass('open')) {
@@ -22,7 +22,7 @@ export default (function() {
     }
   };
 
-  LogFolder.prototype.unfold = function(line) {
+  LogFolder.prototype.unfold = function (line) {
     var folder;
     folder = this.getFolderFromLine(line);
     if (!folder.hasClass('open')) {
@@ -30,11 +30,11 @@ export default (function() {
     }
   };
 
-  LogFolder.prototype.toggle = function(folder) {
+  LogFolder.prototype.toggle = function (folder) {
     return folder.toggleClass('open');
   };
 
-  LogFolder.prototype.getFolderFromLine = function(line) {
+  LogFolder.prototype.getFolderFromLine = function (line) {
     return line.parent('.fold');
   };
 

--- a/app/utils/log-folder.js
+++ b/app/utils/log-folder.js
@@ -39,5 +39,4 @@ export default (function () {
   };
 
   return LogFolder;
-
 })();

--- a/app/utils/pusher.js
+++ b/app/utils/pusher.js
@@ -2,7 +2,7 @@
 import ENV from 'travis/config/environment';
 import Ember from 'ember';
 
-var TravisPusher = function(config, ajaxService) {
+var TravisPusher = function (config, ajaxService) {
   this.init(config, ajaxService);
   TravisPusher.ajaxService = ajaxService;
   return this;
@@ -10,7 +10,7 @@ var TravisPusher = function(config, ajaxService) {
 
 TravisPusher.prototype.active_channels = [];
 
-TravisPusher.prototype.init = function(config, ajaxService) {
+TravisPusher.prototype.init = function (config, ajaxService) {
   this.ajaxService = ajaxService;
   Pusher.warn = this.warn.bind(this);
   if (config.host) {
@@ -22,7 +22,7 @@ TravisPusher.prototype.init = function(config, ajaxService) {
   });
 };
 
-TravisPusher.prototype.subscribeAll = function(channels) {
+TravisPusher.prototype.subscribeAll = function (channels) {
   var channel, i, len, results;
   results = [];
   for (i = 0, len = channels.length; i < len; i++) {
@@ -32,7 +32,7 @@ TravisPusher.prototype.subscribeAll = function(channels) {
   return results;
 };
 
-TravisPusher.prototype.unsubscribeAll = function(channels) {
+TravisPusher.prototype.unsubscribeAll = function (channels) {
   var channel, i, len, results;
   results = [];
   for (i = 0, len = channels.length; i < len; i++) {
@@ -42,22 +42,22 @@ TravisPusher.prototype.unsubscribeAll = function(channels) {
   return results;
 };
 
-TravisPusher.prototype.subscribe = function(channel) {
+TravisPusher.prototype.subscribe = function (channel) {
   var ref;
   if (!channel) {
     return;
   }
   channel = this.prefix(channel);
   if (!((ref = this.pusher) != null ? ref.channel(channel) : void 0)) {
-    return this.pusher.subscribe(channel).bind_all((function(_this) {
-      return function(event, data) {
+    return this.pusher.subscribe(channel).bind_all((function (_this) {
+      return function (event, data) {
         return _this.receive(event, data);
       };
     })(this));
   }
 };
 
-TravisPusher.prototype.unsubscribe = function(channel) {
+TravisPusher.prototype.unsubscribe = function (channel) {
   var ref;
   if (!channel) {
     return;
@@ -70,17 +70,17 @@ TravisPusher.prototype.unsubscribe = function(channel) {
   }
 };
 
-TravisPusher.prototype.prefix = function(channel) {
+TravisPusher.prototype.prefix = function (channel) {
   var prefix;
   prefix = ENV.pusher.channelPrefix || '';
   if (channel.indexOf(prefix) !== 0) {
-    return "" + prefix + channel;
+    return '' + prefix + channel;
   } else {
     return channel;
   }
 };
 
-TravisPusher.prototype.receive = function(event, data) {
+TravisPusher.prototype.receive = function (event, data) {
   if (event.substr(0, 6) === 'pusher') {
     return;
   }
@@ -96,14 +96,14 @@ TravisPusher.prototype.receive = function(event, data) {
       job.clearLog();
     }
   }
-  return Ember.run.next((function(_this) {
-    return function() {
+  return Ember.run.next((function (_this) {
+    return function () {
       return _this.store.receivePusherEvent(event, data);
     };
   })(this));
 };
 
-TravisPusher.prototype.normalize = function(event, data) {
+TravisPusher.prototype.normalize = function (event, data) {
   switch (event) {
     case 'build:started':
     case 'build:finished':
@@ -136,29 +136,29 @@ TravisPusher.prototype.normalize = function(event, data) {
   }
 };
 
-TravisPusher.prototype.warn = function(type, object) {
+TravisPusher.prototype.warn = function (type, object) {
   if (!this.ignoreWarning(type, object.error)) {
     //eslint-disable-next-line
     return console.warn(type, object.error);
   }
 };
 
-TravisPusher.prototype.ignoreWarning = function(type, error) {
+TravisPusher.prototype.ignoreWarning = function (type, error) {
   var code, message, ref, ref1;
   code = (error != null ? (ref = error.data) != null ? ref.code : void 0 : void 0) || 0;
   message = (error != null ? (ref1 = error.data) != null ? ref1.message : void 0 : void 0) || '';
   return this.ignoreCode(code) || this.ignoreMessage(message);
 };
 
-TravisPusher.prototype.ignoreCode = function(code) {
+TravisPusher.prototype.ignoreCode = function (code) {
   return code === 1006;
 };
 
-TravisPusher.prototype.ignoreMessage = function(message) {
+TravisPusher.prototype.ignoreMessage = function (message) {
   return message.indexOf('Existing subscription') === 0 || message.indexOf('No current subscription') === 0;
 };
 
-Pusher.SockJSTransport.isSupported = function() {
+Pusher.SockJSTransport.isSupported = function () {
   if (ENV.pusher.host !== 'ws.pusherapp.com') {
     return false;
   }
@@ -166,13 +166,13 @@ Pusher.SockJSTransport.isSupported = function() {
 
 if (ENV.pro) {
   Pusher.channel_auth_transport = 'bulk_ajax';
-  Pusher.authorizers.bulk_ajax = function(socketId, _callback) {
+  Pusher.authorizers.bulk_ajax = function (socketId, _callback) {
     var channels, name, names;
     channels = Travis.pusher.pusher.channels;
     channels.callbacks = channels.callbacks || [];
     name = this.channel.name;
     names = Object.keys(channels.channels);
-    channels.callbacks.push(function(auths) {
+    channels.callbacks.push(function (auths) {
       return _callback(false, {
         auth: auths[name]
       });
@@ -182,7 +182,7 @@ if (ENV.pro) {
       return TravisPusher.ajaxService.post(Pusher.channel_auth_endpoint, {
         socket_id: socketId,
         channels: names
-      }, function(data) {
+      }, function (data) {
         var callback, i, len, ref, results;
         channels.fetching = false;
         ref = channels.callbacks;
@@ -195,34 +195,34 @@ if (ENV.pro) {
       });
     }
   };
-  Pusher.getDefaultStrategy = function(config) {
+  Pusher.getDefaultStrategy = function (config) {
     return [
       [
-        ":def", "ws_options", {
-          hostUnencrypted: config.wsHost + ":" + config.wsPort + (ENV.pusher.path && ("/" + ENV.pusher.path) || ''),
-          hostEncrypted: config.wsHost + ":" + config.wssPort + (ENV.pusher.path && ("/" + ENV.pusher.path) || ''),
+        ':def', 'ws_options', {
+          hostUnencrypted: config.wsHost + ':' + config.wsPort + (ENV.pusher.path && ('/' + ENV.pusher.path) || ''),
+          hostEncrypted: config.wsHost + ':' + config.wssPort + (ENV.pusher.path && ('/' + ENV.pusher.path) || ''),
           path: config.path
         }
       ], [
-        ":def", "sockjs_options", {
-          hostUnencrypted: config.httpHost + ":" + config.httpPort,
-          hostEncrypted: config.httpHost + ":" + config.httpsPort
+        ':def', 'sockjs_options', {
+          hostUnencrypted: config.httpHost + ':' + config.httpPort,
+          hostEncrypted: config.httpHost + ':' + config.httpsPort
         }
       ], [
-        ":def", "timeouts", {
+        ':def', 'timeouts', {
           loop: true,
           timeout: 15000,
           timeoutLimit: 60000
         }
       ], [
-        ":def", "ws_manager", [
-          ":transport_manager", {
+        ':def', 'ws_manager', [
+          ':transport_manager', {
             lives: 2,
             minPingDelay: 10000,
             maxPingDelay: config.activity_timeout
           }
         ]
-      ], [":def_transport", "ws", "ws", 3, ":ws_options", ":ws_manager"], [":def_transport", "flash", "flash", 2, ":ws_options", ":ws_manager"], [":def_transport", "sockjs", "sockjs", 1, ":sockjs_options"], [":def", "ws_loop", [":sequential", ":timeouts", ":ws"]], [":def", "flash_loop", [":sequential", ":timeouts", ":flash"]], [":def", "sockjs_loop", [":sequential", ":timeouts", ":sockjs"]], [":def", "strategy", [":cached", 1800000, [":first_connected", [":if", [":is_supported", ":ws"], [":best_connected_ever", ":ws_loop", [":delayed", 2000, [":sockjs_loop"]]], [":if", [":is_supported", ":flash"], [":best_connected_ever", ":flash_loop", [":delayed", 2000, [":sockjs_loop"]]], [":sockjs_loop"]]]]]]
+      ], [':def_transport', 'ws', 'ws', 3, ':ws_options', ':ws_manager'], [':def_transport', 'flash', 'flash', 2, ':ws_options', ':ws_manager'], [':def_transport', 'sockjs', 'sockjs', 1, ':sockjs_options'], [':def', 'ws_loop', [':sequential', ':timeouts', ':ws']], [':def', 'flash_loop', [':sequential', ':timeouts', ':flash']], [':def', 'sockjs_loop', [':sequential', ':timeouts', ':sockjs']], [':def', 'strategy', [':cached', 1800000, [':first_connected', [':if', [':is_supported', ':ws'], [':best_connected_ever', ':ws_loop', [':delayed', 2000, [':sockjs_loop']]], [':if', [':is_supported', ':flash'], [':best_connected_ever', ':flash_loop', [':delayed', 2000, [':sockjs_loop']]], [':sockjs_loop']]]]]]
     ];
   };
 }

--- a/app/utils/status-image-formats.js
+++ b/app/utils/status-image-formats.js
@@ -1,40 +1,40 @@
 import { ccXml as ccXmlUrl, statusImage as statusImageUrl } from 'travis/utils/urls';
 var asciidocStatusImage, ccxmlStatusUrl, format, markdownStatusImage,
-    podStatusImage, rdocStatusImage, rstStatusImage, textileStatusImage, urlRepo;
+  podStatusImage, rdocStatusImage, rstStatusImage, textileStatusImage, urlRepo;
 
-urlRepo = (function(slug) {
-  return "https://" + location.host + "/" + slug;
+urlRepo = (function (slug) {
+  return 'https://' + location.host + '/' + slug;
 });
 
-markdownStatusImage = (function(url, slug, branch) {
-  return "[![Build Status](" + (statusImageUrl(slug, branch)) + ")](" + url + ")";
+markdownStatusImage = (function (url, slug, branch) {
+  return '[![Build Status](' + (statusImageUrl(slug, branch)) + ')](' + url + ')';
 });
 
-textileStatusImage = (function(url, slug, branch) {
-  return "!" + (statusImageUrl(slug, branch)) + "!:" + url;
+textileStatusImage = (function (url, slug, branch) {
+  return '!' + (statusImageUrl(slug, branch)) + '!:' + url;
 });
 
-rdocStatusImage = (function(url, slug, branch) {
-  return "{<img src=\"" + (statusImageUrl(slug, branch)) + "\" alt=\"Build Status\" />}[" + url + "]";
+rdocStatusImage = (function (url, slug, branch) {
+  return '{<img src="' + (statusImageUrl(slug, branch)) + '" alt="Build Status" />}[' + url + ']';
 });
 
-asciidocStatusImage = (function(url, slug, branch) {
-  return "image:" + (statusImageUrl(slug, branch)) + "[\"Build Status\", link=\"" + url + "\"]";
+asciidocStatusImage = (function (url, slug, branch) {
+  return 'image:' + (statusImageUrl(slug, branch)) + '["Build Status", link="' + url + '"]';
 });
 
-rstStatusImage = (function(url, slug, branch) {
-  return ".. image:: " + (statusImageUrl(slug, branch)) + "\n    :target: " + url;
+rstStatusImage = (function (url, slug, branch) {
+  return '.. image:: ' + (statusImageUrl(slug, branch)) + '\n    :target: ' + url;
 });
 
-podStatusImage = (function(url, slug, branch) {
-  return "=for html <a href=\"" + url + "\"><img src=\"" + (statusImageUrl(slug, branch)) + "\"></a>";
+podStatusImage = (function (url, slug, branch) {
+  return '=for html <a href="' + url + '"><img src="' + (statusImageUrl(slug, branch)) + '"></a>';
 });
 
-ccxmlStatusUrl = (function(slug, branch) {
+ccxmlStatusUrl = (function (slug, branch) {
   return ccXmlUrl(slug, branch);
 });
 
-format = function(version, slug, branch) {
+format = function (version, slug, branch) {
   var url;
   url = urlRepo(slug);
   switch (version) {

--- a/app/utils/tailing.js
+++ b/app/utils/tailing.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-export default (function() {
+export default (function () {
   function Tailing(window1, tail_selector, log_selector) {
     this.window = window1;
     this.tail_selector = tail_selector;
@@ -16,17 +16,17 @@ export default (function() {
     timeout: 200
   };
 
-  Tailing.prototype.tail = function() {
+  Tailing.prototype.tail = function () {
     return Ember.$(this.tail_selector);
   };
 
-  Tailing.prototype.log = function() {
+  Tailing.prototype.log = function () {
     return Ember.$(this.log_selector);
   };
 
 
 
-  Tailing.prototype.run = function() {
+  Tailing.prototype.run = function () {
     this.autoScroll();
     this.positionButton();
     if (this.active()) {
@@ -34,7 +34,7 @@ export default (function() {
     }
   };
 
-  Tailing.prototype.toggle = function() {
+  Tailing.prototype.toggle = function () {
     if (this.active()) {
       return this.stop();
     } else {
@@ -42,24 +42,24 @@ export default (function() {
     }
   };
 
-  Tailing.prototype.active = function() {
+  Tailing.prototype.active = function () {
     return this.tail().hasClass('active');
   };
 
-  Tailing.prototype.start = function() {
+  Tailing.prototype.start = function () {
     this.tail().addClass('active');
     return this.run();
   };
 
-  Tailing.prototype.isActive = function() {
+  Tailing.prototype.isActive = function () {
     return this.tail().hasClass('active');
   };
 
-  Tailing.prototype.stop = function() {
+  Tailing.prototype.stop = function () {
     return this.tail().removeClass('active');
   };
 
-  Tailing.prototype.autoScroll = function() {
+  Tailing.prototype.autoScroll = function () {
     var logBottom, winBottom;
     if (!this.active()) {
       return false;
@@ -74,7 +74,7 @@ export default (function() {
     }
   };
 
-  Tailing.prototype.onScroll = function() {
+  Tailing.prototype.onScroll = function () {
     var position;
     this.positionButton();
     position = this.window.scrollTop();
@@ -84,7 +84,7 @@ export default (function() {
     return this.position = position;
   };
 
-  Tailing.prototype.positionButton = function() {
+  Tailing.prototype.positionButton = function () {
     var max, offset, tail;
     tail = Ember.$('#tail');
     if (tail.length === 0) {

--- a/app/utils/tailing.js
+++ b/app/utils/tailing.js
@@ -24,8 +24,6 @@ export default (function () {
     return Ember.$(this.logSelector);
   };
 
-
-
   Tailing.prototype.run = function () {
     this.autoScroll();
     this.positionButton();

--- a/app/utils/tailing.js
+++ b/app/utils/tailing.js
@@ -1,10 +1,10 @@
 import Ember from 'ember';
 
 export default (function () {
-  function Tailing(window1, tail_selector, log_selector) {
+  function Tailing(window1, tailSelector, logSelector) {
     this.window = window1;
-    this.tail_selector = tail_selector;
-    this.log_selector = log_selector;
+    this.tailSelector = tailSelector;
+    this.logSelector = logSelector;
     this.position = this.window.scrollTop();
     this.window.scroll(() => {
       return Ember.run.throttle(this, this.onScroll, [], 200, false);
@@ -17,11 +17,11 @@ export default (function () {
   };
 
   Tailing.prototype.tail = function () {
-    return Ember.$(this.tail_selector);
+    return Ember.$(this.tailSelector);
   };
 
   Tailing.prototype.log = function () {
-    return Ember.$(this.log_selector);
+    return Ember.$(this.logSelector);
   };
 
 

--- a/app/utils/tailing.js
+++ b/app/utils/tailing.js
@@ -105,5 +105,4 @@ export default (function () {
   };
 
   return Tailing;
-
 })();

--- a/app/utils/test-auth.js
+++ b/app/utils/test-auth.js
@@ -29,25 +29,25 @@ export default Ember.Object.extend({
   // TODO: we use these properties in templates, but there
   //       really should be something like a 'session' service that can be
   //       injected where we need it
-  userName: function() {
+  userName: function () {
     return this.get('currentUser.name') || this.get('currentUser.login');
   }.property('currentUser.login', 'currentUser.name'),
 
-  gravatarUrl: function() {
-    return location.protocol + "//www.gravatar.com/avatar/" + (this.get('currentUser.gravatarId')) + "?s=48&d=mm";
+  gravatarUrl: function () {
+    return location.protocol + '//www.gravatar.com/avatar/' + (this.get('currentUser.gravatarId')) + '?s=48&d=mm';
   }.property('currentUser.gravatarId'),
 
   permissions: Ember.computed.alias('currentUser.permissions'),
 
-  signedIn: function() {
+  signedIn: function () {
     return this.get('state') === 'signed-in';
   }.property('state'),
 
-  signedOut: function() {
+  signedOut: function () {
     return this.get('state') === 'signed-out';
   }.property('state'),
 
-  signingIn: function() {
+  signingIn: function () {
     return this.get('state') === 'signing-in';
   }.property('state'),
 

--- a/app/utils/test-auth.js
+++ b/app/utils/test-auth.js
@@ -29,27 +29,27 @@ export default Ember.Object.extend({
   // TODO: we use these properties in templates, but there
   //       really should be something like a 'session' service that can be
   //       injected where we need it
-  userName: function () {
+  userName: Ember.computed('currentUser.login', 'currentUser.name', function () {
     return this.get('currentUser.name') || this.get('currentUser.login');
-  }.property('currentUser.login', 'currentUser.name'),
+  }),
 
-  gravatarUrl: function () {
+  gravatarUrl: Ember.computed('currentUser.gravatarId', function () {
     return location.protocol + '//www.gravatar.com/avatar/' + (this.get('currentUser.gravatarId')) + '?s=48&d=mm';
-  }.property('currentUser.gravatarId'),
+  }),
 
   permissions: Ember.computed.alias('currentUser.permissions'),
 
-  signedIn: function () {
+  signedIn: Ember.computed('state', function () {
     return this.get('state') === 'signed-in';
-  }.property('state'),
+  }),
 
-  signedOut: function () {
+  signedOut: Ember.computed('state', function () {
     return this.get('state') === 'signed-out';
-  }.property('state'),
+  }),
 
-  signingIn: function () {
+  signingIn: Ember.computed('state', function () {
     return this.get('state') === 'signing-in';
-  }.property('state'),
+  }),
 
   token() {
     if (this.get('state') === 'signed-in') {

--- a/app/utils/test-auth.js
+++ b/app/utils/test-auth.js
@@ -34,7 +34,8 @@ export default Ember.Object.extend({
   }),
 
   gravatarUrl: Ember.computed('currentUser.gravatarId', function () {
-    return location.protocol + '//www.gravatar.com/avatar/' + (this.get('currentUser.gravatarId')) + '?s=48&d=mm';
+    let gravatarId = this.get('currentUser.gravatarId');
+    return `${location.protocol}//www.gravatar.com/avatar/${gravatarId}?s=48&d=mm`;
   }),
 
   permissions: Ember.computed.alias('currentUser.permissions'),

--- a/app/utils/to-top.js
+++ b/app/utils/to-top.js
@@ -56,5 +56,4 @@ export default (function () {
   };
 
   return ToTop;
-
 })();

--- a/app/utils/to-top.js
+++ b/app/utils/to-top.js
@@ -7,10 +7,10 @@ export default (function () {
   //       situation I prefer a bit less DRY code over simplicity of
   //       the calculations.
 
-  function ToTop(window, element_selector, container_selector) {
+  function ToTop(window, elementSelector, containerSelector) {
     this.window = window;
-    this.element_selector = element_selector;
-    this.container_selector = container_selector;
+    this.elementSelector = elementSelector;
+    this.containerSelector = containerSelector;
     this.position = this.window.scrollTop();
     this.window.scroll(() => {
       return Ember.run.throttle(this, this.onScroll, [], 200, false);
@@ -19,11 +19,11 @@ export default (function () {
   }
 
   ToTop.prototype.element = function () {
-    return Ember.$(this.element_selector);
+    return Ember.$(this.elementSelector);
   };
 
   ToTop.prototype.container = function () {
-    return Ember.$(this.container_selector);
+    return Ember.$(this.containerSelector);
   };
 
   ToTop.prototype.onScroll = function () {

--- a/app/utils/to-top.js
+++ b/app/utils/to-top.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-export default (function() {
+export default (function () {
   // NOTE: I could have probably extract fixed positioning from
   //       Tailing, but then I would need to parametrize positionElement
   //       function to make it flexible to handle both cases. In that
@@ -18,19 +18,19 @@ export default (function() {
     return this;
   }
 
-  ToTop.prototype.element = function() {
+  ToTop.prototype.element = function () {
     return Ember.$(this.element_selector);
   };
 
-  ToTop.prototype.container = function() {
+  ToTop.prototype.container = function () {
     return Ember.$(this.container_selector);
   };
 
-  ToTop.prototype.onScroll = function() {
+  ToTop.prototype.onScroll = function () {
     return this.positionElement();
   };
 
-  ToTop.prototype.positionElement = function() {
+  ToTop.prototype.positionElement = function () {
     var container, containerHeight, element, max, offset, windowHeight;
     element = this.element();
     container = this.container();

--- a/app/utils/urls.js
+++ b/app/utils/urls.js
@@ -2,39 +2,39 @@
 import config from 'travis/config/environment';
 
 var ccXml, email, githubAdmin, githubCommit, githubNetwork, githubPullRequest,
-    githubRepo, githubWatchers, gravatarImage, plainTextLog, statusImage;
+  githubRepo, githubWatchers, gravatarImage, plainTextLog, statusImage;
 
-plainTextLog = function(id) {
-  return config.apiEndpoint + "/jobs/" + id + "/log.txt?deansi=true";
+plainTextLog = function (id) {
+  return config.apiEndpoint + '/jobs/' + id + '/log.txt?deansi=true';
 };
 
-githubPullRequest = function(slug, pullRequestNumber) {
-  return config.sourceEndpoint + "/" + slug + "/pull/" + pullRequestNumber;
+githubPullRequest = function (slug, pullRequestNumber) {
+  return config.sourceEndpoint + '/' + slug + '/pull/' + pullRequestNumber;
 };
 
-githubCommit = function(slug, sha) {
-  return config.sourceEndpoint + "/" + slug + "/commit/" + sha;
+githubCommit = function (slug, sha) {
+  return config.sourceEndpoint + '/' + slug + '/commit/' + sha;
 };
 
-githubRepo = function(slug) {
-  return config.sourceEndpoint + "/" + slug;
+githubRepo = function (slug) {
+  return config.sourceEndpoint + '/' + slug;
 };
 
-githubWatchers = function(slug) {
-  return config.sourceEndpoint + "/" + slug + "/watchers";
+githubWatchers = function (slug) {
+  return config.sourceEndpoint + '/' + slug + '/watchers';
 };
 
-githubNetwork = function(slug) {
-  return config.sourceEndpoint + "/" + slug + "/network";
+githubNetwork = function (slug) {
+  return config.sourceEndpoint + '/' + slug + '/network';
 };
 
-githubAdmin = function(slug) {
-  return config.sourceEndpoint + "/" + slug + "/settings/hooks#travis_minibucket";
+githubAdmin = function (slug) {
+  return config.sourceEndpoint + '/' + slug + '/settings/hooks#travis_minibucket';
 };
 
-statusImage = function(slug, branch) {
+statusImage = function (slug, branch) {
   var token;
-  var prefix = location.protocol + "//" + location.host;
+  var prefix = location.protocol + '//' + location.host;
 
   // the ruby app (waiter) does an indirect, internal redirect to api on build status images
   // but that does not work if you only run `ember serve`
@@ -45,32 +45,32 @@ statusImage = function(slug, branch) {
 
   if (config.pro) {
     token = Travis.__container__.lookup('controller:currentUser').get('model.token');
-    return (prefix + "/" + slug + ".svg?token=" + token) + (branch ? "&branch=" + branch : '');
+    return (prefix + '/' + slug + '.svg?token=' + token) + (branch ? '&branch=' + branch : '');
   } else {
-    return (prefix + "/" + slug + ".svg") + (branch ? "?branch=" + (encodeURIComponent(branch)) : '');
+    return (prefix + '/' + slug + '.svg') + (branch ? '?branch=' + (encodeURIComponent(branch)) : '');
   }
 };
 
-ccXml = function(slug, branch) {
+ccXml = function (slug, branch) {
   var delimiter, token, url;
-  url = "#" + config.apiEndpoint + "/repos/" + slug + "/cc.xml";
+  url = '#' + config.apiEndpoint + '/repos/' + slug + '/cc.xml';
   if (branch) {
-    url = url + "?branch=" + branch;
+    url = url + '?branch=' + branch;
   }
   if (config.pro) {
     delimiter = url.indexOf('?') === -1 ? '?' : '&';
     token = Travis.__container__.lookup('controller:currentUser').get('model.token');
-    url = "" + url + delimiter + "token=" + token;
+    url = '' + url + delimiter + 'token=' + token;
   }
   return url;
 };
 
-email = function(email) {
-  return "mailto:" + email;
+email = function (email) {
+  return 'mailto:' + email;
 };
 
-gravatarImage = function(email, size) {
-    return "https://www.gravatar.com/avatar/" + (md5(email)) + "?s=" + size + "&d=blank";
+gravatarImage = function (email, size) {
+  return 'https://www.gravatar.com/avatar/' + (md5(email)) + '?s=' + size + '&d=blank';
 };
 
 export { plainTextLog, githubPullRequest, githubCommit, githubRepo, githubWatchers, githubNetwork, githubAdmin, statusImage, ccXml, email, gravatarImage };

--- a/app/utils/urls.js
+++ b/app/utils/urls.js
@@ -33,7 +33,6 @@ githubAdmin = function (slug) {
 };
 
 statusImage = function (slug, branch) {
-  var token;
   var prefix = location.protocol + '//' + location.host;
 
   // the ruby app (waiter) does an indirect, internal redirect to api on build status images
@@ -43,11 +42,14 @@ statusImage = function (slug, branch) {
     prefix = config.apiEndpoint;
   }
 
+  let branchParam = branch ? `?branch=${encodeURIComponent(branch)}` : '';
+
   if (config.pro) {
-    token = Travis.__container__.lookup('controller:currentUser').get('model.token');
-    return (prefix + '/' + slug + '.svg?token=' + token) + (branch ? '&branch=' + branch : '');
+    let token = Travis.__container__.lookup('controller:currentUser').get('model.token');
+    let tokenParam = `&token=${token}`;
+    return `${prefix}/${slug}.svg${branchParam}${tokenParam}`;
   } else {
-    return (prefix + '/' + slug + '.svg') + (branch ? '?branch=' + (encodeURIComponent(branch)) : '');
+    return `${prefix}/${slug}.svg${branchParam}`;
   }
 };
 
@@ -73,4 +75,16 @@ gravatarImage = function (email, size) {
   return 'https://www.gravatar.com/avatar/' + (md5(email)) + '?s=' + size + '&d=blank';
 };
 
-export { plainTextLog, githubPullRequest, githubCommit, githubRepo, githubWatchers, githubNetwork, githubAdmin, statusImage, ccXml, email, gravatarImage };
+export {
+  plainTextLog,
+  githubPullRequest,
+  githubCommit,
+  githubRepo,
+  githubWatchers,
+  githubNetwork,
+  githubAdmin,
+  statusImage,
+  ccXml,
+  email,
+  gravatarImage
+};

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -2,16 +2,16 @@
 import Ember from 'ember';
 import Mirage from 'ember-cli-mirage';
 
-export default function() {
-  this.get('/accounts', (schema/*, request*/) => {
-    const users = schema.users.all().models.map(user => Ember.merge(user.attrs, {type: 'user'}));
+export default function () {
+  this.get('/accounts', (schema/* , request*/) => {
+    const users = schema.users.all().models.map(user => Ember.merge(user.attrs, { type: 'user' }));
     const accounts = schema.accounts.all().models.map(account => account.attrs);
 
     return { accounts: users.concat(accounts) };
   });
 
-  this.get('/hooks', function({hooks}, {queryParams: {owner_name}}) {
-    return this.serialize(hooks.where({owner_name}), 'v2');
+  this.get('/hooks', function ({ hooks }, { queryParams: { owner_name } }) {
+    return this.serialize(hooks.where({ owner_name }), 'v2');
   });
 
   this.put('/hooks/:id', (schema, request) => {
@@ -20,8 +20,8 @@ export default function() {
     return user.update(JSON.parse(request.requestBody).hook);
   });
 
-  this.get('/users/:id', function({users}, request) {
-    if(request.requestHeaders.Authorization === 'token testUserToken') {
+  this.get('/users/:id', function ({ users }, request) {
+    if (request.requestHeaders.Authorization === 'token testUserToken') {
       return this.serialize(users.find(request.params.id), 'v2');
     } else {
       return new Mirage.Response(403, {}, {});
@@ -30,10 +30,10 @@ export default function() {
 
   this.get('/users/permissions', (schema, request) => {
     const token = request.requestHeaders.Authorization.split(' ')[1];
-    const user = schema.users.where({token}).models[0];
+    const user = schema.users.where({ token }).models[0];
 
     if (user) {
-      const permissions = schema.permissions.where({userId: user.id});
+      const permissions = schema.permissions.where({ userId: user.id });
 
       return permissions.models.reduce((combinedPermissions, permissions) => {
         ['admin', 'push', 'pull', 'permissions'].forEach(property => {
@@ -54,15 +54,15 @@ export default function() {
     }
   });
 
-  this.get('/v3/broadcasts', (/*schema, request*/) => {
+  this.get('/v3/broadcasts', (/* schema, request*/) => {
     return { broadcasts: [] };
   });
 
-  this.get('/repos', function(schema/*, request*/) {
+  this.get('/repos', function (schema/* , request*/) {
     return schema.repositories.all();
   });
 
-  this.get('/repo/:slug', function(schema, request) {
+  this.get('/repo/:slug', function (schema, request) {
     let repos = schema.repositories.where({ slug: decodeURIComponent(request.params.slug) });
 
     return {
@@ -70,23 +70,23 @@ export default function() {
     };
   });
 
-  this.get('/v3/repo/:id/crons', function(schema/*, request*/) {
+  this.get('/v3/repo/:id/crons', function (schema/* , request*/) {
     return schema.crons.all();
   });
 
   this.get('/cron/:id');
 
-  this.get('/repos/:id/settings', function(schema, request) {
-    return this.serialize(schema.settings.where({repositoryId: request.params.id}).models[0], 'v2');
+  this.get('/repos/:id/settings', function (schema, request) {
+    return this.serialize(schema.settings.where({ repositoryId: request.params.id }).models[0], 'v2');
   });
 
-  this.get('/repos/:id/caches', function(schema, request) {
-    const caches = schema.caches.where({repositoryId: request.params.id});
+  this.get('/repos/:id/caches', function (schema, request) {
+    const caches = schema.caches.where({ repositoryId: request.params.id });
     return this.serialize(caches, 'v2');
   });
 
-  this.get('/settings/env_vars', function(schema, request) {
-    const envVars = schema.envVars.where({repositoryId: request.queryParams.repository_id});
+  this.get('/settings/env_vars', function (schema, request) {
+    const envVars = schema.envVars.where({ repositoryId: request.queryParams.repository_id });
 
     return {
       env_vars: envVars.models.map(envVar => {
@@ -96,44 +96,44 @@ export default function() {
     };
   });
 
-  this.get('/settings/ssh_key/:repo_id', function(schema, request) {
-    return this.serialize(schema.sshKeys.where({repositoryId: request.params.repo_id, type: 'custom'}).models[0], 'v2');
+  this.get('/settings/ssh_key/:repo_id', function (schema, request) {
+    return this.serialize(schema.sshKeys.where({ repositoryId: request.params.repo_id, type: 'custom' }).models[0], 'v2');
   });
 
-  this.get('/v3/repo/:id', function(schema, request) {
+  this.get('/v3/repo/:id', function (schema, request) {
     return schema.repositories.find(request.params.id);
   });
 
-  this.get('/v3/repo/:id/branches', function(schema) {
+  this.get('/v3/repo/:id/branches', function (schema) {
     return schema.branches.all();
   });
 
-  this.get('/repos/:id/key', function(schema, request) {
-    const key = schema.sshKeys.where({repositoryId: request.params.id, type: 'default'}).models[0];
+  this.get('/repos/:id/key', function (schema, request) {
+    const key = schema.sshKeys.where({ repositoryId: request.params.id, type: 'default' }).models[0];
     return {
       key: key.attrs.key,
       fingerprint: key.attrs.fingerprint
     };
   });
 
-  this.get('/jobs/:id', function(schema, request) {
+  this.get('/jobs/:id', function (schema, request) {
     let job = schema.jobs.find(request.params.id);
     return this.serialize(job, 'v2-job');
   });
 
   this.get('/jobs');
 
-  this.get('/builds', function(schema/*, request*/) {
-    return {builds: schema.builds.all().models.map(build => {
+  this.get('/builds', function (schema/* , request*/) {
+    return { builds: schema.builds.all().models.map(build => {
       if (build.commit) {
         build.attrs.commit_id = build.commit.id;
       }
 
       return build;
-    }), commits: schema.commits.all().models};
+    }), commits: schema.commits.all().models };
   });
 
-  this.get('/builds/:id', function(schema, request) {
+  this.get('/builds/:id', function (schema, request) {
     const build = schema.builds.find(request.params.id);
     const response = {
       build: build.attrs,
@@ -151,7 +151,7 @@ export default function() {
     let build = schema.builds.find(request.params.id);
     if (build) {
       return {
-        flash: [{notice: "The build was successfully restarted."}],
+        flash: [{ notice: 'The build was successfully restarted.' }],
         result: true
       };
     } else {
@@ -172,7 +172,7 @@ export default function() {
     let job = schema.jobs.find(request.params.id);
     if (job) {
       return {
-        flash: [{notice: "The job was successfully restarted."}],
+        flash: [{ notice: 'The job was successfully restarted.' }],
         result: true
       };
     } else {
@@ -190,9 +190,9 @@ export default function() {
   });
 
 
-  this.get('/v3/repo/:repo_id/builds', function(schema, request) {
-    const branch = schema.branches.where({name: request.queryParams['branch.name']}).models[0];
-    const builds = schema.builds.where({branchId: branch.id});
+  this.get('/v3/repo/:repo_id/builds', function (schema, request) {
+    const branch = schema.branches.where({ name: request.queryParams['branch.name'] }).models[0];
+    const builds = schema.builds.where({ branchId: branch.id });
 
     /**
       * TODO remove this once the seializers/build is removed.
@@ -204,10 +204,10 @@ export default function() {
     }, 'v3');
   });
 
-  this.get('/jobs/:id/log', function(schema, request) {
+  this.get('/jobs/:id/log', function (schema, request) {
     let log = schema.logs.find(request.params.id);
-    if(log) {
-      return { log: { parts: [{ id: log.attrs.id, number: 1, content: log.attrs.content}] }};
+    if (log) {
+      return { log: { parts: [{ id: log.attrs.id, number: 1, content: log.attrs.content }] } };
     } else {
       return new Mirage.Response(404, {}, {});
     }

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -77,7 +77,8 @@ export default function () {
   this.get('/cron/:id');
 
   this.get('/repos/:id/settings', function (schema, request) {
-    return this.serialize(schema.settings.where({ repositoryId: request.params.id }).models[0], 'v2');
+    let settings = schema.settings.where({ repositoryId: request.params.id }).models[0];
+    return this.serialize(settings, 'v2');
   });
 
   this.get('/repos/:id/caches', function (schema, request) {
@@ -97,7 +98,11 @@ export default function () {
   });
 
   this.get('/settings/ssh_key/:repo_id', function (schema, request) {
-    return this.serialize(schema.sshKeys.where({ repositoryId: request.params.repo_id, type: 'custom' }).models[0], 'v2');
+    let sshKeys = schema.sshKeys.where({
+      repositoryId: request.params.repo_id,
+      type: 'custom'
+    }).models[0];
+    return this.serialize(sshKeys, 'v2');
   });
 
   this.get('/v3/repo/:id', function (schema, request) {
@@ -109,7 +114,10 @@ export default function () {
   });
 
   this.get('/repos/:id/key', function (schema, request) {
-    const key = schema.sshKeys.where({ repositoryId: request.params.id, type: 'default' }).models[0];
+    const key = schema.sshKeys.where({
+      repositoryId: request.params.id,
+      type: 'default'
+    }).models[0];
     return {
       key: key.attrs.key,
       fingerprint: key.attrs.fingerprint

--- a/mirage/factories/account.js
+++ b/mirage/factories/account.js
@@ -1,4 +1,4 @@
-import Mirage/*, {faker} */ from 'ember-cli-mirage';
+import Mirage/* , {faker} */ from 'ember-cli-mirage';
 
 export default Mirage.Factory.extend({
 });

--- a/mirage/factories/branch.js
+++ b/mirage/factories/branch.js
@@ -1,4 +1,4 @@
-import Mirage/*, {faker} */ from 'ember-cli-mirage';
+import Mirage/* , {faker} */ from 'ember-cli-mirage';
 
 export default Mirage.Factory.extend({
 });

--- a/mirage/factories/build.js
+++ b/mirage/factories/build.js
@@ -1,4 +1,4 @@
-import Mirage/*, {faker} */ from 'ember-cli-mirage';
+import Mirage/* , {faker} */ from 'ember-cli-mirage';
 
 export default Mirage.Factory.extend({
 });

--- a/mirage/factories/commit.js
+++ b/mirage/factories/commit.js
@@ -1,4 +1,4 @@
-import Mirage/*, {faker} */ from 'ember-cli-mirage';
+import Mirage/* , {faker} */ from 'ember-cli-mirage';
 
 export default Mirage.Factory.extend({
 });

--- a/mirage/factories/contact.js
+++ b/mirage/factories/contact.js
@@ -3,7 +3,7 @@
 
   Create more files in this directory to define additional factories.
 */
-import Mirage/*, {faker} */ from 'ember-cli-mirage';
+import Mirage/* , {faker} */ from 'ember-cli-mirage';
 
 export default Mirage.Factory.extend({
   // name: 'Pete',                         // strings

--- a/mirage/factories/cron.js
+++ b/mirage/factories/cron.js
@@ -1,4 +1,4 @@
-import Mirage/*, {faker} */ from 'ember-cli-mirage';
+import Mirage/* , {faker} */ from 'ember-cli-mirage';
 
 export default Mirage.Factory.extend({
 });

--- a/mirage/factories/env-var.js
+++ b/mirage/factories/env-var.js
@@ -1,4 +1,4 @@
-import Mirage/*, {faker} */ from 'ember-cli-mirage';
+import Mirage/* , {faker} */ from 'ember-cli-mirage';
 
 export default Mirage.Factory.extend({
 });

--- a/mirage/factories/hook.js
+++ b/mirage/factories/hook.js
@@ -1,4 +1,4 @@
-import Mirage/*, {faker} */ from 'ember-cli-mirage';
+import Mirage/* , {faker} */ from 'ember-cli-mirage';
 
 export default Mirage.Factory.extend({
 });

--- a/mirage/factories/job.js
+++ b/mirage/factories/job.js
@@ -1,4 +1,4 @@
-import Mirage/*, {faker} */ from 'ember-cli-mirage';
+import Mirage/* , {faker} */ from 'ember-cli-mirage';
 
 export default Mirage.Factory.extend({
 });

--- a/mirage/factories/log.js
+++ b/mirage/factories/log.js
@@ -1,4 +1,4 @@
-import Mirage/*, {faker} */ from 'ember-cli-mirage';
+import Mirage/* , {faker} */ from 'ember-cli-mirage';
 
 export default Mirage.Factory.extend({
   content: 'Hello log'

--- a/mirage/factories/repository.js
+++ b/mirage/factories/repository.js
@@ -9,7 +9,7 @@ export default Mirage.Factory.extend({
     if (!repository.attrs.skipPermissions) {
       // Creates permissions for first user in the database
       const user = server.schema.users.all().models[0];
-      server.create('permissions', {user, repository});
+      server.create('permissions', { user, repository });
     }
   }
 });

--- a/mirage/factories/user.js
+++ b/mirage/factories/user.js
@@ -2,7 +2,7 @@ import { Factory } from 'ember-cli-mirage';
 
 export default Factory.extend({
   name: 'Test User',
-  email: "test@travis-ci.com",
+  email: 'test@travis-ci.com',
   correct_scopes: true,
   login: 'testuser',
   synced_at: '2016-01-01T23:04:31Z'

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -1,4 +1,4 @@
-export default function(/* server */) {
+export default function (/* server */) {
 
   // Seed your development database using your factories. This
   // data will not be loaded in your tests.

--- a/mirage/serializers/repository.js
+++ b/mirage/serializers/repository.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { JSONAPISerializer } from 'ember-cli-mirage';
 
 export default JSONAPISerializer.extend({
-  serialize(repository/*, request */) {
+  serialize(repository/* , request */) {
     if (repository.models) {
       return this.turnIntoV3('repo', repository.models);
     } else {
@@ -12,7 +12,7 @@ export default JSONAPISerializer.extend({
 
   _turnIntoV3Singular(type, mirageRecord) {
     let record;
-    if(mirageRecord.attrs) {
+    if (mirageRecord.attrs) {
       record = mirageRecord.attrs;
     }
     record['@type'] = type;
@@ -28,8 +28,8 @@ export default JSONAPISerializer.extend({
 
   turnIntoV3(type, payload) {
     let response;
-    if(Ember.isArray(payload)) {
-      let records = payload.map( (record) => { return this._turnIntoV3Singular(type, record); } );
+    if (Ember.isArray(payload)) {
+      let records = payload.map((record) => { return this._turnIntoV3Singular(type, record); });
       let pluralized = Ember.String.pluralize(type);
       response = {};
       response['@type'] = pluralized;

--- a/mirage/serializers/v2-job.js
+++ b/mirage/serializers/v2-job.js
@@ -1,7 +1,7 @@
 import V2Serializer from './v2';
 
 export default V2Serializer.extend({
-  serialize(job/*, request */) {
+  serialize(job/* , request */) {
     const response = {
       job: job.attrs
     };

--- a/mirage/serializers/v3.js
+++ b/mirage/serializers/v3.js
@@ -3,7 +3,7 @@ import { ActiveModelSerializer } from 'ember-cli-mirage';
 export default ActiveModelSerializer.extend({
   embed: true,
 
-  serialize(object/*, request */) {
+  serialize(object/* , request */) {
     let json = ActiveModelSerializer.prototype.serialize.apply(this, arguments);
 
     if (this.isModel(object)) {

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -7,5 +7,8 @@ module.exports = {
   globals: {
     server: true,
     signInUser: true
+  },
+  rules: {
+    'max-len': 0
   }
 };

--- a/tests/acceptance/auth/automatic-sign-out-test.js
+++ b/tests/acceptance/auth/automatic-sign-out-test.js
@@ -10,13 +10,13 @@ moduleForAcceptance('Acceptance | automatic sign out', {
   }
 });
 
-test('when token is invalid user should be signed out', function(assert) {
+test('when token is invalid user should be signed out', function (assert) {
   window.sessionStorage.setItem('travis.token', 'wrong-token');
   window.localStorage.setItem('travis.token', 'wrong-token');
 
   visit('/');
 
-  andThen(function() {
+  andThen(function () {
     assert.equal(authPage.automaticSignOutNotification, "You've been signed out, because your access token has expired.");
   });
 });

--- a/tests/acceptance/builds/branches-tab-test.js
+++ b/tests/acceptance/builds/branches-tab-test.js
@@ -9,21 +9,21 @@ moduleForAcceptance('Acceptance | builds/branches tab', {
   }
 });
 
-test('visiting /builds/branches-tab', function(assert) {
-  let repo =  server.create('repository', {slug: 'travis-ci/travis-web'});
+test('visiting /builds/branches-tab', function (assert) {
+  let repo =  server.create('repository', { slug: 'travis-ci/travis-web' });
   // create branch
-  server.create('branch', {active: true});
-  let commit = server.create('commit', {author_email: 'mrt@travis-ci.org', author_name: 'Mr T', committer_email: 'mrt@travis-ci.org', committer_name: 'Mr T', branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true});
-  let build = server.create('build', {number: '5', repository: repo, state: 'passed', commit_id: commit.id});
+  server.create('branch', { active: true });
+  let commit = server.create('commit', { author_email: 'mrt@travis-ci.org', author_name: 'Mr T', committer_email: 'mrt@travis-ci.org', committer_name: 'Mr T', branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
+  let build = server.create('build', { number: '5', repository: repo, state: 'passed', commit_id: commit.id });
   build.createCommit();
-  let job = server.create('job', {number: '1234.1', repository: repo, state: 'passed', build_id: build.id, commit_id: commit.id});
+  let job = server.create('job', { number: '1234.1', repository: repo, state: 'passed', build_id: build.id, commit_id: commit.id });
   // create log
   server.create('log', { id: job.id });
 
   branchesRepoTab
     .visit();
 
-  andThen(function() {
+  andThen(function () {
     assert.ok(branchesRepoTab.branchesTabActive, 'Branches tab is active when visiting /org/repo/branches');
   });
 });

--- a/tests/acceptance/builds/cancel-test.js
+++ b/tests/acceptance/builds/cancel-test.js
@@ -9,13 +9,13 @@ moduleForAcceptance('Acceptance | builds/cancel', {
   }
 });
 
-test('cancelling build', function(assert) {
-  let repository =  server.create('repository', {slug: 'travis-ci/travis-web'});
+test('cancelling build', function (assert) {
+  let repository =  server.create('repository', { slug: 'travis-ci/travis-web' });
   // create branch
   server.create('branch', {});
-  let commit = server.create('commit', {author_email: 'mrt@travis-ci.org', author_name: 'Mr T', committer_email: 'mrt@travis-ci.org', committer_name: 'Mr T', branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true});
-  let build = server.create('build', {number: '5', repository_id: repository.id, state: 'running', commit_id: commit.id, commit});
-  let job = server.create('job', {number: '1234.1', repository_id: repository.id, state: 'running', build, commit_id: commit.id});
+  let commit = server.create('commit', { author_email: 'mrt@travis-ci.org', author_name: 'Mr T', committer_email: 'mrt@travis-ci.org', committer_name: 'Mr T', branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
+  let build = server.create('build', { number: '5', repository_id: repository.id, state: 'running', commit_id: commit.id, commit });
+  let job = server.create('job', { number: '1234.1', repository_id: repository.id, state: 'running', build, commit_id: commit.id });
   // create log
   server.create('log', { id: job.id });
 
@@ -23,7 +23,7 @@ test('cancelling build', function(assert) {
     .visit()
     .cancelBuild();
 
-  andThen(function() {
+  andThen(function () {
     assert.equal(buildPage.cancelledNotification, 'Build has been successfully cancelled.', 'cancelled build notification should be displayed');
   });
 });

--- a/tests/acceptance/builds/current-tab-test.js
+++ b/tests/acceptance/builds/current-tab-test.js
@@ -9,25 +9,25 @@ moduleForAcceptance('Acceptance | builds/current tab', {
   }
 });
 
-test('renders most recent repository without builds', function(assert) {
-  server.create('repository', {slug: 'travis-ci/travis-web'});
+test('renders most recent repository without builds', function (assert) {
+  server.create('repository', { slug: 'travis-ci/travis-web' });
 
   currentRepoTab
     .visit();
 
-  andThen(function() {
+  andThen(function () {
     assert.ok(currentRepoTab.currentTabActive, 'Current tab is active by default when loading dashboard');
     assert.equal(currentRepoTab.showsNoBuildsMessaging, 'No builds for this repository', 'Current tab shows no builds message');
   });
 });
 
-test('renders most recent repository and most recent build when builds present', function(assert) {
-  let repo =  server.create('repository', {slug: 'travis-ci/travis-web'});
+test('renders most recent repository and most recent build when builds present', function (assert) {
+  let repo =  server.create('repository', { slug: 'travis-ci/travis-web' });
   // create branch
   server.create('branch', {});
-  let build = server.create('build', {number: '5', repository: repo, state: 'passed'});
-  let commit = server.create('commit', {author_email: 'mrt@travis-ci.org', author_name: 'Mr T', committer_email: 'mrt@travis-ci.org', committer_name: 'Mr T', branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true});
-  let job = server.create('job', {number: '1234.1', repository: repo, state: 'passed', build_id: build.id, commit_id: commit.id});
+  let build = server.create('build', { number: '5', repository: repo, state: 'passed' });
+  let commit = server.create('commit', { author_email: 'mrt@travis-ci.org', author_name: 'Mr T', committer_email: 'mrt@travis-ci.org', committer_name: 'Mr T', branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
+  let job = server.create('job', { number: '1234.1', repository: repo, state: 'passed', build_id: build.id, commit_id: commit.id });
   // create branch
   server.create('log', { id: job.id });
 
@@ -40,7 +40,7 @@ test('renders most recent repository and most recent build when builds present',
   currentRepoTab
     .visit();
 
-  andThen(function() {
+  andThen(function () {
     assert.ok(currentRepoTab.currentTabActive, 'Current tab is active by default when loading dashboard');
     assert.ok(currentRepoTab.showsCurrentBuild, 'Shows current build');
   });

--- a/tests/acceptance/builds/restart-test.js
+++ b/tests/acceptance/builds/restart-test.js
@@ -9,13 +9,13 @@ moduleForAcceptance('Acceptance | builds/restart', {
   }
 });
 
-test('restarting build', function(assert) {
-  let repository =  server.create('repository', {slug: 'travis-ci/travis-web'});
+test('restarting build', function (assert) {
+  let repository =  server.create('repository', { slug: 'travis-ci/travis-web' });
   // create branch
   server.create('branch', {});
-  let commit = server.create('commit', {author_email: 'mrt@travis-ci.org', author_name: 'Mr T', committer_email: 'mrt@travis-ci.org', committer_name: 'Mr T', branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true});
-  let build = server.create('build', {number: '5', repository_id: repository.id, state: 'passed', commit_id: commit.id, commit});
-  let job = server.create('job', {number: '1234.1', repository_id: repository.id, state: 'passed', build, commit_id: commit.id});
+  let commit = server.create('commit', { author_email: 'mrt@travis-ci.org', author_name: 'Mr T', committer_email: 'mrt@travis-ci.org', committer_name: 'Mr T', branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
+  let build = server.create('build', { number: '5', repository_id: repository.id, state: 'passed', commit_id: commit.id, commit });
+  let job = server.create('job', { number: '1234.1', repository_id: repository.id, state: 'passed', build, commit_id: commit.id });
   // create log
   server.create('log', { id: job.id });
 
@@ -23,7 +23,7 @@ test('restarting build', function(assert) {
     .visit()
     .restartBuild();
 
-  andThen(function() {
+  andThen(function () {
     assert.equal(buildPage.restartedNotification, 'The build was successfully restarted.', 'restarted notification should display proper build restarted text');
     assert.equal(buildPage.singleJobLogText, 'Hello log', 'shows log text of single build job');
   });

--- a/tests/acceptance/home-page-test.js
+++ b/tests/acceptance/home-page-test.js
@@ -9,10 +9,10 @@ moduleForAcceptance('Acceptance | home page for user with no repositories', {
   }
 });
 
-test('signed in but without repositories', function(assert) {
+test('signed in but without repositories', function (assert) {
   dashboardPage.visit();
 
-  andThen(function() {
+  andThen(function () {
     assert.equal(currentURL(), '/getting_started');
   });
 });

--- a/tests/acceptance/job-view-test.js
+++ b/tests/acceptance/job-view-test.js
@@ -4,14 +4,14 @@ import jobPage from 'travis/tests/pages/job';
 
 moduleForAcceptance('Acceptance | job view');
 
-test('visiting job-view', function(assert) {
+test('visiting job-view', function (assert) {
 
-  let repo =  server.create('repository', {slug: 'travis-ci/travis-web'});
+  let repo =  server.create('repository', { slug: 'travis-ci/travis-web' });
   // create branch
   server.create('branch', {});
-  let commit = server.create('commit', {author_email: 'mrt@travis-ci.org', author_name: 'Mr T', committer_email: 'mrt@travis-ci.org', committer_name: 'Mr T', branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true});
-  let build = server.create('build', {repository_id: repo.id, state: 'passed', commit_id: commit.id, commit});
-  let job = server.create('job', {number: '1234.1', repository_id: repo.id, state: 'passed', build_id: build.id, commit, build});
+  let commit = server.create('commit', { author_email: 'mrt@travis-ci.org', author_name: 'Mr T', committer_email: 'mrt@travis-ci.org', committer_name: 'Mr T', branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
+  let build = server.create('build', { repository_id: repo.id, state: 'passed', commit_id: commit.id, commit });
+  let job = server.create('job', { number: '1234.1', repository_id: repo.id, state: 'passed', build_id: build.id, commit, build });
   commit.job = job;
 
   job.save();
@@ -20,9 +20,9 @@ test('visiting job-view', function(assert) {
   // create log
   server.create('log', { id: job.id });
 
-  visit('/travis-ci/travis-web/jobs/'+ job.id);
+  visit('/travis-ci/travis-web/jobs/' + job.id);
 
-  andThen(function() {
+  andThen(function () {
     assert.equal(jobPage.branch, 'acceptance-tests');
     assert.equal(jobPage.message, 'acceptance-tests This is a message');
     assert.equal(jobPage.state, '#1234.1 passed');
@@ -33,22 +33,22 @@ test('visiting job-view', function(assert) {
 });
 
 
-test('handling log error', function(assert) {
-  let repo =  server.create('repository', {slug: 'travis-ci/travis-web'});
+test('handling log error', function (assert) {
+  let repo =  server.create('repository', { slug: 'travis-ci/travis-web' });
   // create branch
   server.create('branch', {});
-  let commit = server.create('commit', {author_email: 'mrt@travis-ci.org', author_name: 'Mr T', committer_email: 'mrt@travis-ci.org', committer_name: 'Mr T', branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true});
-  let build = server.create('build', {repository_id: repo.id, state: 'passed', commit_id: commit.id, commit});
-  let job = server.create('job', {number: '1234.1', reposiptoy_id: repo.id, state: 'passed', build_id: build.id, commit, build});
+  let commit = server.create('commit', { author_email: 'mrt@travis-ci.org', author_name: 'Mr T', committer_email: 'mrt@travis-ci.org', committer_name: 'Mr T', branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
+  let build = server.create('build', { repository_id: repo.id, state: 'passed', commit_id: commit.id, commit });
+  let job = server.create('job', { number: '1234.1', reposiptoy_id: repo.id, state: 'passed', build_id: build.id, commit, build });
 
   commit.job = job;
 
   job.save();
   commit.save();
 
-  visit('/travis-ci/travis-web/jobs/'+ job.id);
+  visit('/travis-ci/travis-web/jobs/' + job.id);
 
-  andThen(function() {
+  andThen(function () {
     assert.equal(jobPage.branch, 'acceptance-tests');
     assert.equal(jobPage.message, 'acceptance-tests This is a message');
     assert.equal(jobPage.state, '#1234.1 passed');

--- a/tests/acceptance/job-view-test.js
+++ b/tests/acceptance/job-view-test.js
@@ -5,7 +5,6 @@ import jobPage from 'travis/tests/pages/job';
 moduleForAcceptance('Acceptance | job view');
 
 test('visiting job-view', function (assert) {
-
   let repo =  server.create('repository', { slug: 'travis-ci/travis-web' });
   // create branch
   server.create('branch', {});

--- a/tests/acceptance/jobs/cancel-test.js
+++ b/tests/acceptance/jobs/cancel-test.js
@@ -9,13 +9,13 @@ moduleForAcceptance('Acceptance | jobs/cancel', {
   }
 });
 
-test('restarting job', function(assert) {
-  let repo =  server.create('repository', {slug: 'travis-ci/travis-web'});
+test('restarting job', function (assert) {
+  let repo =  server.create('repository', { slug: 'travis-ci/travis-web' });
   // create branch
   server.create('branch', {});
-  let commit = server.create('commit', {author_email: 'mrt@travis-ci.org', author_name: 'Mr T', committer_email: 'mrt@travis-ci.org', committer_name: 'Mr T', branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true});
-  let build = server.create('build', {repository_id: repo.id, state: 'running', commit_id: commit.id, commit});
-  let job = server.create('job', {number: '1234.1', repository_id: repo.id, state: 'running', build_id: build.id, commit, build});
+  let commit = server.create('commit', { author_email: 'mrt@travis-ci.org', author_name: 'Mr T', committer_email: 'mrt@travis-ci.org', committer_name: 'Mr T', branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
+  let build = server.create('build', { repository_id: repo.id, state: 'running', commit_id: commit.id, commit });
+  let job = server.create('job', { number: '1234.1', repository_id: repo.id, state: 'running', build_id: build.id, commit, build });
   commit.job = job;
 
   job.save();
@@ -28,7 +28,7 @@ test('restarting job', function(assert) {
     .visit()
     .cancelJob();
 
-  andThen(function() {
+  andThen(function () {
     assert.equal(jobPage.cancelledNotification, 'Job has been successfully cancelled.', 'cancelled job notification should be displayed');
   });
 });

--- a/tests/acceptance/jobs/restart-test.js
+++ b/tests/acceptance/jobs/restart-test.js
@@ -9,13 +9,13 @@ moduleForAcceptance('Acceptance | jobs/restart', {
   }
 });
 
-test('restarting job', function(assert) {
-  let repo =  server.create('repository', {slug: 'travis-ci/travis-web'});
+test('restarting job', function (assert) {
+  let repo =  server.create('repository', { slug: 'travis-ci/travis-web' });
   // create branch
   server.create('branch', {});
-  let commit = server.create('commit', {author_email: 'mrt@travis-ci.org', author_name: 'Mr T', committer_email: 'mrt@travis-ci.org', committer_name: 'Mr T', branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true});
-  let build = server.create('build', {repository_id: repo.id, state: 'failed', commit_id: commit.id, commit});
-  let job = server.create('job', {number: '1234.1', repository_id: repo.id, state: 'failed', build_id: build.id, commit, build});
+  let commit = server.create('commit', { author_email: 'mrt@travis-ci.org', author_name: 'Mr T', committer_email: 'mrt@travis-ci.org', committer_name: 'Mr T', branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
+  let build = server.create('build', { repository_id: repo.id, state: 'failed', commit_id: commit.id, commit });
+  let job = server.create('job', { number: '1234.1', repository_id: repo.id, state: 'failed', build_id: build.id, commit, build });
   commit.job = job;
 
   job.save();
@@ -28,7 +28,7 @@ test('restarting job', function(assert) {
     .visit()
     .restartJob();
 
-  andThen(function() {
+  andThen(function () {
     assert.equal(jobPage.restartedNotification, 'The job was successfully restarted.', 'restarted notification should display proper job restarted text');
   });
 });

--- a/tests/acceptance/profile-test.js
+++ b/tests/acceptance/profile-test.js
@@ -53,10 +53,10 @@ moduleForAcceptance('Acceptance | profile', {
   }
 });
 
-test('view profile', function(assert) {
-  profilePage.visit({username: 'feministkilljoy'});
+test('view profile', function (assert) {
+  profilePage.visit({ username: 'feministkilljoy' });
 
-  andThen(function() {
+  andThen(function () {
     assert.equal(profilePage.name, 'Sara Ahmed');
 
     assert.equal(profilePage.accounts().count, 2, 'expected two accounts');
@@ -79,8 +79,8 @@ test('view profile', function(assert) {
   });
 });
 
-test('view token', function(assert) {
-  profilePage.visit({username: 'feministkilljoy'});
+test('view token', function (assert) {
+  profilePage.visit({ username: 'feministkilljoy' });
 
   andThen(() => {
     assert.ok(profilePage.token.isHidden, 'expected token to be hidden by default');
@@ -88,13 +88,13 @@ test('view token', function(assert) {
 
   profilePage.token.show();
 
-  andThen(function() {
+  andThen(function () {
     assert.equal(profilePage.token.value, 'testUserToken');
   });
 });
 
-test('updating hooks', function(assert) {
-  profilePage.visit({username: 'feministkilljoy'});
+test('updating hooks', function (assert) {
+  profilePage.visit({ username: 'feministkilljoy' });
 
   profilePage.administerableHooks(0).toggle();
   profilePage.administerableHooks(1).toggle();

--- a/tests/acceptance/repo-build-list-routes-test.js
+++ b/tests/acceptance/repo-build-list-routes-test.js
@@ -25,7 +25,7 @@ moduleForAcceptance('Acceptance | repo build list routes', {
     const oneYearAgo = new Date();
     oneYearAgo.setYear(oneYearAgo.getFullYear() - 1);
 
-    const beforeOneYearAgo = new Date(oneYearAgo.getTime() - 1000*60*5);
+    const beforeOneYearAgo = new Date(oneYearAgo.getTime() - 1000 * 60 * 5);
 
     const lastBuild = branch.createBuild({
       state: 'passed',
@@ -80,8 +80,8 @@ moduleForAcceptance('Acceptance | repo build list routes', {
   }
 });
 
-test('view crons', function(assert) {
-  page.visitCrons({organization: 'killjoys', repo: 'living-a-feminist-life'});
+test('view crons', function (assert) {
+  page.visitCrons({ organization: 'killjoys', repo: 'living-a-feminist-life' });
 
   andThen(() => {
     assert.equal(page.builds().count, 1, 'expected one cron build');
@@ -97,8 +97,8 @@ test('view crons', function(assert) {
   });
 });
 
-test('view build history', function(assert) {
-  page.visitBuildHistory({organization: 'killjoys', repo: 'living-a-feminist-life'});
+test('view build history', function (assert) {
+  page.visitBuildHistory({ organization: 'killjoys', repo: 'living-a-feminist-life' });
 
   andThen(() => {
     assert.equal(page.builds().count, 3, 'expected three builds');
@@ -117,8 +117,8 @@ test('view build history', function(assert) {
   });
 });
 
-test('view pull requests', function(assert) {
-  page.visitPullRequests({organization: 'killjoys', repo: 'living-a-feminist-life'});
+test('view pull requests', function (assert) {
+  page.visitPullRequests({ organization: 'killjoys', repo: 'living-a-feminist-life' });
 
   andThen(() => {
     assert.equal(page.builds().count, 1, 'expected one pull request build');

--- a/tests/acceptance/repo-builds-test.js
+++ b/tests/acceptance/repo-builds-test.js
@@ -93,8 +93,8 @@ moduleForAcceptance('Acceptance | repo branches', {
   }
 });
 
-test('view branches', function(assert) {
-  branchesPage.visit({organization: 'killjoys', repo: 'living-a-feminist-life'});
+test('view branches', function (assert) {
+  branchesPage.visit({ organization: 'killjoys', repo: 'living-a-feminist-life' });
 
   andThen(() => {
     assert.equal(branchesPage.defaultBranch.name, 'primary');

--- a/tests/acceptance/repo-caches-test.js
+++ b/tests/acceptance/repo-caches-test.js
@@ -17,7 +17,7 @@ moduleForAcceptance('Acceptance | repo caches', {
 
     this.repository = repository;
 
-    const oneDayAgo = new Date(new Date().getTime() - 1000*60*60*24);
+    const oneDayAgo = new Date(new Date().getTime() - 1000 * 60 * 60 * 24);
 
     repository.createCache({
       branch: 'a-branch-name',
@@ -25,7 +25,7 @@ moduleForAcceptance('Acceptance | repo caches', {
       size: 89407938
     });
 
-    const twoDaysAgo = new Date(new Date().getTime() - 1000*60*60*24*2);
+    const twoDaysAgo = new Date(new Date().getTime() - 1000 * 60 * 60 * 24 * 2);
 
     repository.createCache({
       branch: 'PR.1919',
@@ -35,8 +35,8 @@ moduleForAcceptance('Acceptance | repo caches', {
   }
 });
 
-test('view and delete caches', function(assert) {
-  page.visit({organization: 'killjoys', repo: 'living-a-feminist-life'});
+test('view and delete caches', function (assert) {
+  page.visit({ organization: 'killjoys', repo: 'living-a-feminist-life' });
 
   andThen(() => {
     assert.equal(page.pushCaches().count, 1, 'expected one push cache');
@@ -60,14 +60,14 @@ test('view and delete caches', function(assert) {
 
   const requestBodies = [];
 
-  server.delete(`/repos/${this.repository.id}/caches`, function(schema, request) {
+  server.delete(`/repos/${this.repository.id}/caches`, function (schema, request) {
     requestBodies.push(request.requestBody || 'empty');
   });
 
   page.pushCaches(0).delete();
 
   andThen(() => {
-    assert.deepEqual(JSON.parse(requestBodies.pop()), {branch: 'a-branch-name'});
+    assert.deepEqual(JSON.parse(requestBodies.pop()), { branch: 'a-branch-name' });
 
     assert.equal(page.pushCaches().count, 0);
   });

--- a/tests/acceptance/repo-settings-test.js
+++ b/tests/acceptance/repo-settings-test.js
@@ -25,8 +25,8 @@ moduleForAcceptance('Acceptance | repo settings', {
       slug: 'killjoys/living-a-feminist-life',
 
       // FIXME figure out how to define this more cleanly
-      "@permissions": {
-        "create_cron": true
+      '@permissions': {
+        'create_cron': true
       }
     });
 
@@ -95,10 +95,10 @@ moduleForAcceptance('Acceptance | repo settings', {
   }
 });
 
-test('view settings', function(assert) {
-  settingsPage.visit({organization: 'killjoys', repo: 'living-a-feminist-life'});
+test('view settings', function (assert) {
+  settingsPage.visit({ organization: 'killjoys', repo: 'living-a-feminist-life' });
 
-  andThen(function() {
+  andThen(function () {
     assert.ok(settingsPage.buildOnlyWithTravisYml.isActive, 'expected builds only with .travis.yml');
     assert.ok(settingsPage.buildPushes.isActive, 'expected builds for pushes');
 
@@ -128,12 +128,12 @@ test('view settings', function(assert) {
   });
 });
 
-test('change general settings', function(assert) {
-  settingsPage.visit({organization: 'killjoys', repo: 'living-a-feminist-life'});
+test('change general settings', function (assert) {
+  settingsPage.visit({ organization: 'killjoys', repo: 'living-a-feminist-life' });
 
   const requestBodies = [];
 
-  server.patch(`/repos/${this.repository.id}/settings`, function(schema, request) {
+  server.patch(`/repos/${this.repository.id}/settings`, function (schema, request) {
     requestBodies.push(JSON.parse(request.requestBody));
   });
 
@@ -141,44 +141,44 @@ test('change general settings', function(assert) {
 
   andThen(() => {
     assert.notOk(settingsPage.buildPushes.isActive, 'expected no builds for pushes');
-    assert.deepEqual(requestBodies.pop(), {settings: {build_pushes: false}});
+    assert.deepEqual(requestBodies.pop(), { settings: { build_pushes: false } });
   });
 
   settingsPage.buildOnlyWithTravisYml.toggle();
 
   andThen(() => {
     assert.notOk(settingsPage.buildOnlyWithTravisYml.isActive, 'expected builds without .travis.yml');
-    assert.deepEqual(requestBodies.pop(), {settings: {builds_only_with_travis_yml: false}});
+    assert.deepEqual(requestBodies.pop(), { settings: { builds_only_with_travis_yml: false } });
   });
 
   settingsPage.buildPullRequests.toggle();
 
   andThen(() => {
     assert.notOk(settingsPage.buildPullRequests.isActive, 'expected no builds for pull requests');
-    assert.deepEqual(requestBodies.pop(), {settings: {build_pull_requests: false}});
+    assert.deepEqual(requestBodies.pop(), { settings: { build_pull_requests: false } });
   });
 
   settingsPage.limitConcurrentBuilds.fill('2010');
 
   andThen(() => {
     assert.equal(settingsPage.limitConcurrentBuilds.value, '2010');
-    assert.deepEqual(requestBodies.pop(), {settings: {maximum_number_of_builds: 2010}});
+    assert.deepEqual(requestBodies.pop(), { settings: { maximum_number_of_builds: 2010 } });
   });
 
   settingsPage.limitConcurrentBuilds.toggle();
 
   andThen(() => {
     assert.notOk(settingsPage.limitConcurrentBuilds.isActive, 'expected unlimited concurrent builds');
-    assert.deepEqual(requestBodies.pop(), {settings: {maximum_number_of_builds: 0}});
+    assert.deepEqual(requestBodies.pop(), { settings: { maximum_number_of_builds: 0 } });
   });
 });
 
-test('delete and create environment variables', function(assert) {
-  settingsPage.visit({organization: 'killjoys', repo: 'living-a-feminist-life'});
+test('delete and create environment variables', function (assert) {
+  settingsPage.visit({ organization: 'killjoys', repo: 'living-a-feminist-life' });
 
   const deletedIds = [];
 
-  server.delete('/settings/env_vars/:id', function(schema, request) {
+  server.delete('/settings/env_vars/:id', function (schema, request) {
     deletedIds.push(request.params.id);
   });
 
@@ -192,7 +192,7 @@ test('delete and create environment variables', function(assert) {
 
   const requestBodies = [];
 
-  server.post('/settings/env_vars', function(schema, request) {
+  server.post('/settings/env_vars', function (schema, request) {
     const parsedRequestBody = JSON.parse(request.requestBody);
     requestBodies.push(parsedRequestBody);
     return parsedRequestBody;
@@ -208,16 +208,16 @@ test('delete and create environment variables', function(assert) {
     assert.ok(settingsPage.environmentVariables(1).isPublic, 'expected environment variable to be public');
     assert.equal(settingsPage.environmentVariables(1).value, 'true');
 
-    assert.deepEqual(requestBodies.pop(), {env_var: {name: 'drafted', value: 'true', public: true, repository_id: this.repository.id}});
+    assert.deepEqual(requestBodies.pop(), { env_var: { name: 'drafted', value: 'true', public: true, repository_id: this.repository.id } });
   });
 });
 
-test('delete and create crons', function(assert) {
-  settingsPage.visit({organization: 'killjoys', repo: 'living-a-feminist-life'});
+test('delete and create crons', function (assert) {
+  settingsPage.visit({ organization: 'killjoys', repo: 'living-a-feminist-life' });
 
   const deletedIds = [];
 
-  server.delete('/cron/:id', function(schema, request) {
+  server.delete('/cron/:id', function (schema, request) {
     deletedIds.push(request.params.id);
     schema.db.crons.remove(request.params.id);
     return {};
@@ -231,12 +231,12 @@ test('delete and create crons', function(assert) {
   });
 });
 
-test('delete and set SSH keys', function(assert) {
-  settingsPage.visit({organization: 'killjoys', repo: 'living-a-feminist-life'});
+test('delete and set SSH keys', function (assert) {
+  settingsPage.visit({ organization: 'killjoys', repo: 'living-a-feminist-life' });
 
   const deletedIds = [];
 
-  server.delete('/settings/ssh_key/:id', function(schema, request) {
+  server.delete('/settings/ssh_key/:id', function (schema, request) {
     deletedIds.push(request.params.id);
   });
 

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -5,7 +5,7 @@ import destroyApp from '../helpers/destroy-app';
 
 const { RSVP: { Promise } } = Ember;
 
-export default function(name, options = {}) {
+export default function (name, options = {}) {
   module(name, {
     beforeEach() {
       this.application = startApp();

--- a/tests/helpers/sign-in-user.js
+++ b/tests/helpers/sign-in-user.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-export default Ember.Test.registerAsyncHelper('signInUser', function(app, user) {
+export default Ember.Test.registerAsyncHelper('signInUser', function (app, user) {
   const token = 'testUserToken';
   user.attrs.token = token;
   user.save();

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -10,7 +10,7 @@ export default function startApp(attrs) {
   let attributes = Ember.merge({}, config.APP);
   attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
 
-  Ember.run(function() {
+  Ember.run(function () {
     application = Application.create(attributes);
     application.setupForTesting();
     application.injectTestHelpers();

--- a/tests/integration/components/add-env-var-test.js
+++ b/tests/integration/components/add-env-var-test.js
@@ -8,7 +8,7 @@ moduleForComponent('add-env-var', 'Integration | Component | add env-var', {
   integration: true
 });
 
-test('it adds an env var on submit', function(assert) {
+test('it adds an env var on submit', function (assert) {
   assert.expect(6);
 
   // this shouldn't be needed, probably some bug in tests setup with new ember-data
@@ -17,8 +17,8 @@ test('it adds an env var on submit', function(assert) {
   assert.equal(store.peekAll('envVar').get('length'), 0, 'precond: store should be empty');
 
   var repo;
-  Ember.run(function() {
-    repo  = store.push({ data: { id: 1, type: 'repo', attributes: { slug: 'travis-ci/travis-web'}}});
+  Ember.run(function () {
+    repo  = store.push({ data: { id: 1, type: 'repo', attributes: { slug: 'travis-ci/travis-web' } } });
   });
 
   this.set('repo', repo);
@@ -40,10 +40,10 @@ test('it adds an env var on submit', function(assert) {
   assert.ok(!envVar.get('public'), 'env var should be private');
 
   var done = assert.async();
-  setTimeout(function() { done(); }, 500);
+  setTimeout(function () { done(); }, 500);
 });
 
-test('it shows an error if no name is present', function(assert) {
+test('it shows an error if no name is present', function (assert) {
   assert.expect(3);
 
   this.render(hbs`{{add-env-var repo=repo}}`);
@@ -61,7 +61,7 @@ test('it shows an error if no name is present', function(assert) {
   assert.ok(!this.$('.form-error-message').length, 'the error message should be removed after value is changed');
 });
 
-test('it adds a public env var on submit', function(assert) {
+test('it adds a public env var on submit', function (assert) {
   assert.expect(6);
 
   this.registry.register('transform:boolean', DS.BooleanTransform);
@@ -69,8 +69,8 @@ test('it adds a public env var on submit', function(assert) {
   assert.equal(store.peekAll('envVar').get('length'), 0, 'precond: store should be empty');
 
   var repo;
-  Ember.run(function() {
-    repo  = store.push({data: { id: 1, type: 'repo', attributes: { slug: 'travis-ci/travis-web'}}});
+  Ember.run(function () {
+    repo  = store.push({ data: { id: 1, type: 'repo', attributes: { slug: 'travis-ci/travis-web' } } });
   });
 
   this.set('repo', repo);
@@ -94,5 +94,5 @@ test('it adds a public env var on submit', function(assert) {
   assert.ok(envVar.get('public'), 'env var should be public');
 
   var done = assert.async();
-  setTimeout(function() { done(); }, 500);
+  setTimeout(function () { done(); }, 500);
 });

--- a/tests/integration/components/add-ssh-key-test.js
+++ b/tests/integration/components/add-ssh-key-test.js
@@ -73,5 +73,4 @@ test('it throws an error if value for ssh key is blank', function (assert) {
 
   fillIn(this.$('.ssh-value'), 'bar');
   assert.ok(!this.$('.form-error-message').length, 'error message is removed if value is filled in');
-
 });

--- a/tests/integration/components/add-ssh-key-test.js
+++ b/tests/integration/components/add-ssh-key-test.js
@@ -8,15 +8,15 @@ moduleForComponent('add-ssh-key', 'Integration | Component | add ssh-key', {
   integration: true
 });
 
-test('it adds an ssh key on submit', function(assert) {
+test('it adds an ssh key on submit', function (assert) {
   assert.expect(6);
 
   this.registry.register('transform:boolean', DS.BooleanTransform);
   var store = Ember.getOwner(this).lookup('service:store');
 
   var repo;
-  Ember.run(function() {
-    repo  = store.push({data: { id: 1, type: 'repo', attributes: { slug: 'travis-ci/travis-web'}}});
+  Ember.run(function () {
+    repo  = store.push({ data: { id: 1, type: 'repo', attributes: { slug: 'travis-ci/travis-web' } } });
   });
 
   this.set('repo', repo);
@@ -39,19 +39,19 @@ test('it adds an ssh key on submit', function(assert) {
   assert.equal(sshKey.get('id'), 1, 'ssh key id should still be repo id');
 
   var done = assert.async();
-  setTimeout(function() { done(); }, 500);
+  setTimeout(function () { done(); }, 500);
 });
 
 
-test('it throws an error if value for ssh key is blank', function(assert) {
+test('it throws an error if value for ssh key is blank', function (assert) {
   assert.expect(5);
 
   this.registry.register('transform:boolean', DS.BooleanTransform);
   var store = Ember.getOwner(this).lookup('service:store');
 
   var repo;
-  Ember.run(function() {
-    repo  = store.push({data: { id: 1, type: 'repo', attributes: { slug: 'travis-ci/travis-web'}}});
+  Ember.run(function () {
+    repo  = store.push({ data: { id: 1, type: 'repo', attributes: { slug: 'travis-ci/travis-web' } } });
   });
 
   this.set('repo', repo);

--- a/tests/integration/components/branch-row-test.js
+++ b/tests/integration/components/branch-row-test.js
@@ -6,39 +6,39 @@ moduleForComponent('branch-row', 'Integration | Component | branch row', {
   integration: true
 });
 
-test('it renders data correctly', function() {
+test('it renders data correctly', function () {
   const branch = Ember.Object.create({
-    name: "master",
+    name: 'master',
     repository: {
       id: 15038,
-      name: "php-test-staging",
-      slug: "travis-repos/php-test-staging"
+      name: 'php-test-staging',
+      slug: 'travis-repos/php-test-staging'
     },
     default_branch: true,
     exists_on_github: true,
     last_build: {
       id: 393177,
-      number: "1",
-      state: "passed",
+      number: '1',
+      state: 'passed',
       duration: 22,
-      event_type: "push",
+      event_type: 'push',
       previous_state: null,
-      started_at: "2015-03-10T23:19:31Z",
-      finished_at: "2015-03-10T23:19:45Z",
+      started_at: '2015-03-10T23:19:31Z',
+      finished_at: '2015-03-10T23:19:45Z',
       commit: {
         id: 160181,
-        sha: "a82f6ba76c7b729375ed6a1d7a26b765f694df12",
-        ref: "refs/heads/master",
-        message: "Add money example as hello world",
-        compare_url: "https://github.com/travis-repos/php-test-staging/compare/3d86ee98be2b...a82f6ba76c7b",
-        committed_at: "2014-11-20T18:34:04Z",
+        sha: 'a82f6ba76c7b729375ed6a1d7a26b765f694df12',
+        ref: 'refs/heads/master',
+        message: 'Add money example as hello world',
+        compare_url: 'https://github.com/travis-repos/php-test-staging/compare/3d86ee98be2b...a82f6ba76c7b',
+        committed_at: '2014-11-20T18:34:04Z',
         committer: {
-          name: "Dan Buch",
-          avatar_url: "https://0.gravatar.com/avatar/563fd372b4d51781853bc85147f06a36"
+          name: 'Dan Buch',
+          avatar_url: 'https://0.gravatar.com/avatar/563fd372b4d51781853bc85147f06a36'
         },
         author: {
-          name: "Dan Buch",
-          avatar_url: "https://0.gravatar.com/avatar/563fd372b4d51781853bc85147f06a36"
+          name: 'Dan Buch',
+          avatar_url: 'https://0.gravatar.com/avatar/563fd372b4d51781853bc85147f06a36'
         }
       }
     }

--- a/tests/integration/components/env-var-test.js
+++ b/tests/integration/components/env-var-test.js
@@ -7,13 +7,13 @@ moduleForComponent('env-var', 'Integration | Component | env-var', {
   integration: true
 });
 
-test('it renders an env-var with private value', function(assert) {
+test('it renders an env-var with private value', function (assert) {
   assert.expect(2);
 
   this.registry.register('transform:boolean', DS.BooleanTransform);
   var store = Ember.getOwner(this).lookup('service:store');
   Ember.run(() => {
-    var envVar = store.push({data: { id: 1, type: 'env-var', attributes: { name: 'foo', value: 'bar', public: false}}});
+    var envVar = store.push({ data: { id: 1, type: 'env-var', attributes: { name: 'foo', value: 'bar', public: false } } });
     this.set('envVar', envVar);
   });
 
@@ -24,13 +24,13 @@ test('it renders an env-var with private value', function(assert) {
 
 });
 
-test('it renders an env-var with public value', function(assert) {
+test('it renders an env-var with public value', function (assert) {
   assert.expect(2);
 
   this.registry.register('transform:boolean', DS.BooleanTransform);
   var store = Ember.getOwner(this).lookup('service:store');
   Ember.run(() => {
-    var envVar = store.push({data: { id: 1, type: 'env-var', attributes: { name: 'foo', value: 'bar', public: true}}});
+    var envVar = store.push({ data: { id: 1, type: 'env-var', attributes: { name: 'foo', value: 'bar', public: true } } });
     this.set('envVar', envVar);
   });
 

--- a/tests/integration/components/env-var-test.js
+++ b/tests/integration/components/env-var-test.js
@@ -21,7 +21,6 @@ test('it renders an env-var with private value', function (assert) {
 
   assert.equal(this.$('.env-var-name').text(), 'foo', 'name should be displayed');
   assert.equal(this.$('.env-var-value input').val(), '••••••••••••••••', 'value should be hidden');
-
 });
 
 test('it renders an env-var with public value', function (assert) {
@@ -38,7 +37,6 @@ test('it renders an env-var with public value', function (assert) {
 
   assert.equal(this.$('.env-var-name').text(), 'foo', 'name should be displayed');
   assert.equal(this.$('.env-var-value input').val(), 'bar', 'value should not be hidden');
-
 });
 
 // test('it deletes an env-var', function(assert) {

--- a/tests/integration/components/lastbuild-tile-test.js
+++ b/tests/integration/components/lastbuild-tile-test.js
@@ -5,7 +5,7 @@ moduleForComponent('lastbuild-tile', 'Integration | Component | lastbuild tile',
   integration: true
 });
 
-test('it renders', function(assert) {
+test('it renders', function (assert) {
   // Set any properties with this.set('myProperty', 'value');
   // Handle any actions with this.on('myAction', function(val) { ... });"
 

--- a/tests/integration/components/owner-repo-tile-test.js
+++ b/tests/integration/components/owner-repo-tile-test.js
@@ -6,37 +6,37 @@ moduleForComponent('owner-repo-tile', 'OwnerRepoTileComponent', {
   integration:true
 });
 
-test('it renders', function() {
+test('it renders', function () {
   const repo = Ember.Object.create({
-    slug: "travis-ci/travis-chat",
+    slug: 'travis-ci/travis-chat',
     active: false,
-    "private": false,
-		current_build: {
-			number: "25",
-			state: "passed",
-			duration: 252,
-			event_type: "push",
-			previous_state: "passed",
-			started_at: "2013-07-08T11:03:19Z",
-			finished_at: "2013-07-08T11:06:50Z",
-			commit: {
-				sha: "16fff347ff55403caf44c53357855ebc32adf95d",
-				compare_url: "https://github.com/travis-ci/travis-chat/compare/3c4e9ea50141...16fff347ff55"
-			}
-		},
+    'private': false,
+    current_build: {
+      number: '25',
+      state: 'passed',
+      duration: 252,
+      event_type: 'push',
+      previous_state: 'passed',
+      started_at: '2013-07-08T11:03:19Z',
+      finished_at: '2013-07-08T11:06:50Z',
+      commit: {
+        sha: '16fff347ff55403caf44c53357855ebc32adf95d',
+        compare_url: 'https://github.com/travis-ci/travis-chat/compare/3c4e9ea50141...16fff347ff55'
+      }
+    },
     default_branch: {
-      name: "master",
+      name: 'master',
       last_build: {
-        number: "25",
-        state: "passed",
+        number: '25',
+        state: 'passed',
         duration: 252,
-        event_type: "push",
-        previous_state: "passed",
-        started_at: "2013-07-08T11:03:19Z",
-        finished_at: "2013-07-08T11:06:50Z",
+        event_type: 'push',
+        previous_state: 'passed',
+        started_at: '2013-07-08T11:03:19Z',
+        finished_at: '2013-07-08T11:06:50Z',
         commit: {
-          sha: "16fff347ff55403caf44c53357855ebc32adf95d",
-          compare_url: "https://github.com/travis-ci/travis-chat/compare/3c4e9ea50141...16fff347ff55"
+          sha: '16fff347ff55403caf44c53357855ebc32adf95d',
+          compare_url: 'https://github.com/travis-ci/travis-chat/compare/3c4e9ea50141...16fff347ff55'
         }
       }
     }

--- a/tests/integration/components/owner-repo-tile-test.js
+++ b/tests/integration/components/owner-repo-tile-test.js
@@ -3,7 +3,7 @@ import { test, moduleForComponent } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
 moduleForComponent('owner-repo-tile', 'OwnerRepoTileComponent', {
-  integration:true
+  integration: true
 });
 
 test('it renders', function () {

--- a/tests/integration/components/ssh-key-test.js
+++ b/tests/integration/components/ssh-key-test.js
@@ -15,7 +15,6 @@ test('it renders the default ssh key if no custom key is set', function (assert)
 
   assert.equal(this.$('.ssh-key-name').text().trim(), 'no custom key set', 'should display that no custom key is set');
   assert.equal(this.$('.ssh-key-value').text().trim(), 'fingerprint', 'should display default key fingerprint');
-
 });
 
 test('it renders the custom ssh key if custom key is set', function (assert) {
@@ -33,7 +32,6 @@ test('it renders the custom ssh key if custom key is set', function (assert) {
 
   assert.equal(this.$('.ssh-key-name').text().trim(), 'fookey', 'should display key description');
   assert.equal(this.$('.ssh-key-value').text().trim(), 'somethingthing', 'should display custom key fingerprint');
-
 });
 
 
@@ -74,5 +72,4 @@ test('it does not delete the custom key if permissions are insufficient', functi
   this.render(hbs`{{ssh-key key=key sshKeyDeleted="sshKeyDeleted" pushAccess=false}}`);
 
   assert.ok(Ember.isEmpty(this.$('.ssh-key-action').find('a')), 'delete link should not be displayed');
-
 });

--- a/tests/integration/components/ssh-key-test.js
+++ b/tests/integration/components/ssh-key-test.js
@@ -6,10 +6,10 @@ moduleForComponent('ssh-key', 'Integration | Component | ssh-key', {
   integration: true
 });
 
-test('it renders the default ssh key if no custom key is set', function(assert) {
+test('it renders the default ssh key if no custom key is set', function (assert) {
   assert.expect(2);
 
-  var key = Ember.Object.create({fingerprint: 'fingerprint'});
+  var key = Ember.Object.create({ fingerprint: 'fingerprint' });
   this.set('key', key);
   this.render(hbs`{{ssh-key key=key sshKeyDeleted="sshKeyDeleted"}}`);
 
@@ -18,14 +18,14 @@ test('it renders the default ssh key if no custom key is set', function(assert) 
 
 });
 
-test('it renders the custom ssh key if custom key is set', function(assert) {
+test('it renders the custom ssh key if custom key is set', function (assert) {
   assert.expect(2);
 
   var store = Ember.getOwner(this).lookup('service:store');
 
   var key;
-  Ember.run(function() {
-    key = store.push({data: { id: 1, type: 'ssh-key', attributes: { description: 'fookey', fingerprint: 'somethingthing' }}});
+  Ember.run(function () {
+    key = store.push({ data: { id: 1, type: 'ssh-key', attributes: { description: 'fookey', fingerprint: 'somethingthing' } } });
   });
 
   this.set('key', key);
@@ -37,19 +37,19 @@ test('it renders the custom ssh key if custom key is set', function(assert) {
 });
 
 
-test('it deletes a custom key if permissions are right', function(assert) {
+test('it deletes a custom key if permissions are right', function (assert) {
   assert.expect(1);
 
   var store = Ember.getOwner(this).lookup('service:store');
 
   var key;
-  Ember.run(function() {
-    key = store.push({data: { id: 1, type: 'ssh-key', attributes: { description: 'fookey', fingerprint: 'somethingthing' }}});
+  Ember.run(function () {
+    key = store.push({ data: { id: 1, type: 'ssh-key', attributes: { description: 'fookey', fingerprint: 'somethingthing' } } });
   });
 
   this.set('key', key);
   this.render(hbs`{{ssh-key key=key sshKeyDeleted="sshKeyDeleted" pushAccess=true}}`);
-  this.on('sshKeyDeleted', function() {});
+  this.on('sshKeyDeleted', function () {});
 
   this.$('.ssh-key-action a').click();
 
@@ -57,17 +57,17 @@ test('it deletes a custom key if permissions are right', function(assert) {
 
   // we don't deal with saving records for now, so at least wait till it's done
   var done = assert.async();
-  setTimeout(function() { done(); }, 500);
+  setTimeout(function () { done(); }, 500);
 });
 
-test('it does not delete the custom key if permissions are insufficient', function(assert) {
+test('it does not delete the custom key if permissions are insufficient', function (assert) {
   assert.expect(1);
 
   var store = Ember.getOwner(this).lookup('service:store');
 
   var key;
-  Ember.run(function() {
-    key = store.push({data: { id: 1, type: 'ssh-key', attributes: { description: 'fookey', fingerprint: 'somethingthing' }}});
+  Ember.run(function () {
+    key = store.push({ data: { id: 1, type: 'ssh-key', attributes: { description: 'fookey', fingerprint: 'somethingthing' } } });
   });
 
   this.set('key', key);

--- a/tests/integration/v2-serializer-test.js
+++ b/tests/integration/v2-serializer-test.js
@@ -23,12 +23,12 @@ module('Integration | Mirage Serializer | V2Serializer', {
       blogPost: Model.extend()
     });
 
-    const author = this.schema.authors.create({name: 'Sara Ahmed'});
+    const author = this.schema.authors.create({ name: 'Sara Ahmed' });
 
-    author.createBook({title: 'Willful Subjects'});
-    author.createBook({title: 'On Being Included'});
+    author.createBook({ title: 'Willful Subjects' });
+    author.createBook({ title: 'On Being Included' });
 
-    this.schema.blogPosts.create({title: 'Equality Credentials'});
+    this.schema.blogPosts.create({ title: 'Equality Credentials' });
 
     this.registry = new SerializerRegistry(this.schema, {
       application: V2Serializer
@@ -40,7 +40,7 @@ module('Integration | Mirage Serializer | V2Serializer', {
   }
 });
 
-test('it serialises with underscored property keys', function(assert) {
+test('it serialises with underscored property keys', function (assert) {
   const books = this.schema.books.all();
   const result = this.registry.serialize(books);
 
@@ -57,7 +57,7 @@ test('it serialises with underscored property keys', function(assert) {
   });
 });
 
-test('it sideloads included resources', function(assert) {
+test('it sideloads included resources', function (assert) {
   const registryWithInclusion = new SerializerRegistry(this.schema, {
     application: V2Serializer,
     author: V2Serializer.extend({
@@ -86,7 +86,7 @@ test('it sideloads included resources', function(assert) {
   });
 });
 
-test('it uses an underscored container key', function(assert) {
+test('it uses an underscored container key', function (assert) {
   const blogPost = this.schema.blogPosts.find(1);
   const result = this.registry.serialize(blogPost);
 

--- a/tests/integration/v3-serializer-test.js
+++ b/tests/integration/v3-serializer-test.js
@@ -22,10 +22,10 @@ module('Integration | Mirage Serializer | V3Serializer', {
       })
     });
 
-    const author = this.schema.authors.create({name: 'Sara Ahmed'});
+    const author = this.schema.authors.create({ name: 'Sara Ahmed' });
 
-    author.createBook({title: 'Willful Subjects'});
-    author.createBook({title: 'On Being Included'});
+    author.createBook({ title: 'Willful Subjects' });
+    author.createBook({ title: 'On Being Included' });
 
     this.registry = new SerializerRegistry(this.schema, {
       application: V3Serializer,
@@ -40,7 +40,7 @@ module('Integration | Mirage Serializer | V3Serializer', {
   }
 });
 
-test('it serialises a collection with underscored property keys and pagination', function(assert) {
+test('it serialises a collection with underscored property keys and pagination', function (assert) {
   const books = this.schema.books.all();
   const result = this.registry.serialize(books);
 
@@ -69,7 +69,7 @@ test('it serialises a collection with underscored property keys and pagination',
   });
 });
 
-test('it serialises a single resource with its properties included directly and a related resource embedded', function(assert) {
+test('it serialises a single resource with its properties included directly and a related resource embedded', function (assert) {
   const book = this.schema.books.find(1);
   const registryWithInclusion = new SerializerRegistry(this.schema, {
     application: V3Serializer,

--- a/tests/unit/components/build-repo-actions-test.js
+++ b/tests/unit/components/build-repo-actions-test.js
@@ -2,7 +2,7 @@ import { test, moduleForComponent } from 'ember-qunit';
 import Ember from 'ember';
 
 let userStub = Ember.Object.extend({
-  hasAccessToRepo: function(repo) {
+  hasAccessToRepo: function (repo) {
     ok(repo.get('id', 44));
     ok(true, 'hasAccessToRepo was called');
     return false;
@@ -22,7 +22,7 @@ moduleForComponent('build-repo-actions', 'BuildRepoActionsComponent', {
   }
 });
 
-test('it shows cancel button if canCancel is true', function() {
+test('it shows cancel button if canCancel is true', function () {
   var component;
   component = this.subject({
     canCancel: true
@@ -31,7 +31,7 @@ test('it shows cancel button if canCancel is true', function() {
   return ok(component.$('a[title="Cancel Build"]').length, 'cancel link should be visible');
 });
 
-test('it shows restart button if canRestart is true', function() {
+test('it shows restart button if canRestart is true', function () {
   var component;
   component = this.subject({
     canRestart: true
@@ -40,7 +40,7 @@ test('it shows restart button if canRestart is true', function() {
   return ok(component.$('a[title="Restart Build"]').length, 'restart link should be visible');
 });
 
-test('user can cancel if she has permissions to a repo and build is cancelable', function() {
+test('user can cancel if she has permissions to a repo and build is cancelable', function () {
   var build, component;
   build = Ember.Object.create({
     canCancel: false,
@@ -57,7 +57,7 @@ test('user can cancel if she has permissions to a repo and build is cancelable',
   return ok(component.get('canCancel'));
 });
 
-test('user can restart if she has permissions to a repo and job is restartable', function() {
+test('user can restart if she has permissions to a repo and job is restartable', function () {
   var build, component;
   build = Ember.Object.create({
     canRestart: false,
@@ -74,7 +74,7 @@ test('user can restart if she has permissions to a repo and job is restartable',
   return ok(component.get('canRestart'));
 });
 
-test('it properly checks for user permissions for a repo', function() {
+test('it properly checks for user permissions for a repo', function () {
   var component, repo;
   expect(3);
   repo = Ember.Object.create({

--- a/tests/unit/components/builds-item-test.js
+++ b/tests/unit/components/builds-item-test.js
@@ -1,10 +1,10 @@
 // TODO: Convert to integration test
 import { test, moduleForComponent } from 'ember-qunit';
 moduleForComponent('builds-item', {
-    needs: ['helper:format-sha', 'helper:format-duration', 'helper:format-time', 'helper:format-message', 'helper:pretty-date', 'component:status-icon', 'component:request-icon', 'component:user-avatar']
+  needs: ['helper:format-sha', 'helper:format-duration', 'helper:format-time', 'helper:format-message', 'helper:pretty-date', 'component:status-icon', 'component:request-icon', 'component:user-avatar']
 });
 
-test('it renders', function() {
+test('it renders', function () {
   var attributes, component;
   attributes = {
     id: 10000,
@@ -15,7 +15,7 @@ test('it renders', function() {
     pullRequest: false,
     eventType: 'push',
     commit: {
-      sha: "a5e8093098f9c0fb46856b753fb8943c7fbf26f3",
+      sha: 'a5e8093098f9c0fb46856b753fb8943c7fbf26f3',
       branch: 'foobarbranch',
       authorName: 'Test Author',
       authorEmail: 'author@example.com'

--- a/tests/unit/components/caches-item-test.js
+++ b/tests/unit/components/caches-item-test.js
@@ -3,14 +3,14 @@ moduleForComponent('caches-item', 'CachesItemComponent', {
   needs: ['helper:format-time', 'helper:travis-mb', 'component:request-icon']
 });
 
-test('it renders', function() {
+test('it renders', function () {
   var attributes, component;
   attributes = {
     repository_id: 10,
     size: 1024 * 1024,
-    branch: "master",
-    last_modified: "2015-04-16T11:25:00Z",
-    type: "push"
+    branch: 'master',
+    last_modified: '2015-04-16T11:25:00Z',
+    type: 'push'
   };
   component = this.subject({
     cache: attributes

--- a/tests/unit/components/hooks-list-item-test.js
+++ b/tests/unit/components/hooks-list-item-test.js
@@ -3,16 +3,16 @@ moduleForComponent('hooks-list-item', 'HooksListItemComponent', {
   needs: ['component:hook-switch']
 });
 
-test('it renders', function() {
+test('it renders', function () {
   var attributes, component;
   attributes = {
     id: 10000,
-    name: "foo-bar",
-    owner_name: "foo",
-    description: "A foo repo",
+    name: 'foo-bar',
+    owner_name: 'foo',
+    description: 'A foo repo',
     active: true,
-    urlGithub: "https://github.com/foo/foobar",
-    slug: "foo/foo-bar"
+    urlGithub: 'https://github.com/foo/foobar',
+    slug: 'foo/foo-bar'
   };
   component = this.subject({
     hook: attributes

--- a/tests/unit/components/job-repo-actions-test.js
+++ b/tests/unit/components/job-repo-actions-test.js
@@ -2,7 +2,7 @@ import { test, moduleForComponent } from 'ember-qunit';
 import Ember from 'ember';
 
 let userStub = Ember.Object.extend({
-  hasAccessToRepo: function(repo) {
+  hasAccessToRepo: function (repo) {
     ok(repo.get('id', 44));
     ok(true, 'hasAccessToRepo was called');
     return false;
@@ -21,7 +21,7 @@ moduleForComponent('job-repo-actions', 'JobRepoActionsComponent', {
   }
 });
 
-test('it shows cancel button if canCancel is true', function() {
+test('it shows cancel button if canCancel is true', function () {
   var component;
   component = this.subject({
     canCancel: true
@@ -30,7 +30,7 @@ test('it shows cancel button if canCancel is true', function() {
   return ok(component.$('a[title="Cancel job"]').length, 'cancel link should be visible');
 });
 
-test('it shows restart button if canRestart is true', function() {
+test('it shows restart button if canRestart is true', function () {
   var component;
   component = this.subject({
     canRestart: true
@@ -39,7 +39,7 @@ test('it shows restart button if canRestart is true', function() {
   return ok(component.$('a[title="Restart job"]').length, 'restart link should be visible');
 });
 
-test('user can cancel if she has permissions to a repo and job is cancelable', function() {
+test('user can cancel if she has permissions to a repo and job is cancelable', function () {
   var component, job;
   job = Ember.Object.create({
     canCancel: false,
@@ -56,7 +56,7 @@ test('user can cancel if she has permissions to a repo and job is cancelable', f
   return ok(component.get('canCancel'));
 });
 
-test('user can restart if she has permissions to a repo and job is restartable', function() {
+test('user can restart if she has permissions to a repo and job is restartable', function () {
   var component, job;
   job = Ember.Object.create({
     canRestart: false,
@@ -73,7 +73,7 @@ test('user can restart if she has permissions to a repo and job is restartable',
   return ok(component.get('canRestart'));
 });
 
-test('it properly checks for user permissions for a repo', function() {
+test('it properly checks for user permissions for a repo', function () {
   var component, repo;
   expect(3);
   repo = Ember.Object.create({

--- a/tests/unit/components/jobs-item-test.js
+++ b/tests/unit/components/jobs-item-test.js
@@ -4,7 +4,7 @@ moduleForComponent('jobs-item', 'JobsItemComponent', {
   needs: ['helper:format-duration', 'helper:pretty-date', 'component:status-icon']
 });
 
-test('it renders', function() {
+test('it renders', function () {
   var attributes, component, job;
   attributes = {
     id: 10,
@@ -31,7 +31,7 @@ test('it renders', function() {
   return equal(component.$('.job-duration').text().trim(), '1 min 40 sec', 'duration should be displayed');
 });
 
-test('outputs info on not set properties', function() {
+test('outputs info on not set properties', function () {
   var component, job;
   job = Ember.Object.create();
   component = this.subject({
@@ -42,7 +42,7 @@ test('outputs info on not set properties', function() {
   return ok(component.$('.job-lang').text().match(/no language set/), 'a message about no language being set should be displayed');
 });
 
-test('when env is not set, gemfile is displayed in the env section', function() {
+test('when env is not set, gemfile is displayed in the env section', function () {
   var attributes, component, job;
   attributes = {
     id: 10,
@@ -63,7 +63,7 @@ test('when env is not set, gemfile is displayed in the env section', function() 
   return equal(component.$('.job-env .label-align').text().trim(), 'Gemfile: foo/Gemfile', 'env should be displayed');
 });
 
-test('when env is set, gemfile is displayed in the language section', function() {
+test('when env is set, gemfile is displayed in the language section', function () {
   var attributes, component, job;
   attributes = {
     id: 10,

--- a/tests/unit/components/jobs-list-test.js
+++ b/tests/unit/components/jobs-list-test.js
@@ -5,7 +5,7 @@ moduleForComponent('jobs-list', 'JobsListComponent', {
   needs: ['helper:format-duration', 'component:jobs-item']
 });
 
-test('it renders a list of jobs', function() {
+test('it renders a list of jobs', function () {
   var component, jobs;
   jobs = [
     Ember.Object.create({
@@ -27,7 +27,7 @@ test('it renders a list of jobs', function() {
   return ok(component.$('.jobs-item:nth(1)').hasClass('failed'), 'failed class should be applied to a job');
 });
 
-test('it renders "Allowed Failures" version without a `required` property', function() {
+test('it renders "Allowed Failures" version without a `required` property', function () {
   var component, jobs;
   jobs = [
     Ember.Object.create({

--- a/tests/unit/components/loading-indicator-test.js
+++ b/tests/unit/components/loading-indicator-test.js
@@ -4,7 +4,7 @@ moduleForComponent('loading-indicator', {
   unit: true
 });
 
-test('it renders', function() {
+test('it renders', function () {
   var component;
   component = this.subject({
     center: true

--- a/tests/unit/components/no-builds-test.js
+++ b/tests/unit/components/no-builds-test.js
@@ -3,7 +3,7 @@ moduleForComponent('no-builds', {
   unit: true
 });
 
-test('it renders', function(assert) {
+test('it renders', function (assert) {
   var component;
   assert.expect(2);
   component = this.subject();

--- a/tests/unit/components/not-active-test.js
+++ b/tests/unit/components/not-active-test.js
@@ -13,7 +13,7 @@ moduleForComponent('not-active', 'Unit | Component | not active', {
   }
 });
 
-test('canActivate returns true if a user has access to a repo', function(assert) {
+test('canActivate returns true if a user has access to a repo', function (assert) {
   let component = this.subject();
   let repo = Ember.Object.create({ id: 1 });
 
@@ -22,13 +22,13 @@ test('canActivate returns true if a user has access to a repo', function(assert)
   assert.ok(component.get('canActivate'));
 });
 
-test("canActivate returns false if user doesn't exist", function(assert) {
+test("canActivate returns false if user doesn't exist", function (assert) {
   let component = this.subject();
 
   assert.ok(!component.get('canActivate'));
 });
 
-test("canActivate returns false if user doesn't push access to the repo", function(assert) {
+test("canActivate returns false if user doesn't push access to the repo", function (assert) {
   let component = this.subject();
 
   let repo = Ember.Object.create({ id: 2 });

--- a/tests/unit/components/repo-actions-test.js
+++ b/tests/unit/components/repo-actions-test.js
@@ -6,9 +6,7 @@ moduleForComponent('repo-actions', 'RepoActionsComponent', {
 });
 
 test('it renders', function () {
-
-  var component;
-  component = this.subject({});
+  let component = this.subject({});
   this.render();
   return ok(component.$().hasClass('repo-main-tools'), 'component has class');
 });

--- a/tests/unit/components/repo-actions-test.js
+++ b/tests/unit/components/repo-actions-test.js
@@ -5,7 +5,7 @@ moduleForComponent('repo-actions', 'RepoActionsComponent', {
   needs: ['component:build-repo-actions', 'component:job-repo-actions']
 });
 
-test('it renders', function() {
+test('it renders', function () {
 
   var component;
   component = this.subject({});

--- a/tests/unit/components/requests-item-test.js
+++ b/tests/unit/components/requests-item-test.js
@@ -3,7 +3,7 @@ moduleForComponent('requests-item', {
   needs: ['helper:format-message', 'helper:format-time', 'helper:github-commit-link', 'component:status-icon', 'component:request-icon']
 });
 
-test('it renders request data', function(assert) {
+test('it renders request data', function (assert) {
   var component, request, yesterday;
   yesterday = new Date();
   yesterday.setDate(yesterday.getDate() - 1);
@@ -35,7 +35,7 @@ test('it renders request data', function(assert) {
   return assert.equal(component.$('.row-item:nth-child(5)').text().trim(), '10', 'build number should be displayed');
 });
 
-test('it renders PR number if a request is a PR', function(assert) {
+test('it renders PR number if a request is a PR', function (assert) {
   var component, request;
   request = {
     id: 1,

--- a/tests/unit/components/travis-status-test.js
+++ b/tests/unit/components/travis-status-test.js
@@ -5,13 +5,13 @@ moduleForComponent('travis-status', 'TravisStatusComponent', {
   unit: true
 });
 
-test('adds incident class to .status-circle', function() {
+test('adds incident class to .status-circle', function () {
   var component;
   expect(3);
   component = this.subject();
-  component.statusPageStatusUrl = "https://status-url.example.com";
-  component.getStatus = function() {
-    return new Ember.RSVP.Promise(function(resolve/*, reject*/) {
+  component.statusPageStatusUrl = 'https://status-url.example.com';
+  component.getStatus = function () {
+    return new Ember.RSVP.Promise(function (resolve/* , reject*/) {
       return resolve({
         status: {
           indicator: 'major'

--- a/tests/unit/components/user-avatar-test.js
+++ b/tests/unit/components/user-avatar-test.js
@@ -5,12 +5,12 @@ moduleForComponent('user-avatar', 'UserAvatarComponent | Unit', {
   unit: true
 });
 
-test('it renders', function() {
+test('it renders', function () {
 
-  var name = "Hello Test";
-  var url = "https://someurl.com/someimage.jpg";
+  var name = 'Hello Test';
+  var url = 'https://someurl.com/someimage.jpg';
 
-  var component = this.subject({url: url, name: name});
+  var component = this.subject({ url: url, name: name });
   this.render();
 
   ok(component.$().hasClass('avatar'), 'component should have right class');

--- a/tests/unit/components/user-avatar-test.js
+++ b/tests/unit/components/user-avatar-test.js
@@ -6,7 +6,6 @@ moduleForComponent('user-avatar', 'UserAvatarComponent | Unit', {
 });
 
 test('it renders', function () {
-
   var name = 'Hello Test';
   var url = 'https://someurl.com/someimage.jpg';
 

--- a/tests/unit/mixins/polling-test.js
+++ b/tests/unit/mixins/polling-test.js
@@ -4,30 +4,30 @@ import Ember from 'ember';
 import Polling from 'travis/mixins/polling';
 
 var hookRuns = 0,
-    pollingChangesHistory = [];
+  pollingChangesHistory = [];
 
-define('travis/components/polling-test', [], function() {
+define('travis/components/polling-test', [], function () {
   var PollingService;
   PollingService = Ember.Object.extend({
-    startPolling: function(model) {
+    startPolling: function (model) {
       return pollingChangesHistory.push({
         type: 'start',
         model: model
       });
     },
-    stopPolling: function(model) {
+    stopPolling: function (model) {
       return pollingChangesHistory.push({
         type: 'stop',
         model: model
       });
     },
-    startPollingHook: function(source) {
+    startPollingHook: function (source) {
       return pollingChangesHistory.push({
         type: 'start-hook',
         source: source + ''
       });
     },
-    stopPollingHook: function(source) {
+    stopPollingHook: function (source) {
       return pollingChangesHistory.push({
         type: 'stop-hook',
         source: source + ''
@@ -35,15 +35,15 @@ define('travis/components/polling-test', [], function() {
     }
   });
   return Ember.Component.extend(Polling, {
-    init: function() {
+    init: function () {
       this._super.apply(this, arguments);
       return this.set('polling', PollingService.create());
     },
     pollModels: ['model1', 'model2'],
-    pollHook: function() {
+    pollHook: function () {
       return hookRuns += 1;
     },
-    toString: function() {
+    toString: function () {
       return '<PollingTestingComponent>';
     }
   });
@@ -51,19 +51,19 @@ define('travis/components/polling-test', [], function() {
 
 moduleForComponent('polling-test', 'PollingMixin', {
   needs: [],
-  setup: function() {
+  setup: function () {
     hookRuns = 0;
     return pollingChangesHistory = [];
   }
 });
 
-test('it properly stops polling hook without any models', function() {
+test('it properly stops polling hook without any models', function () {
   var component, expected;
   component = this.subject({
     pollModels: null
   });
   this.render();
-  Ember.run(function() {
+  Ember.run(function () {
     return component.destroy();
   });
   expected = [
@@ -78,7 +78,7 @@ test('it properly stops polling hook without any models', function() {
   return deepEqual(pollingChangesHistory, expected);
 });
 
-test('it works even if one of the model is null', function() {
+test('it works even if one of the model is null', function () {
   var component, expected;
   component = this.subject({
     model1: {
@@ -86,7 +86,7 @@ test('it works even if one of the model is null', function() {
     }
   });
   this.render();
-  Ember.run(function() {
+  Ember.run(function () {
     return component.destroy();
   });
   expected = [
@@ -111,7 +111,7 @@ test('it works even if one of the model is null', function() {
   return deepEqual(pollingChangesHistory, expected);
 });
 
-test('it polls for both models if they are present', function() {
+test('it polls for both models if they are present', function () {
   var component, expected;
   component = this.subject({
     model1: {
@@ -122,7 +122,7 @@ test('it polls for both models if they are present', function() {
     }
   });
   this.render();
-  Ember.run(function() {
+  Ember.run(function () {
     return component.destroy();
   });
   expected = [
@@ -157,7 +157,7 @@ test('it polls for both models if they are present', function() {
   return deepEqual(pollingChangesHistory, expected);
 });
 
-test('it detects model changes', function() {
+test('it detects model changes', function () {
   var component, expected;
   component = this.subject({
     model1: {
@@ -165,12 +165,12 @@ test('it detects model changes', function() {
     }
   });
   this.render();
-  Ember.run(function() {
+  Ember.run(function () {
     return component.set('model1', {
       name: 'bar'
     });
   });
-  Ember.run(function() {
+  Ember.run(function () {
     return component.destroy();
   });
   expected = [

--- a/tests/unit/models/commit-test.js
+++ b/tests/unit/models/commit-test.js
@@ -4,10 +4,10 @@ moduleForModel('commit', 'Unit | Model | commit', {
   needs: ['model:build']
 });
 
-test('calculation of avatar urls via Gravatar', function() {
+test('calculation of avatar urls via Gravatar', function () {
   var model;
   model = this.subject();
-  Ember.run(function() {
+  Ember.run(function () {
     return model.setProperties({
       authorEmail: 'author@example.com',
       committerEmail: 'author@example.com',
@@ -19,10 +19,10 @@ test('calculation of avatar urls via Gravatar', function() {
   return equal(model.get('committerAvatarUrlOrGravatar'), 'https://www.gravatar.com/avatar/5c1e6d6e64e12aca17657581a48005d1?s=40&d=blank', 'correctly sets gravatar image');
 });
 
-test('calculation of avatar urls via overriding parameter', function() {
+test('calculation of avatar urls via overriding parameter', function () {
   var model;
   model = this.subject();
-  Ember.run(function() {
+  Ember.run(function () {
     return model.setProperties({
       authorEmail: 'author@example.com',
       committerEmail: 'author@example.com',

--- a/tests/unit/serializers/build-test.js
+++ b/tests/unit/serializers/build-test.js
@@ -16,13 +16,13 @@ test('it normalizes the singular response', function () {
       event_type: 'push',
       pull_request: false,
       pull_request_title: null,
-      pull_request_number:null,
+      pull_request_number: null,
       config: { 'language': 'ruby' },
       state: 'passed',
       started_at: '2016-02-24T16:37:54Z',
-      finished_at:'2016-02-24T16:40:10Z',
+      finished_at: '2016-02-24T16:40:10Z',
       duration: 72,
-      job_ids:[5, 6]
+      job_ids: [5, 6]
     },
     commit: {
       id: 3,
@@ -50,7 +50,7 @@ test('it normalizes the singular response', function () {
       finished_at: '2016-02-24T16:38:19Z',
       queue: 'builds.docker',
       allow_failure: false,
-      tags:null
+      tags: null
     }, {
       id: 6,
       repository_id: 2,
@@ -64,7 +64,7 @@ test('it normalizes the singular response', function () {
       finished_at: '2016-02-24T16:38:19Z',
       queue: 'builds.docker',
       allow_failure: false,
-      tags:null
+      tags: null
     }]
   };
 

--- a/tests/unit/serializers/build-test.js
+++ b/tests/unit/serializers/build-test.js
@@ -5,37 +5,37 @@ moduleForModel('build', 'Unit | Serializer | build', {
   needs: ['serializer:build', 'model:commit', 'model:job', 'model:branch']
 });
 
-test("it normalizes the singular response", function() {
+test('it normalizes the singular response', function () {
   QUnit.dump.maxDepth = 10;
   let payload = {
     build: {
       id: 1,
       repository_id: 2,
       commit_id: 3,
-      number: "10",
-      event_type: "push",
+      number: '10',
+      event_type: 'push',
       pull_request: false,
       pull_request_title: null,
       pull_request_number:null,
-      config: { "language": "ruby" },
-      state: "passed",
-      started_at: "2016-02-24T16:37:54Z",
-      finished_at:"2016-02-24T16:40:10Z",
+      config: { 'language': 'ruby' },
+      state: 'passed',
+      started_at: '2016-02-24T16:37:54Z',
+      finished_at:'2016-02-24T16:40:10Z',
       duration: 72,
       job_ids:[5, 6]
     },
     commit: {
       id: 3,
-      sha: "864c69a9588024331ba0190e9d8492ae0b6d5eff",
-      branch: "development",
+      sha: '864c69a9588024331ba0190e9d8492ae0b6d5eff',
+      branch: 'development',
       branch_is_default: false,
-      message: "A commit",
-      committed_at: "2016-02-24T16:36:23Z",
-      author_name: "Mr. Travis",
-      author_email: "nothing@travis-ci.org",
-      committer_name: "Mr. Travis",
-      committer_email: "nothing@travis-ci.org",
-      compare_url: "https://github.com/drogus/test-project-1/compare/432d5426aa67...864c69a95880"
+      message: 'A commit',
+      committed_at: '2016-02-24T16:36:23Z',
+      author_name: 'Mr. Travis',
+      author_email: 'nothing@travis-ci.org',
+      committer_name: 'Mr. Travis',
+      committer_email: 'nothing@travis-ci.org',
+      compare_url: 'https://github.com/drogus/test-project-1/compare/432d5426aa67...864c69a95880'
     },
     jobs: [{
       id: 5,
@@ -43,26 +43,26 @@ test("it normalizes the singular response", function() {
       build_id: 1,
       commit_id: 3,
       log_id: 7,
-      state: "passed",
-      number: "10.1",
-      config: { "language": "ruby" },
-      started_at: "2016-02-24T16:37:54Z",
-      finished_at: "2016-02-24T16:38:19Z",
-      queue: "builds.docker",
+      state: 'passed',
+      number: '10.1',
+      config: { 'language': 'ruby' },
+      started_at: '2016-02-24T16:37:54Z',
+      finished_at: '2016-02-24T16:38:19Z',
+      queue: 'builds.docker',
       allow_failure: false,
       tags:null
-    },{
+    }, {
       id: 6,
       repository_id: 2,
       build_id: 1,
       commit_id: 3,
       log_id: 8,
-      state: "passed",
-      number: "10.2",
-      config: { "language": "ruby" },
-      started_at: "2016-02-24T16:37:54Z",
-      finished_at: "2016-02-24T16:38:19Z",
-      queue: "builds.docker",
+      state: 'passed',
+      number: '10.2',
+      config: { 'language': 'ruby' },
+      started_at: '2016-02-24T16:37:54Z',
+      finished_at: '2016-02-24T16:38:19Z',
+      queue: 'builds.docker',
       allow_failure: false,
       tags:null
     }]
@@ -74,115 +74,115 @@ test("it normalizes the singular response", function() {
   let result = serializer.normalizeResponse(store, store.modelFor('build'), payload, 1, 'findRecord');
 
   let expectedResult = {
-    "data": {
-      "id": "1",
-      "type": "build",
-      "attributes": {
-        "state": "passed",
-        "number": 10,
-        "_duration": 72,
-        "_config": { "language": "ruby" },
-        "_startedAt": "2016-02-24T16:37:54Z",
-        "_finishedAt": "2016-02-24T16:40:10Z",
-        "pullRequest": false,
-        "pullRequestTitle": null,
-        "pullRequestNumber": null,
-        "eventType": "push"
+    'data': {
+      'id': '1',
+      'type': 'build',
+      'attributes': {
+        'state': 'passed',
+        'number': 10,
+        '_duration': 72,
+        '_config': { 'language': 'ruby' },
+        '_startedAt': '2016-02-24T16:37:54Z',
+        '_finishedAt': '2016-02-24T16:40:10Z',
+        'pullRequest': false,
+        'pullRequestTitle': null,
+        'pullRequestNumber': null,
+        'eventType': 'push'
       },
-      "relationships": {
-        "branch": {
-          "data": {
-            "name": "development",
-            "default_branch": false,
-            "@href": "\/repo\/2\/branch\/development",
-            "id": "\/repo\/2\/branch\/development",
-            "type": "branch"
+      'relationships': {
+        'branch': {
+          'data': {
+            'name': 'development',
+            'default_branch': false,
+            '@href': '\/repo\/2\/branch\/development',
+            'id': '\/repo\/2\/branch\/development',
+            'type': 'branch'
           }
         },
-        "repo": {
-          "data": {
-            "id": "2",
-            "type": "repo"
+        'repo': {
+          'data': {
+            'id': '2',
+            'type': 'repo'
           }
         },
-        "commit": {
-          "data": {
-            "id": "3",
-            "sha": "864c69a9588024331ba0190e9d8492ae0b6d5eff",
-            "branch": "development",
-            "branch_is_default": false,
-            "message": "A commit",
-            "committed_at": "2016-02-24T16:36:23Z",
-            "author_name": "Mr. Travis",
-            "author_email": "nothing@travis-ci.org",
-            "committer_name": "Mr. Travis",
-            "committer_email": "nothing@travis-ci.org",
-            "compare_url": "https:\/\/github.com\/drogus\/test-project-1\/compare\/432d5426aa67...864c69a95880",
-            "type": "commit"
+        'commit': {
+          'data': {
+            'id': '3',
+            'sha': '864c69a9588024331ba0190e9d8492ae0b6d5eff',
+            'branch': 'development',
+            'branch_is_default': false,
+            'message': 'A commit',
+            'committed_at': '2016-02-24T16:36:23Z',
+            'author_name': 'Mr. Travis',
+            'author_email': 'nothing@travis-ci.org',
+            'committer_name': 'Mr. Travis',
+            'committer_email': 'nothing@travis-ci.org',
+            'compare_url': 'https:\/\/github.com\/drogus\/test-project-1\/compare\/432d5426aa67...864c69a95880',
+            'type': 'commit'
           }
         },
-        "jobs": {
-          "data": [
+        'jobs': {
+          'data': [
             {
-              "id": "5",
-              "repository_id": 2,
-              "build_id": 1,
-              "commit_id": 3,
-              "log_id": 7,
-              "state": "passed",
-              "number": "10.1",
-              "config": { "language": "ruby" },
-              "started_at": "2016-02-24T16:37:54Z",
-              "finished_at": "2016-02-24T16:38:19Z",
-              "queue": "builds.docker",
-              "allow_failure": false,
-              "tags": null,
-              "type": "job"
+              'id': '5',
+              'repository_id': 2,
+              'build_id': 1,
+              'commit_id': 3,
+              'log_id': 7,
+              'state': 'passed',
+              'number': '10.1',
+              'config': { 'language': 'ruby' },
+              'started_at': '2016-02-24T16:37:54Z',
+              'finished_at': '2016-02-24T16:38:19Z',
+              'queue': 'builds.docker',
+              'allow_failure': false,
+              'tags': null,
+              'type': 'job'
             },
             {
-              "id": "6",
-              "repository_id": 2,
-              "build_id": 1,
-              "commit_id": 3,
-              "log_id": 8,
-              "state": "passed",
-              "number": "10.2",
-              "config": { "language": "ruby" },
-              "started_at": "2016-02-24T16:37:54Z",
-              "finished_at": "2016-02-24T16:38:19Z",
-              "queue": "builds.docker",
-              "allow_failure": false,
-              "tags": null,
-              "type": "job"
+              'id': '6',
+              'repository_id': 2,
+              'build_id': 1,
+              'commit_id': 3,
+              'log_id': 8,
+              'state': 'passed',
+              'number': '10.2',
+              'config': { 'language': 'ruby' },
+              'started_at': '2016-02-24T16:37:54Z',
+              'finished_at': '2016-02-24T16:38:19Z',
+              'queue': 'builds.docker',
+              'allow_failure': false,
+              'tags': null,
+              'type': 'job'
             }
           ]
         }
       }
     },
-    "included": [
+    'included': [
       {
-        "id": "\/repo\/2\/branch\/development",
-        "type": "branch",
-        "attributes": {},
-        "relationships": {}
+        'id': '\/repo\/2\/branch\/development',
+        'type': 'branch',
+        'attributes': {},
+        'relationships': {}
       },
       {
-        "id": "3",
-        "type": "commit",
-        "attributes": {},
-        "relationships": {}
+        'id': '3',
+        'type': 'commit',
+        'attributes': {},
+        'relationships': {}
       },
       {
-        "id": "5",
-        "type": "job",
-        "attributes": {},
-        "relationships": {}
+        'id': '5',
+        'type': 'job',
+        'attributes': {},
+        'relationships': {}
       },
       {
-        "id": "6",
-        "type": "job",
-        "attributes": {},
-        "relationships": {}
+        'id': '6',
+        'type': 'job',
+        'attributes': {},
+        'relationships': {}
       }
     ]
   };

--- a/tests/unit/services/flashes-test.js
+++ b/tests/unit/services/flashes-test.js
@@ -5,7 +5,7 @@ moduleFor('service:flashes', 'Unit | Service | flashes', {
   // needs: ['service:foo']
 });
 
-test('it allows to show an error', function(assert) {
+test('it allows to show an error', function (assert) {
   let service = this.subject();
 
   assert.equal(service.get('flashes.length'), 0, 'precond - flashes initializes with 0 elements');
@@ -15,7 +15,7 @@ test('it allows to show an error', function(assert) {
   assert.deepEqual(service.get('flashes.firstObject'), { message: 'There was an error!', type: 'error' }, 'there should be an error message in flashes');
 });
 
-test('it allows to show a notice', function(assert) {
+test('it allows to show a notice', function (assert) {
   let service = this.subject();
 
   assert.equal(service.get('flashes.length'), 0, 'precond - flashes initializes with 0 elements');
@@ -25,7 +25,7 @@ test('it allows to show a notice', function(assert) {
   assert.deepEqual(service.get('flashes.firstObject'), { message: 'There was a notice!', type: 'notice' }, 'there should be a notice message in flashes');
 });
 
-test('it allows to show a success', function(assert) {
+test('it allows to show a success', function (assert) {
   let service = this.subject();
 
   assert.equal(service.get('flashes.length'), 0, 'precond - flashes initializes with 0 elements');

--- a/tests/unit/services/permissions-test.js
+++ b/tests/unit/services/permissions-test.js
@@ -12,7 +12,7 @@ moduleFor('service:permissions', 'Unit | Service | permissions', {
   }
 });
 
-test('it checks permissions', function(assert) {
+test('it checks permissions', function (assert) {
   let service = this.subject();
   service.set('currentUser.permissions', [1]);
 
@@ -23,20 +23,20 @@ test('it checks permissions', function(assert) {
   assert.notOk(service.hasPermission(1));
 });
 
-test('it checks permissions if a repo object is given', function(assert) {
+test('it checks permissions if a repo object is given', function (assert) {
   let service = this.subject();
   service.set('currentUser.permissions', [1, 3]);
 
   let repo1 = Ember.Object.create({ id: 1 }),
-      repo2 = Ember.Object.create({ id: 2 }),
-      repo3 = Ember.Object.create({ id: '3' });
+    repo2 = Ember.Object.create({ id: 2 }),
+    repo3 = Ember.Object.create({ id: '3' });
 
   assert.ok(service.hasPermission(repo1));
   assert.notOk(service.hasPermission(repo2));
   assert.ok(service.hasPermission(repo3));
 });
 
-test('it checks push permissions', function(assert) {
+test('it checks push permissions', function (assert) {
   let service = this.subject();
   service.set('currentUser.pushPermissions', [1]);
 
@@ -48,20 +48,20 @@ test('it checks push permissions', function(assert) {
   assert.notOk(service.hasPushPermission(1));
 });
 
-test('it checks push permissions if a repo object is given', function(assert) {
+test('it checks push permissions if a repo object is given', function (assert) {
   let service = this.subject();
   service.set('currentUser.pushPermissions', [1, 3]);
 
   let repo1 = Ember.Object.create({ id: 1 }),
-      repo2 = Ember.Object.create({ id: 2 }),
-      repo3 = Ember.Object.create({ id: '3' });
+    repo2 = Ember.Object.create({ id: 2 }),
+    repo3 = Ember.Object.create({ id: '3' });
 
   assert.ok(service.hasPushPermission(repo1));
   assert.notOk(service.hasPushPermission(repo2));
   assert.ok(service.hasPushPermission(repo3));
 });
 
-test('it checks admin permissions', function(assert) {
+test('it checks admin permissions', function (assert) {
   let service = this.subject();
   service.set('currentUser.adminPermissions', [1]);
 
@@ -73,13 +73,13 @@ test('it checks admin permissions', function(assert) {
   assert.notOk(service.hasAdminPermission(1));
 });
 
-test('it checks admin permissions if a repo object is given', function(assert) {
+test('it checks admin permissions if a repo object is given', function (assert) {
   let service = this.subject();
   service.set('currentUser.adminPermissions', [1, 3]);
 
   let repo1 = Ember.Object.create({ id: 1 }),
-      repo2 = Ember.Object.create({ id: 2 }),
-      repo3 = Ember.Object.create({ id: '3' });
+    repo2 = Ember.Object.create({ id: 2 }),
+    repo3 = Ember.Object.create({ id: '3' });
 
   assert.ok(service.hasAdminPermission(repo1));
   assert.ok(service.hasAdminPermission(repo3));

--- a/tests/unit/services/polling-test.js
+++ b/tests/unit/services/polling-test.js
@@ -11,14 +11,14 @@ module('PollingService', {
   teardown() {
     config.ajaxPolling = false;
     if (!service.get('isDestroyed')) {
-      return Ember.run(function() {
+      return Ember.run(function () {
         return service.destroy();
       });
     }
   }
 });
 
-test('polls for each of the models', function() {
+test('polls for each of the models', function () {
   var history, model1, model2;
   expect(3);
   history = [];
@@ -26,13 +26,13 @@ test('polls for each of the models', function() {
     pollingInterval: 20
   });
   model1 = {
-    reload: function() {
+    reload: function () {
       ok(true);
       return history.push('model1');
     }
   };
   model2 = {
-    reload: function() {
+    reload: function () {
       ok(true);
       return history.push('model2');
     }
@@ -40,39 +40,39 @@ test('polls for each of the models', function() {
   service.startPolling(model1);
   service.startPolling(model2);
   stop();
-  return setTimeout(function() {
+  return setTimeout(function () {
     start();
     deepEqual(history, ['model1', 'model2']);
-    return Ember.run(function() {
+    return Ember.run(function () {
       return service.destroy();
     });
   }, 30);
 });
 
-test('it will stop running any reloads after it is destroyed', function() {
+test('it will stop running any reloads after it is destroyed', function () {
   var model;
   expect(1);
   service = Polling.create({
     pollingInterval: 20
   });
   model = {
-    reload: function() {
+    reload: function () {
       return ok(true);
     }
   };
   service.startPolling(model);
   stop();
-  setTimeout(function() {
-    return Ember.run(function() {
+  setTimeout(function () {
+    return Ember.run(function () {
       return service.destroy();
     });
   }, 30);
-  return setTimeout(function() {
+  return setTimeout(function () {
     return start();
   }, 50);
 });
 
-test('it stops reloading models after they were removed from polling', function() {
+test('it stops reloading models after they were removed from polling', function () {
   var history, model1, model2;
   expect(4);
   history = [];
@@ -80,13 +80,13 @@ test('it stops reloading models after they were removed from polling', function(
     pollingInterval: 30
   });
   model1 = {
-    reload: function() {
+    reload: function () {
       ok(true);
       return history.push('model1');
     }
   };
   model2 = {
-    reload: function() {
+    reload: function () {
       ok(true);
       return history.push('model2');
     }
@@ -94,10 +94,10 @@ test('it stops reloading models after they were removed from polling', function(
   service.startPolling(model1);
   service.startPolling(model2);
   stop();
-  return setTimeout(function() {
+  return setTimeout(function () {
     service.stopPolling(model2);
-    return setTimeout(function() {
-      Ember.run(function() {
+    return setTimeout(function () {
+      Ember.run(function () {
         return service.destroy();
       });
       start();
@@ -106,23 +106,23 @@ test('it stops reloading models after they were removed from polling', function(
   }, 40);
 });
 
-test('it runs a hook on each interval', function() {
+test('it runs a hook on each interval', function () {
   var source;
   expect(1);
   service = Polling.create({
     pollingInterval: 20
   });
   source = {
-    pollHook: function() {
+    pollHook: function () {
       return ok(true);
     }
   };
   service.startPollingHook(source);
   stop();
-  return setTimeout(function() {
+  return setTimeout(function () {
     service.stopPollingHook(source);
-    return setTimeout(function() {
-      Ember.run(function() {
+    return setTimeout(function () {
+      Ember.run(function () {
         return service.destroy();
       });
       return start();
@@ -130,25 +130,25 @@ test('it runs a hook on each interval', function() {
   }, 30);
 });
 
-test('it will not run pollHook if the source is destroyed', function() {
+test('it will not run pollHook if the source is destroyed', function () {
   var source;
   expect(1);
   service = Polling.create({
     pollingInterval: 20
   });
   source = Ember.Object.extend({
-    pollHook: function() {
+    pollHook: function () {
       return ok(true);
     }
   }).create();
   service.startPollingHook(source);
   stop();
-  return setTimeout(function() {
-    Ember.run(function() {
+  return setTimeout(function () {
+    Ember.run(function () {
       return source.destroy();
     });
-    return setTimeout(function() {
-      Ember.run(function() {
+    return setTimeout(function () {
+      Ember.run(function () {
         return service.destroy();
       });
       return start();

--- a/tests/unit/services/raven-test.js
+++ b/tests/unit/services/raven-test.js
@@ -3,7 +3,7 @@ import { moduleFor, test } from 'ember-qunit';
 moduleFor('service:raven', 'Unit | Service | raven', {
 });
 
-test('it filters errors matching whitelist', function(assert) {
+test('it filters errors matching whitelist', function (assert) {
   let service = this.subject();
   let filteredError = { message: 'foo is an error we should filter' };
   let unfilteredError = { message: 'throw dat' };
@@ -11,6 +11,6 @@ test('it filters errors matching whitelist', function(assert) {
   service.shouldReportError = () => true;
   service.set('whitelistMessages', ['foo', 'bar', 'baz']);
 
-  assert.ok(service.ignoreError(filteredError), "Service should ignore whitelisted error");
-  assert.notOk(service.ignoreError(unfilteredError), "Service should not ignore non-whitelisted error");
+  assert.ok(service.ignoreError(filteredError), 'Service should ignore whitelisted error');
+  assert.notOk(service.ignoreError(unfilteredError), 'Service should not ignore non-whitelisted error');
 });

--- a/tests/unit/utils/eventually-test.js
+++ b/tests/unit/utils/eventually-test.js
@@ -1,23 +1,23 @@
 import eventually from 'travis/utils/eventually';
 
-module("eventually");
+module('eventually');
 
-test("eventually runs a callback with passed item right away if it's not a promise", function() {
+test("eventually runs a callback with passed item right away if it's not a promise", function () {
   stop();
   expect(1);
 
-  eventually({ foo: 'bar' }, function(result) {
+  eventually({ foo: 'bar' }, function (result) {
     equal(result.foo, 'bar');
     start();
   });
 });
 
-test("eventually runs a callback when promise resolves if a passed object is a promise", function() {
+test('eventually runs a callback when promise resolves if a passed object is a promise', function () {
   stop();
   expect(1);
 
-  let promise = { then: function(callback) { callback({ foo: 'bar'}); } };
-  eventually(promise, function(result) {
+  let promise = { then: function (callback) { callback({ foo: 'bar' }); } };
+  eventually(promise, function (result) {
     equal(result.foo, 'bar');
     start();
   });

--- a/tests/unit/utils/favicon-manager-test.js
+++ b/tests/unit/utils/favicon-manager-test.js
@@ -3,7 +3,7 @@ import FaviconManager from 'travis/utils/favicon-manager';
 
 var fakeHead, manager;
 
-module("Favicon manager", {
+module('Favicon manager', {
   beforeEach() {
     fakeHead = Ember.$('<div id="fake-head"></div>').appendTo(Ember.$('#qunit-fixture'));
     return manager = new FaviconManager(fakeHead[0]);
@@ -14,19 +14,19 @@ module("Favicon manager", {
   }
 });
 
-test('use <head> tag by default', function() {
+test('use <head> tag by default', function () {
   manager = new FaviconManager();
   return equal(manager.getHeadTag(), Ember.$('head')[0]);
 });
 
-test('set favicon if there is no link tag in head', function() {
+test('set favicon if there is no link tag in head', function () {
   var link;
   equal(fakeHead.find('link').length, 0, 'there should be no link tags initially');
   manager.setFavicon('foobar');
   link = fakeHead.find('link')[0];
   ok(link, 'link tag should be added by favicon manager');
   stop();
-  return setTimeout(function() {
+  return setTimeout(function () {
     start();
     equal(link.getAttribute('href'), 'foobar', 'href attribute for the link should be properly set');
     equal(link.getAttribute('rel'), 'icon', 'rel attribute for the link should be properly set');
@@ -34,7 +34,7 @@ test('set favicon if there is no link tag in head', function() {
   }, 20);
 });
 
-test('replace exisiting link tag', function() {
+test('replace exisiting link tag', function () {
   var link, links;
   fakeHead.append(Ember.$('<link id="foo" rel="icon"></link>'));
   ok('foo', fakeHead.find('link').attr('id'), 'initially link should exist');
@@ -44,7 +44,7 @@ test('replace exisiting link tag', function() {
   link = links[0];
   ok(!link.getAttribute('id'), 'existing link should be replaced with a new one');
   stop();
-  return setTimeout(function() {
+  return setTimeout(function () {
     start();
     equal(link.getAttribute('href'), 'foobar', 'href attribute for the link should be properly set');
     equal(link.getAttribute('rel'), 'icon', 'rel attribute for the link should be properly set');
@@ -52,7 +52,7 @@ test('replace exisiting link tag', function() {
   }, 20);
 });
 
-test('find link with rel=icon only', function() {
+test('find link with rel=icon only', function () {
   fakeHead.append(Ember.$('<link id="foo" rel="foo"></link>'));
   return ok(!manager.getLinkTag());
 });

--- a/tests/unit/utils/status-image-formats-test.js
+++ b/tests/unit/utils/status-image-formats-test.js
@@ -2,13 +2,13 @@ import format from 'travis/utils/status-image-formats';
 
 module('Status image formats');
 
-test('it generates CCTray url with a slug', function() {
+test('it generates CCTray url with a slug', function () {
   var url;
   url = format('CCTray', 'travis-ci/travis-web');
   return equal(url, '#/repos/travis-ci/travis-web/cc.xml');
 });
 
-test('it generates CCTray url with a slug and a branch', function() {
+test('it generates CCTray url with a slug and a branch', function () {
   var url;
   url = format('CCTray', 'travis-ci/travis-web', 'development');
   return equal(url, '#/repos/travis-ci/travis-web/cc.xml?branch=development');


### PR DESCRIPTION
I've disabled some rules temporarily to either:
1) Figure out how to modify our code to comply
2) Figure out how to customize the rule as I think it's good in theory but will cause pain.

A good example of 2) is the case of an AJAX headers object. While we'd like object properties to be consistent, and also to be non-strings if possible, that is sometimes unavoidable: `'foo-bar'` must, for instance, be stringified.

However, this currently throws an error, because `Accept` doesn't *have* to be a string:

```json
{
  "Accept": "application/json",
  "Travis-API-Version": "3"
}
```

I don't want to enforce consistency (either all stringified or none), because that would mean that the presence of any hyphenated key would force us to use them for everything.

So I'm waiting to enforce this until I figure out a good workaround.