### PR TITLE
Use default_branch.last_build isntead of current_build on owner's page

### DIFF
--- a/app/components/owner-repo-tile.js
+++ b/app/components/owner-repo-tile.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 export default Ember.Component.extend({
   tagName: 'li',
   classNames: ['owner-tile', 'row-li'],
-  classNameBindings: ['repo.current_build.state'],
+  classNameBindings: ['repo.default_branch.last_build.state'],
 
   ownerName: function() {
     return this.get('repo.slug').split(/\//)[0];
@@ -13,12 +13,12 @@ export default Ember.Component.extend({
     return this.get('repo.slug').split(/\//)[1];
   }.property('repo.slug'),
 
-  isAnimating: function() {
+  isAnimating: Ember.computed('repo.default_branch.last_build.state', function () {
     var animationStates, state;
-    state = this.get('repo.current_build.state');
+    state = this.get('repo.default_branch.last_build.state');
     animationStates = ['received', 'queued', 'started', 'booting'];
     if (animationStates.indexOf(state) !== -1) {
       return true;
     }
-  }.property('repo.current_build.state')
+  })
 });

--- a/app/controllers/owner/repositories.js
+++ b/app/controllers/owner/repositories.js
@@ -11,7 +11,7 @@ export default Ember.Controller.extend({
         if (item.active) {
           return item;
         }
-      }).sortBy('currentBuild.finished_at').reverse();
+      }).sortBy('default_branch.last_build.finished_at').reverse();
     }
     return repos;
   }.property('model')

--- a/app/routes/owner/repositories.js
+++ b/app/routes/owner/repositories.js
@@ -20,8 +20,9 @@ export default TravisRoute.extend({
       };
     }
 
-    return Ember.$.ajax(config.apiEndpoint + ("/v3/owner/" + transition.params.owner.owner + "?include=owner.repositories,repository.default_branch,build.commit,repository.current_build"), options).then(function(response) {
-      return response;
-    });
+    let includes = `?include=owner.repositories,repository.default_branch,build.commit,repository.current_build`;
+    let { owner } = transition.params.owner;
+    let url = `${config.apiEndpoint}/v3/owner/${owner}${includes}`;
+    return Ember.$.get(url, options);
   }
 });

--- a/app/templates/components/owner-repo-tile.hbs
+++ b/app/templates/components/owner-repo-tile.hbs
@@ -4,37 +4,37 @@
 <div class="row-item fade-out">
   <div clas="one-line">
     <h2 class="repo-title">
-    {{status-icon status=repo.current_build.state}}
+    {{status-icon status=repo.default_branch.last_build.state}}
     {{#link-to "repo" ownerName repoName }}
       <span class="label-align">{{repoName}}</span>
     {{/link-to}}
     </h2>
   </div>
 </div>
-{{#if repo.current_build}}
+{{#if repo.default_branch.last_build}}
   <div class="row-item row-color">
     <div class="one-line">
-      {{#link-to "build" ownerName repoName repo.current_build.id}}
+      {{#link-to "build" ownerName repoName repo.default_branch.last_build.id}}
         <span class="icon-hash">
           </span>
-        <span class="label-align">{{repo.current_build.number}}</span>
+        <span class="label-align">{{repo.default_branch.last_build.number}}</span>
       {{/link-to}}
     </div>
   </div>
 
   <div class="row-item fade-out">
     <div class="one-line">
-      {{request-icon event=repo.current_build.event_type}}
+      {{request-icon event=repo.default_branch.last_build.event_type}}
       <span class="label-align">{{repo.default_branch.name}}</span>
     </div>
   </div>
 
   <div class="row-item">
     <div class="one-line">
-      <a href="{{repo.current_build.commit.compare_url}}">
+      <a href="{{repo.default_branch.last_build.commit.compare_url}}">
         <span class="icon-github">
         </span>
-        <span class="label-align">{{format-sha repo.current_build.commit.sha}}</span>
+        <span class="label-align">{{format-sha repo.default_branch.last_build.commit.sha}}</span>
       </a>
     </div>
   </div>
@@ -43,8 +43,8 @@
     <div class="one-line">
       <span class="icon-calendar">
       </span>
-      <span class="build-status label-align">{{repo.current_build.state}}</span>
-      <span class="finished-at label-align">{{format-time repo.current_build.finished_at}}</span>
+      <span class="build-status label-align">{{repo.default_branch.last_build.state}}</span>
+      <span class="finished-at label-align">{{format-time repo.default_branch.last_build.finished_at}}</span>
     </div>
   </div>
 {{else}}


### PR DESCRIPTION
When we were changing the app to use current_build, we also change
owner's page, but this was a mistake, the intended behaviour is to show
master's branch status.