### PR TITLE
Remove crons tab from builds page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,9 @@ cache:
 
 before_install:
   - mkdir travis-phantomjs
-  - wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
-  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -C $PWD/travis-phantomjs
-  - export PATH=$PWD/travis-phantomjs:$PATH
+  - wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
+  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis-phantomjs
+  - export PATH=$PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
   - "npm config set spin false"
   - "npm install -g npm@^2"
 

--- a/app/components/builds-wrapper.js
+++ b/app/components/builds-wrapper.js
@@ -21,11 +21,6 @@ export default Ember.Component.extend({
         event_type: 'pull_request',
         repository_id: repositoryId
       });
-    } else if (contentType === 'crons') {
-      return store.filter('build', {
-        event_type: 'cron',
-        repository_id: repositoryId
-      });
     } else {
       return store.query('build', {
         repository_id: repositoryId,

--- a/app/components/repo-show-tabs.js
+++ b/app/components/repo-show-tabs.js
@@ -23,13 +23,7 @@ export default Ember.Component.extend({
     }
   }.property('tab'),
 
-  classCrons: function() {
-    if (this.get('tab') === 'crons') {
-      return 'active';
-    }
-  }.property('tab'),
-
-  classBranches: function() {
+  classBranches: function () {
     if (this.get('tab') === 'branches') {
       return 'active';
     }

--- a/app/controllers/builds.js
+++ b/app/controllers/builds.js
@@ -34,11 +34,7 @@ export default Ember.Controller.extend({
     return this.get('tab') === 'branches';
   }.property('tab'),
 
-  displayCrons: function() {
-    return this.get('tab') === 'crons';
-  }.property('tab'),
-
-  noticeData: function() {
+  noticeData: function () {
     return {
       repo: this.get('repo'),
       auth: this.auth.token()

--- a/app/router.js
+++ b/app/router.js
@@ -47,7 +47,6 @@ Router.map(function() {
       this.route('job', { path: '/jobs/:job_id', resetNamespace: true });
       this.route('builds', { path: '/builds', resetNamespace: true });
       this.route('pullRequests', { path: '/pull_requests', resetNamespace: true });
-      this.route('crons', { path: '/crons', resetNamespace: true });
       this.route('requests', { path: '/requests', resetNamespace: true });
       if (config.endpoints.caches) {
         this.route('caches', { path: '/caches', resetNamespace: true });

--- a/app/routes/crons.js
+++ b/app/routes/crons.js
@@ -1,5 +1,0 @@
-import AbstractBuildsRoute from 'travis/routes/abstract-builds';
-
-export default AbstractBuildsRoute.extend({
-  contentType: 'crons'
-});

--- a/app/templates/builds.hbs
+++ b/app/templates/builds.hbs
@@ -4,7 +4,7 @@
     {{#each builds as |build|}}
       {{builds-item build=build}}
     {{else}}
-      {{no-builds repo=repo isPR=displayPullRequests isBranch=displayBranches isCron=displayCrons}}
+      {{no-builds repo=repo isPR=displayPullRequests isBranch=displayBranches}}
     {{/each}}
   </ul>
   {{#if displayShowMoreButton}}

--- a/app/templates/components/no-builds.hbs
+++ b/app/templates/components/no-builds.hbs
@@ -68,11 +68,6 @@
     {{#if isBranch}}
       <h2 class="page-title">No other branches for this repository</h2>
     {{else}}
-      {{#if isCron}}
-        <h2 class="page-title">No cron builds for this repository yet</h2>
-        <p class="page-notice">Want to know when your configured builds will be enqueued?</p>
-        {{#link-to "settings" repo class="button button--green"}}Go to the Settings Page{{/link-to}}
-      {{else}}
         <h2 class="page-title">No builds for this repository</h2>
         <p class="page-notice">Want to start testing this project on Travis CI?</p>
         <a href="http://docs.travis-ci.com/user/getting-started/" class="button button--green">Read the Docs on Getting Started</a>
@@ -81,7 +76,6 @@
         {{else}}
           <a href="#" class="button button--green" {{action (perform triggerBuild)}}>Trigger the first build</a>
         {{/if}} --}}
-      {{/if}}
     {{/if}}
   {{/if}}
 </div>

--- a/app/templates/components/repo-show-tabs.hbs
+++ b/app/templates/components/repo-show-tabs.hbs
@@ -27,15 +27,6 @@
       {{/link-to}}
     {{/if}}
   </li>
-  {{#if repo.slug}}
-    {{#if repo.cronJobs}}
-      <li id="tab_crons" class={{classCrons}}>
-        {{#link-to "crons" repo}}
-          Crons
-        {{/link-to}}
-      </li>
-    {{/if}}
-  {{/if}}
   <li id="tab_build" class={{classBuild}}>
     {{#if build.id}}
       {{#if repo.slug}}

--- a/tests/acceptance/builds/current-tab-test.js
+++ b/tests/acceptance/builds/current-tab-test.js
@@ -31,17 +31,14 @@ test('renders most recent repository and most recent build when builds present',
   // create branch
   server.create('log', { id: job.id });
 
-  build.commit = commit;
-  commit.build = build;
-
-  build.save();
-  commit.save();
+  build.update('commit', commit);
+  commit.update('build', build);
 
   currentRepoTab
     .visit();
 
   andThen(function() {
     assert.ok(currentRepoTab.currentTabActive, 'Current tab is active by default when loading dashboard');
-    assert.ok(currentRepoTab.showsCurrentBuild, 'Shows current build');
+    assert.equal(currentRepoTab.showsCurrentBuild, 'acceptance-tests This is a message', 'Shows current build');
   });
 });

--- a/tests/acceptance/builds/current-tab-test.js
+++ b/tests/acceptance/builds/current-tab-test.js
@@ -39,6 +39,12 @@ test('renders most recent repository and most recent build when builds present',
 
   andThen(function() {
     assert.ok(currentRepoTab.currentTabActive, 'Current tab is active by default when loading dashboard');
-    assert.equal(currentRepoTab.showsCurrentBuild, 'acceptance-tests This is a message', 'Shows current build');
+  });
+
+  andThen(function() {
+    // TODO: This shouldn't be necessary. The cause for this test's
+    // unreliability is that we assert before the build information has been
+    // resolved. I'm actually not sure how this ever worked before.
+    assert.ok(currentRepoTab.showsCurrentBuild, 'Shows current build');
   });
 });

--- a/tests/acceptance/repo-build-list-routes-test.js
+++ b/tests/acceptance/repo-build-list-routes-test.js
@@ -80,25 +80,8 @@ moduleForAcceptance('Acceptance | repo build list routes', {
   }
 });
 
-test('view crons', function(assert) {
-  page.visitCrons({organization: 'killjoys', repo: 'living-a-feminist-life'});
-
-  andThen(() => {
-    assert.equal(page.builds().count, 1, 'expected one cron build');
-
-    const build = page.builds(0);
-
-    assert.ok(build.passed, 'expected the cron to have passed');
-    assert.equal(build.name, 'successful-cron-branch');
-    assert.equal(build.committer, 'Sara Ahmed');
-    assert.equal(build.commitSha, '1234567');
-    assert.equal(build.commitDate, 'about a year ago');
-    assert.equal(build.duration, '5 min');
-  });
-});
-
-test('view build history', function(assert) {
-  page.visitBuildHistory({organization: 'killjoys', repo: 'living-a-feminist-life'});
+test('view build history', function (assert) {
+  page.visitBuildHistory({ organization: 'killjoys', repo: 'living-a-feminist-life' });
 
   andThen(() => {
     assert.equal(page.builds().count, 3, 'expected three builds');

--- a/tests/pages/build-list.js
+++ b/tests/pages/build-list.js
@@ -9,7 +9,6 @@ let {
 
 export default PageObject.create({
   visitBuildHistory: visitable(':organization/:repo/builds'),
-  visitCrons: visitable(':organization/:repo/crons'),
   visitPullRequests: visitable(':organization/:repo/pull_requests'),
 
   builds: collection({

--- a/tests/pages/repo-tabs/current.js
+++ b/tests/pages/repo-tabs/current.js
@@ -9,5 +9,5 @@ export default create({
   visit: visitable('travis-ci/travis-web'),
   currentTabActive: hasClass('active', '#tab_current'),
   showsNoBuildsMessaging: text('.missing-notice h2.page-title'),
-  showsCurrentBuild: hasClass('passed', 'section.build-header')
+  showsCurrentBuild: text('h2.build-title')
 });

--- a/tests/pages/repo-tabs/current.js
+++ b/tests/pages/repo-tabs/current.js
@@ -9,5 +9,5 @@ export default create({
   visit: visitable('travis-ci/travis-web'),
   currentTabActive: hasClass('active', '#tab_current'),
   showsNoBuildsMessaging: text('.missing-notice h2.page-title'),
-  showsCurrentBuild: text('h2.build-title')
+  showsCurrentBuild: hasClass('passed', 'section.build-header')
 });


### PR DESCRIPTION
Crons are still currently interspersed between API-triggered builds and
available in the `Build History` tab.

This addresses https://github.com/travis-pro/team-teal/issues/1036.