### PR TITLE
Users can once again expand hooks after restarting build

### DIFF
--- a/app/utils/log-folder.js
+++ b/app/utils/log-folder.js
@@ -3,7 +3,10 @@ import Ember from 'ember';
 export default (function() {
   function LogFolder(element) {
     this.element = element;
-    this.element.on('click', '.fold', (function(_this) {
+    let handlerSelector = '.fold';
+    this.element
+      .off('click', handlerSelector) // remove any previous click handlers
+      .on('click', handlerSelector, (function(_this) {
       return function(event) {
         var folder;
         folder = _this.getFolderFromLine(Ember.$(event.target));


### PR DESCRIPTION
We were registering new click handlers every time a new log component was inserted into the DOM, but are not
removing them during teardown. Instead of trying to understand that logic now, I have simply removed the previous click
handlers with `$.off()`.

This fixes https://github.com/travis-pro/team-teal/issues/931.