### PR TITLE
Don't add `private-` suffix manually to pusher channels

### DIFF
--- a/app/components/hook-switch.js
+++ b/app/components/hook-switch.js
@@ -16,11 +16,7 @@ export default Ember.Component.extend({
       repoId = hook.get('id');
 
     return hook.toggle().then(() => {
-      let channel = 'repo-' + repoId;
-      if (hook.get('private') || this.get('config').enterprise) {
-        channel = 'private-' + channel;
-      }
-      pusher.subscribe(channel);
+      pusher.subscribe(`repo-${repoId}`);
     }, () => {
       this.toggleProperty('hook.active');
       return this.sendAction('onToggleError', hook);

--- a/app/components/not-active.js
+++ b/app/components/not-active.js
@@ -26,7 +26,6 @@ export default Ember.Component.extend({
 
   activate: task(function * () {
     const apiEndpoint = config.apiEndpoint;
-    const repo = this.get('repo');
     const repoId = this.get('repo.id');
 
     try {
@@ -38,15 +37,7 @@ export default Ember.Component.extend({
       });
 
       if (response.active) {
-        const pusher = this.get('pusher');
-
-        let channel = `repo-${repoId}`;
-
-        if (repo.get('private') || this.get('config').enterprise) {
-          channel = `private-${channel}`;
-        }
-
-        pusher.subscribe(`repo-${repoId}`);
+        this.get('pusher').subscribe(`repo-${repoId}`);
 
         this.get('repo').set('active', true);
         this.get('flashes').success('Repository has been successfully activated.');


### PR DESCRIPTION
We already have [code](https://github.com/travis-ci/travis-web/blob/f500c1eb225f087b9eed992ed970facacc71d611/app/utils/pusher.js#L73-L81) that automatically adds `config.pusher.channelPrefix`
to all pusher channels if it's set