### PR TITLE
Add fastboot

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "ember-cli-deprecation-workflow": "0.2.3",
     "ember-cli-document-title": "0.3.1",
     "ember-cli-eslint": "1.7.0",
+    "ember-cli-fastboot": "1.0.0-beta.4",
     "ember-cli-htmlbars": "^1.0.8",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",
@@ -51,6 +52,7 @@
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
+    "ember-network": "0.3.0",
     "ember-resolver": "^2.0.3",
     "emberx-select": "2.1.2",
     "loader.js": "^4.0.10"


### PR DESCRIPTION
Ember network is necessary because we do not have access to $.ajax() within node.
This provides a fetch() that is compatible with the browser API to make it run in both
the browser and node.

We could remove this if we ported all network calls to Ember Data in the future, but I do not
think we are ready for that yet (maybe never due to things like logs).

This is totally WIP and is not close to a running state, just wanted to get it out there.
