### PR TITLE
Change hovertext if job incomplete

### DIFF
--- a/app/models/build.js
+++ b/app/models/build.js
@@ -134,7 +134,8 @@ Build.reopen({
   formattedFinishedAt: Ember.computed('finishedAt', function () {
     let finishedAt = this.get('finishedAt');
     if (finishedAt) {
-      return moment(finishedAt).format('lll');
+      var m = moment(finishedAt);
+      return m.isValid() ? m.format('lll') : 'not finished yet';
     }
   })
 

--- a/app/models/job.js
+++ b/app/models/job.js
@@ -159,7 +159,8 @@ export default Model.extend(DurationCalculations, {
   formattedFinishedAt: Ember.computed('finishedAt', function () {
     let finishedAt = this.get('finishedAt');
     if (finishedAt) {
-      return moment(finishedAt).format('lll');
+      var m = moment(finishedAt);
+      return m.isValid() ? m.format('lll') : 'not finished yet';
     }
   }),
 


### PR DESCRIPTION
Currently, it says 'Invalid date'. In other parts of the website,
though, if a job is incomplete, hovering will say 'not finished yet'.