### PR TITLE
Move debug logging behind feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,29 @@ You can also start an interactive test runner for easier development:
 
     ember test --serve
 
+### Feature Flags
+
+`travis-web` is beginning the transition to use feature flags wherever it makes
+sense. To enable/disable/add/remove a feature flag for the application, you can
+edit the `config/environment.js` file. For instance, to enable `some-feature`, you would
+simply add/update the file like so:
+
+```js
+  {
+    featureFlags: {
+      'some-feature': true
+    }
+  }
+```
+
+This uses the awesome [ember-feature-flags](https://github.com/kategengler/ember-feature-flags) addon under the hood, so be sure to read its own
+documentation for more information.
+
+### Debugging
+
+Ember's default logging has been disabled in all environments by default and
+moved to a feature flag. To enable it, simply edit the `debug-logging` feature
+flag as mentioned previously in the `Feature Flags` section.
 
 ### Updating the team page
 

--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -44,8 +44,10 @@ export default ActiveModelAdapter.extend({
 
   handleResponse(status, headers, payload) {
     if (status > 299) {
-      // eslint-disable-next-line
-      console.log("[ERROR] API responded with an error (" + status + "): " + (JSON.stringify(payload)));
+      if (this.get('features.debugLogging')) {
+        // eslint-disable-next-line
+        console.log("[ERROR] API responded with an error (" + status + "): " + (JSON.stringify(payload)));
+      }
     }
 
     return this._super(...arguments);

--- a/app/app.js
+++ b/app/app.js
@@ -12,10 +12,20 @@ Ember.LinkComponent.reopen({
   attributeBindings: ['alt']
 });
 
+// This can be set per environment in config/environment.js
+var debuggingEnabled = config.featureFlags['debug-logging'];
+
 var App = Ember.Application.extend(Ember.Evented, {
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
   Resolver: Resolver,
+
+  // Configure global logging based on debug feature flag
+  LOG_TRANSITIONS: debuggingEnabled,
+  LOG_TRANSITIONS_INTERNAL: debuggingEnabled,
+  LOG_ACTIVE_GENERATION: debuggingEnabled,
+  LOG_MODULE_RESOLVER: debuggingEnabled,
+  LOG_VIEW_LOOKUPS: debuggingEnabled,
 
   ready() {
     if (location.hash.slice(0, 2) === '#!') {

--- a/app/components/log-content.js
+++ b/app/components/log-content.js
@@ -73,7 +73,7 @@ export default Ember.Component.extend({
   currentUser: alias('auth.currentUser'),
 
   didInsertElement() {
-    if (this.features.isEnabled('debug-logging')) {
+    if (this.get('features.debugLogging')) {
       //eslint-disable-next-line
       console.log('log view: did insert');
     }
@@ -82,7 +82,7 @@ export default Ember.Component.extend({
   },
 
   willDestroyElement() {
-    if (this.features.isEnabled('debug-logging')) {
+    if (this.get('features.debugLogging')) {
       //eslint-disable-next-line
       console.log('log view: will destroy');
     }
@@ -171,7 +171,7 @@ export default Ember.Component.extend({
   partsDidChange(parts, start, _, added) {
     Ember.run.schedule('afterRender', this, function () {
       var i, j, len, part, ref, ref1, ref2, results;
-      if (this.features.isEnabled('debug-logging')) {
+      if (this.get('features.debugLogging')) {
         //eslint-disable-next-line
         console.log('log view: parts did change');
       }

--- a/app/components/log-content.js
+++ b/app/components/log-content.js
@@ -8,8 +8,6 @@ import { plainTextLog as plainTextLogUrl } from 'travis/utils/urls';
 const { service } = Ember.inject;
 const { alias } = Ember.computed;
 
-Log.DEBUG = false;
-
 Log.LIMIT = 10000;
 
 Log.Scroll = function (options) {
@@ -75,7 +73,7 @@ export default Ember.Component.extend({
   currentUser: alias('auth.currentUser'),
 
   didInsertElement() {
-    if (Log.DEBUG) {
+    if (this.features.isEnabled('debug-logging')) {
       //eslint-disable-next-line
       console.log('log view: did insert');
     }
@@ -84,7 +82,7 @@ export default Ember.Component.extend({
   },
 
   willDestroyElement() {
-    if (Log.DEBUG) {
+    if (this.features.isEnabled('debug-logging')) {
       //eslint-disable-next-line
       console.log('log view: will destroy');
     }
@@ -173,7 +171,7 @@ export default Ember.Component.extend({
   partsDidChange(parts, start, _, added) {
     Ember.run.schedule('afterRender', this, function () {
       var i, j, len, part, ref, ref1, ref2, results;
-      if (Log.DEBUG) {
+      if (this.features.isEnabled('debug-logging')) {
         //eslint-disable-next-line
         console.log('log view: parts did change');
       }

--- a/app/initializers/inject-feature-flags.js
+++ b/app/initializers/inject-feature-flags.js
@@ -1,0 +1,17 @@
+import config from 'travis/config/environment';
+
+export function initialize(app) {
+  let serviceName = config.featureFlagsService || 'features';
+  let serviceLookupName = `service:${serviceName}`;
+  app.inject('adapter', serviceName, serviceLookupName);
+  app.inject('model', serviceName, serviceLookupName);
+  if (config.environment === 'development') {
+    // eslint-disable-next-line
+    console.log('EMBER FEATURE FLAGS were auto-injected into all: routes, controllers, components, adapters and models');
+  }
+}
+
+export default {
+  name: 'inject-feature-flags',
+  initialize
+};

--- a/app/models/job.js
+++ b/app/models/job.js
@@ -37,7 +37,8 @@ export default Model.extend(DurationCalculations, {
     this.set('isLogAccessed', true);
     return Log.create({
       job: this,
-      ajax: this.get('ajax')
+      ajax: this.get('ajax'),
+      container: Ember.getOwner(this)
     });
   }),
 

--- a/app/models/log.js
+++ b/app/models/log.js
@@ -1,4 +1,3 @@
-/* global Log */
 import Ember from 'ember';
 import config from 'travis/config/environment';
 
@@ -52,7 +51,11 @@ var Request = Ember.Object.extend({
   }
 });
 
+const { service } = Ember.inject;
+
 var LogModel = Ember.Object.extend({
+  features: service(),
+
   version: 0,
   isLoaded: false,
   length: 0,
@@ -181,7 +184,7 @@ var LogModel = Ember.Object.extend({
   },
 
   debug(message) {
-    if (Log.DEBUG) {
+    if (this.get('features').isEnabled('debug-logging')) {
       // eslint-disable-next-line
       console.log(message);
     }

--- a/app/models/log.js
+++ b/app/models/log.js
@@ -184,7 +184,7 @@ var LogModel = Ember.Object.extend({
   },
 
   debug(message) {
-    if (this.get('features').isEnabled('debug-logging')) {
+    if (this.get('features.debugLogging')) {
       // eslint-disable-next-line
       console.log(message);
     }

--- a/app/routes/first-sync.js
+++ b/app/routes/first-sync.js
@@ -29,8 +29,10 @@ export default SimpleLayoutRoute.extend({
             return self.transitionTo('profile');
           }
         }).then(null, function (e) {
-          // eslint-disable-next-line
-          return console.log('There was a problem while redirecting from first sync', e);
+          if (this.get('features.debugLogging')) {
+            // eslint-disable-next-line
+            return console.log('There was a problem while redirecting from first sync', e);
+          }
         });
       }, this.get('config').syncingPageRedirectionTime);
     }

--- a/app/services/ajax.js
+++ b/app/services/ajax.js
@@ -15,6 +15,7 @@ const { service } = Ember.inject;
 
 export default Ember.Service.extend({
   auth: service(),
+  features: service(),
 
   get(url, callback, errorCallback) {
     return this.ajax(url, 'get', {
@@ -70,8 +71,10 @@ export default Ember.Service.extend({
     };
     error = options.error || function () {};
     options.error = (data, status, xhr) => {
-      //eslint-disable-next-line
-      console.log("[ERROR] API responded with an error (" + status + "): " + (JSON.stringify(data)));
+      if (Ember.get(this, 'features').get('debugLogging')) {
+        //eslint-disable-next-line
+        console.log("[ERROR] API responded with an error (" + status + "): " + (JSON.stringify(data)));
+      }
       return error.call(this, data, status, xhr);
     };
 
@@ -118,8 +121,10 @@ export default Ember.Service.extend({
             try {
               return jQuery.parseJSON(xhr.responseText);
             } catch (error1) {
-              // eslint-disable-next-line
-              return console.log('error while parsing a response', method, options.url, xhr.responseText);
+              if (Ember.get(this, 'features').get('debugLogging')) {
+                // eslint-disable-next-line
+                console.log('error while parsing a response', method, options.url, xhr.responseText);
+              }
             }
           } else {
             return xhr.responseText;

--- a/app/utils/pusher.js
+++ b/app/utils/pusher.js
@@ -71,8 +71,7 @@ TravisPusher.prototype.unsubscribe = function (channel) {
 };
 
 TravisPusher.prototype.prefix = function (channel) {
-  var prefix;
-  prefix = ENV.pusher.channelPrefix || '';
+  let prefix = ENV.pusher.channelPrefix || '';
   if (channel.indexOf(prefix) !== 0) {
     return '' + prefix + channel;
   } else {

--- a/config/environment.js
+++ b/config/environment.js
@@ -82,12 +82,6 @@ module.exports = function(environment) {
   }
 
   if (environment === 'development') {
-    ENV.APP.LOG_TRANSITIONS = true,
-    ENV.APP.LOG_TRANSITIONS_INTERNAL = true,
-    ENV.APP.LOG_ACTIVE_GENERATION = true,
-    ENV.APP.LOG_MODULE_RESOLVER = true,
-    ENV.APP.LOG_VIEW_LOOKUPS = true,
-
     ENV['ember-cli-mirage'] = {
       enabled: false
     };
@@ -103,13 +97,6 @@ module.exports = function(environment) {
     // Testem prefers this...
     ENV.baseURL = '/';
     ENV.locationType = 'none';
-
-    // keep test console output quieter
-    ENV.APP.LOG_TRANSITIONS = false,
-    ENV.APP.LOG_TRANSITIONS_INTERNAL = false,
-    ENV.APP.LOG_ACTIVE_GENERATION = false,
-    ENV.APP.LOG_MODULE_RESOLVER = false,
-    ENV.APP.LOG_VIEW_LOOKUPS = false,
 
     ENV.APP.rootElement = '#ember-testing';
 
@@ -128,12 +115,6 @@ module.exports = function(environment) {
   }
 
   if (environment === 'production') {
-    ENV.APP.LOG_TRANSITIONS = true,
-    ENV.APP.LOG_TRANSITIONS_INTERNAL = true,
-    ENV.APP.LOG_ACTIVE_GENERATION = true,
-    ENV.APP.LOG_MODULE_RESOLVER = true,
-    ENV.APP.LOG_VIEW_LOOKUPS = true,
-
     ENV.release = process.env.SOURCE_VERSION || "-";
     ENV['ember-cli-mirage'] = {
       enabled: false

--- a/config/environment.js
+++ b/config/environment.js
@@ -31,7 +31,11 @@ module.exports = function(environment) {
     endpoints: {},
     intervals: { updateTimes: 1000 },
     githubOrgsOauthAccessSettingsUrl: 'https://github.com/settings/connections/applications/f244293c729d5066cf27',
-    ajaxPolling: false
+    ajaxPolling: false,
+
+    featureFlags: {
+      'debug-logging': false
+    }
   };
 
   var statusPageStatusUrl = 'https://pnpcptp8xh9k.statuspage.io/api/v2/status.json';

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "ember-data-filter": "1.13.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.5",
+    "ember-feature-flags": "3.0.0",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "emberx-select": "2.1.2",

--- a/vendor/log.js
+++ b/vendor/log.js
@@ -18,7 +18,7 @@ Log.extend = function(one, other) {
 };
 
 Log.extend(Log, {
-  DEBUG: true,
+  DEBUG: false,
   SLICE: 500,
   TIMEOUT: 25,
   FOLD: /fold:(start|end):([\w_\-\.]+)/,


### PR DESCRIPTION
Currently, any user in any environment (including when we run our tests) will see console output when using the application. In development and production environments, this is only noticeable when the developer tools are opened, but it can still be distracting.

To quiet the noise, I've moved all of our application logging -- from Ember's internal transition logging to our errors when requests fail -- behind a unified feature flag that can be independently set per environment. Because this can be helpful on occasion, I've kept the logging in place, which can be turned on again at any time. I'd like to also integrate this within our UI so users can toggle it themselves to help debug issues.

To enable this for more debugging output at any time, you can enable the `debug-logging` feature flag in `config/environment.js` like so:

```js
{
  // ...
  featureFlags: {
    'debug-logging': true
  }
}
```

I've also included directions in the `README` for developers looking to contribute.