### PR TITLE
Remove unused/invalid alt attribute for {{link-to}} helpers

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -8,10 +8,6 @@ import initHsBeacon from 'travis/utils/init-hs-beacon';
 
 Ember.MODEL_FACTORY_INJECTIONS = true;
 
-Ember.LinkComponent.reopen({
-  attributeBindings: ['alt']
-});
-
 // This can be set per environment in config/environment.js
 var debuggingEnabled = config.featureFlags['debug-logging'];
 


### PR DESCRIPTION
I think this can be removed. It doesn't appear to be used, and if it is, seems like it's actually invalid HTML?