### PR TITLE
Add ember-qunit-nice-errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "ember-export-application-global": "^1.0.5",
     "ember-feature-flags": "3.0.0",
     "ember-load-initializers": "^0.5.1",
+    "ember-qunit-nice-errors": "0.1.0",
     "ember-resolver": "^2.0.3",
     "emberx-select": "2.1.2",
     "loader.js": "^4.0.10"


### PR DESCRIPTION
As [discussed](https://travisci.slack.com/archives/web/p1469122883000009). Here’s an example of how it changes the output:

![image](https://cloud.githubusercontent.com/assets/43280/17162345/26fa85b8-536a-11e6-97f3-9d107136766a.png)

When I write `assert.ok` I tend to add an assertion description, like `assert.ok(false, 'should be true')`, because the test failure message is barely useful otherwise. So this doesn’t help much with that; in this screenshot, I deleted the assertion description to see what the output would look like. But there are some `assert.ok`s scattered around the codebase without a description, and I also think the message for `assert.equal` might be an improvement too.