### PR TITLE
Remove alt attributes from uses of link-to

### DIFF
--- a/app/templates/top.hbs
+++ b/app/templates/top.hbs
@@ -1,9 +1,9 @@
 <div class="topbar {{if is-open 'has-autoheight'}} {{if showBroadcasts 'has-autoheight'}}">
   <h1 id="logo" class="logo" {{action "cheatcode" on="doubleClick"}}>
     {{#if isDashboard}}
-      {{#link-to "dashboard" alt="Travis CI"}}Travis CI{{/link-to}}
+      {{#link-to "dashboard"}}Travis CI{{/link-to}}
     {{else}}
-      {{#link-to "main" alt="Travis CI"}}Travis CI{{/link-to}}
+      {{#link-to "main"}}Travis CI{{/link-to}}
     {{/if}}
     </h1>
   <div class="navigation-toggle">


### PR DESCRIPTION
Since @clekstro removed the ability to set this attribute in #623, might as well remove these attempts to use that ability.