### PR TITLE
Update ember-qunit-nice-errors to 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "ember-feature-flags": "3.0.0",
     "ember-keyboard-shortcuts": "0.3.0",
     "ember-load-initializers": "^0.5.1",
-    "ember-qunit-nice-errors": "1.0.0",
+    "ember-qunit-nice-errors": "1.1.1",
     "ember-prism": "0.0.7",
     "ember-resolver": "^2.0.3",
     "emberx-select": "2.1.2",


### PR DESCRIPTION
Updated to the new version of the addon [ember-qunit-nice-errors](https://github.com/wyeworks/ember-qunit-nice-errors) the addon was originally included in #631