### PR TITLE
Prevent `tokenVisibility` from bubbling.

### DIFF
--- a/app/components/org-item.js
+++ b/app/components/org-item.js
@@ -24,7 +24,7 @@ export default Ember.Component.extend({
 
   actions: {
     tokenVisibility() {
-      return this.toggleProperty('tokenIsVisible');
+      this.toggleProperty('tokenIsVisible');
     }
   }
 });


### PR DESCRIPTION
Prevent `return true;` which causes the action to be bubbled up to the routing sytem (and no other handlers exist to handle it).