### PR TITLE
Backport 655 for 2.0: always encrypt websocket connection to pusher/slanger

### DIFF
--- a/waiter/lib/travis/web/app.rb
+++ b/waiter/lib/travis/web/app.rb
@@ -190,6 +190,7 @@ class Travis::Web::App
       pusher['host'] = options[:pusher_host] if options[:pusher_host]
       pusher['path'] = options[:pusher_path] if options[:pusher_path]
       pusher['channelPrefix'] = options[:pusher_channel_prefix] if options[:pusher_channel_prefix]
+      pusher['encrypted'] = true
       config['pusher'] = pusher
 
       config['gaCode'] = options[:ga_code] if options[:ga_code]


### PR DESCRIPTION
This backports #655.

cc @rkh @bnferguson 