### PR TITLE
Restore log truncation

### DIFF
--- a/app/components/log-content.js
+++ b/app/components/log-content.js
@@ -44,7 +44,7 @@ Log.Limit = function (maxLines, limitedLogCallback) {
 
 Log.Limit.prototype = Log.extend(new Log.Listener(), {
   count: 0,
-  insert(node) {
+  insert(log, node) {
     if (node.type === 'paragraph' && !node.hidden) {
       this.count += 1;
       if (this.limited) {


### PR DESCRIPTION
There is code present to truncate logs at 10k lines, but a bug prevented it from functioning.

For now, this just fixes the bug, but I plan to add an acceptance test to ensure we don’t lose this feature again.