### PR TITLE
Reset log truncation flag after job restart

### DIFF
--- a/app/components/log-content.js
+++ b/app/components/log-content.js
@@ -113,6 +113,7 @@ export default Ember.Component.extend({
 
   createEngine(log) {
     if (log || (log = this.get('log'))) {
+      this.set('limited', false);
       this.clearLogElement();
       log.onClear(() => {
         this.teardownLog();


### PR DESCRIPTION
Restarted jobs that formerly had truncated logs were showing as truncated immediately, even when they only had a few log lines showing. Log truncation was probably added before the
job reset UI, so when truncation broke, no handling was added for resetting the limited flag when a job was restarted.

Adding automated testing for this might be difficult, but I’ll try it in my separate pull request for overall truncation tests.