### PR TITLE
Update ember-prism for deprecation fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ember-cli-document-title": "0.3.1",
     "ember-cli-eslint": "1.7.0",
     "ember-cli-heap": "1.0.0",
-    "ember-cli-htmlbars": "^1.0.8",
+    "ember-cli-htmlbars": "^1.1.0",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-inline-images": "^0.0.4",
@@ -56,7 +56,7 @@
     "ember-keyboard-shortcuts": "0.3.0",
     "ember-load-initializers": "^0.5.1",
     "ember-qunit-nice-errors": "1.1.1",
-    "ember-prism": "0.0.7",
+    "ember-prism": "brandonjmckay/ember-prism#30f2782",
     "ember-resolver": "^2.0.3",
     "emberx-select": "2.1.2",
     "loader.js": "^4.0.10"


### PR DESCRIPTION
This incorporates [a fix](https://github.com/brandonjmckay/ember-prism/pull/18) for `ember-prism` that was causing [this deprecation warning](https://travis-ci.org/travis-ci/travis-web/jobs/157967105#L392) when Ember processes start:

```
DEPRECATION: Overriding init without calling this._super is deprecated. Please call `this._super.init && this._super.init.apply(this, arguments);` addon: `ember-cli-htmlbars`
```

There’s no released version yet, hence the SHA, but the warning is annoying enough to me after a period of clean warninglessness, so I’m going to merge this 😆