### PR TITLE
Convert tasks to single-instance

### DIFF
--- a/app/components/add-cron-job.js
+++ b/app/components/add-cron-job.js
@@ -37,7 +37,7 @@ export default Ember.Component.extend({
     this.reset();
 
     yield cron.save();
-  }),
+  }).drop(),
 
   intervals: ['monthly', 'weekly', 'daily'],
 

--- a/app/components/add-env-var.js
+++ b/app/components/add-env-var.js
@@ -40,7 +40,7 @@ export default Ember.Component.extend({
       } catch (e) {
       }
     }
-  }),
+  }).drop(),
 
   actions: {
     nameChanged() {

--- a/app/components/add-ssh-key.js
+++ b/app/components/add-ssh-key.js
@@ -73,5 +73,5 @@ export default Ember.Component.extend({
         return this.addErrorsFromResponse(errors);
       }
     }
-  })
+  }).drop()
 });

--- a/app/components/caches-item.js
+++ b/app/components/caches-item.js
@@ -21,7 +21,7 @@ export default Ember.Component.extend({
       yield this.get('ajax').ajax(`/repos/${repo.get('id')}/caches`, 'DELETE', { data });
       return this.get('caches').removeObject(this.get('cache'));
     }
-  }),
+  }).drop(),
 
   actions: {
     performDelete() {

--- a/app/components/cron-job.js
+++ b/app/components/cron-job.js
@@ -73,5 +73,5 @@ export default Ember.Component.extend({
 
   delete: task(function* () {
     yield this.get('cron').destroyRecord();
-  })
+  }).drop()
 });

--- a/app/components/env-var.js
+++ b/app/components/env-var.js
@@ -19,5 +19,5 @@ export default Ember.Component.extend({
 
   delete: task(function* () {
     yield this.get('envVar').destroyRecord();
-  })
+  }).drop()
 });

--- a/app/components/limit-concurrent-builds.js
+++ b/app/components/limit-concurrent-builds.js
@@ -38,7 +38,7 @@ export default Ember.Component.extend({
 
       this.set('value', 0);
     }
-  }),
+  }).drop(),
 
   actions: {
     limitChanged() {

--- a/app/components/no-builds.js
+++ b/app/components/no-builds.js
@@ -12,5 +12,5 @@ export default Ember.Component.extend({
       },
       type: 'POST'
     });
-  })
+  }).drop()
 });

--- a/app/components/not-active.js
+++ b/app/components/not-active.js
@@ -45,5 +45,5 @@ export default Ember.Component.extend({
     } catch (e) {
       this.get('flashes').error('There was an error while trying to activate the repository.');
     }
-  })
+  }).drop()
 });

--- a/app/components/settings-switch.js
+++ b/app/components/settings-switch.js
@@ -20,7 +20,7 @@ export default Ember.Component.extend({
     } catch (e) {
       this.get('flashes').error('There was an error while saving settings. Please try again.');
     }
-  }),
+  }).drop(),
 
   click() {
     this.get('save').perform();

--- a/app/components/ssh-key.js
+++ b/app/components/ssh-key.js
@@ -12,5 +12,5 @@ export default Ember.Component.extend({
     } catch (e) {}
 
     this.sendAction('sshKeyDeleted');
-  })
+  }).drop()
 });

--- a/app/controllers/caches.js
+++ b/app/controllers/caches.js
@@ -22,5 +22,5 @@ export default Ember.Controller.extend({
 
       this.set('model', Ember.Object.create());
     }
-  })
+  }).drop()
 });


### PR DESCRIPTION
This was an unfortunate mistake on my part when I [originally converted these to ember-concurrency tasks](https://github.com/travis-ci/travis-web/pull/598): I thought tasks were single-instance by default, but the `drop()` call is required for that.