### PR TITLE
Show next and last run times for crons

### DIFF
--- a/app/adapters/cron.js
+++ b/app/adapters/cron.js
@@ -10,7 +10,7 @@ export default V3Adapter.extend({
     const url = `${this.urlPrefix()}${data.branch}/cron`;
     return this.ajax(url, 'POST', {
       data: {
-        disable_by_build: data.disable_by_build,
+        dont_run_if_recent_build_exists: data.dont_run_if_recent_build_exists,
         interval: data.interval
       }
     });

--- a/app/components/add-cron-job.js
+++ b/app/components/add-cron-job.js
@@ -31,7 +31,7 @@ export default Ember.Component.extend({
     const cron = store.createRecord('cron', {
       branch,
       interval: this.get('selectedInterval') || 'monthly',
-      disable_by_build: this.get('selectedOption') || false
+      dont_run_if_recent_build_exists: this.get('selectedOption') || false
     });
 
     this.reset();
@@ -41,5 +41,5 @@ export default Ember.Component.extend({
 
   intervals: ['monthly', 'weekly', 'daily'],
 
-  options: ['Always run', 'Only run if no new commits']
+  options: ['Always run', 'Do not run if there has been a build in the last 24h']
 });

--- a/app/components/cron-job.js
+++ b/app/components/cron-job.js
@@ -9,64 +9,9 @@ export default Ember.Component.extend({
   isDeleting: false,
   actionType: 'Save',
   store: service(),
-
-  intervalText: Ember.computed('cron.created_at', function () {
-    function timeOfDay(creationTime) {
-      let hours = creationTime.getHours();
-      let ampm = hours >= 12 ? 'pm' : 'am';
-      hours = hours % 12;
-      hours = hours !== 0 ? hours : 12;
-      return `${hours} ${ampm}`;
-    }
-
-    function dayOfWeek(creationTime) {
-      let weekday = new Array(7);
-      weekday[0] = 'Sunday';
-      weekday[1] = 'Monday';
-      weekday[2] = 'Tuesday';
-      weekday[3] = 'Wednesday';
-      weekday[4] = 'Thursday';
-      weekday[5] = 'Friday';
-      weekday[6] = 'Saturday';
-      return weekday[creationTime.getDay()];
-    }
-
-    function dayOfMonth(creationTime) {
-      let post = 'th';
-      let day = creationTime.getDate();
-      if (day === 1) {
-        post = 'st';
-      } else if (day === 2) {
-        post = 'nd';
-      } else if (day === 3) {
-        post = 'rd';
-      }
-      return day + post;
-    }
-
-    let interval = this.get('cron.interval');
-    let creationTime = new Date(this.get('cron.created_at'));
-    let text = '';
-    let time = timeOfDay(creationTime);
-
-    switch (interval) {
-      case 'monthly':
-        text = `Enqueues the ${dayOfMonth(creationTime)} of every month after ${time}`;
-        break;
-      case 'weekly':
-        text = `Enqueues each ${dayOfWeek(creationTime)} after ${time}`;
-        break;
-      case 'daily':
-        text = `Enqueues each day after ${time}`;
-        break;
-    }
-    return text;
-  }),
-
-
-  disableByBuild: Ember.computed('cron.disable_by_build', function () {
-    if (this.get('cron.disable_by_build')) {
-      return 'Only if no new commit';
+  dontRunIfRecentBuildExists: Ember.computed('cron.dont_run_if_recent_build_exists', function () {
+    if (this.get('cron.dont_run_if_recent_build_exists')) {
+      return 'Do not run if there has been a build in the last 24h';
     } else {
       return 'Always run';
     }

--- a/app/models/cron.js
+++ b/app/models/cron.js
@@ -5,6 +5,8 @@ import { belongsTo } from 'ember-data/relationships';
 export default Model.extend({
   branch: belongsTo('branch', { async: true }),
   interval: attr('string'),
-  disable_by_build: attr('boolean'),
-  created_at: attr('string')
+  dont_run_if_recent_build_exists: attr('boolean'),
+  created_at: attr('string'),
+  last_run: attr('string'),
+  next_run: attr('string')
 });

--- a/app/styles/app/layouts/settings.sass
+++ b/app/styles/app/layouts/settings.sass
@@ -139,8 +139,14 @@
 
 .cron-job-text
   @media #{$medium-up}
-    width: grid-calc(3, 12)
+    width: grid-calc(5, 30)
     padding-right: 5px
+
+.dont-run-if-recent-build-exists
+  white-space: inherit
+
+.interval
+  text-transform: capitalize
 
 %settings-action-section
   display: inline-block

--- a/app/templates/components/cron-job.hbs
+++ b/app/templates/components/cron-job.hbs
@@ -1,6 +1,8 @@
 <div class="cron-job-text branch-name">{{cron.branch.name}}</div>
-<div class="cron-job-text enqueuing-interval">{{intervalText}}</div>
-<div class="cron-job-text disable-by-build">{{disableByBuild}}</div>
+<div class="cron-job-text interval">{{cron.interval}}</div>
+<div class="cron-job-text last-run" last-run={{cron.last_run}}>Last: {{format-time cron.last_run}}</div>
+<div class="cron-job-text next-run" next-run={{cron.next_run}}>Next: {{format-time cron.next_run}}</div>
+<div class="cron-job-text dont-run-if-recent-build-exists">{{dontRunIfRecentBuildExists}}</div>
 <div class="cron-job-action">
   <div class="tooltip">
     {{#if delete.isRunning}}

--- a/app/utils/helpers.js
+++ b/app/utils/helpers.js
@@ -15,6 +15,7 @@ var _escape, _githubCommitReferenceLink, _githubCommitReferenceRegexp,
   intersect, mapObject, only, pathFrom, safe, timeAgoInWords, timeInWords, timeago;
 
 timeago = Ember.$.timeago;
+timeago.settings.allowFuture = true;
 
 mapObject = Ember.$.map;
 

--- a/tests/acceptance/repo/settings-test.js
+++ b/tests/acceptance/repo/settings-test.js
@@ -1,3 +1,4 @@
+/* global moment */
 import { test } from 'qunit';
 import moduleForAcceptance from 'travis/tests/helpers/module-for-acceptance';
 import settingsPage from 'travis/tests/pages/settings';
@@ -77,16 +78,18 @@ moduleForAcceptance('Acceptance | repo settings', {
 
     this.dailyCron = server.create('cron', {
       interval: 'daily',
-      disable_by_build: false,
-      next_enqueuing: '2016-05-20T13:19:19Z',
+      dont_run_if_recent_build_exists: false,
+      last_run: moment(),
+      next_run: moment().add(1, 'days'),
       repository_id: repoId,
       branchId: dailyBranch.id
     });
 
     server.create('cron', {
       interval: 'weekly',
-      disable_by_build: true,
-      next_enqueuing: '2016-05-20T14:20:10Z',
+      dont_run_if_recent_build_exists: true,
+      last_run: moment(),
+      next_run: moment().add(1, 'weeks'),
       repository_id: repoId,
       branchId: weeklyBranch.id
     });
@@ -114,12 +117,16 @@ test('view settings', function (assert) {
     assert.equal(settingsPage.environmentVariables(1).value, '••••••••••••••••');
 
     assert.equal(settingsPage.crons(0).branchName, 'daily-branch');
-    assert.ok(settingsPage.crons(0).enqueuingInterval.indexOf('Enqueues each day after') === 0, 'Shows daily enqueuing text');
-    assert.ok(settingsPage.crons(0).disableByBuildText.indexOf('Always run') === 0, 'expected cron to run even if no new commit after last build');
+    assert.equal(settingsPage.crons(0).interval, 'daily');
+    assert.equal(settingsPage.crons(0).lastRun, 'Last: less than a minute ago');
+    assert.equal(settingsPage.crons(0).nextRun, 'Next: about 24 hours from now');
+    assert.ok(settingsPage.crons(0).dontRunIfRecentBuildExistsText.indexOf('Always run') === 0, 'expected cron to run even if there is a build in the last 24h');
 
     assert.equal(settingsPage.crons(1).branchName, 'weekly-branch');
-    assert.ok(settingsPage.crons(1).enqueuingInterval.indexOf('Enqueues each') === 0, 'Shows weekly enqueuing text');
-    assert.ok(settingsPage.crons(1).disableByBuildText.indexOf('Only if no new commit') === 0, 'expected cron to run only if no new commit after last build');
+    assert.equal(settingsPage.crons(1).interval, 'weekly');
+    assert.equal(settingsPage.crons(1).lastRun, 'Last: less than a minute ago');
+    assert.equal(settingsPage.crons(1).nextRun, 'Next: 7 days from now');
+    assert.ok(settingsPage.crons(1).dontRunIfRecentBuildExistsText.indexOf('Do not run if there has been a build in the last 24h') === 0, 'expected Do not run if there has been a build in the last 24h');
 
     assert.equal(settingsPage.sshKey.name, 'testy');
     assert.equal(settingsPage.sshKey.fingerprint, 'dd:cc:bb:aa');

--- a/tests/pages/settings.js
+++ b/tests/pages/settings.js
@@ -95,10 +95,11 @@ export default PageObject.create({
 
     item: {
       branchName: text('.branch-name'),
-      enqueuingInterval: text('.enqueuing-interval'),
-      disableByBuildText: text('.disable-by-build'),
-
-      delete: clickable('.cron-job-delete')
+      interval: text('.interval'),
+      nextRun: text('.next-run'),
+      lastRun: text('.last-run'),
+      dontRunIfRecentBuildExistsText: text('.dont-run-if-recent-build-exists'),
+      delete: clickable('.icon-trash')
     }
   }),
 


### PR DESCRIPTION
This PR is a part of the a big [re-factoring of cron jobs](https://github.com/travis-ci/travis-api/pull/319) and it does the following:
- Show next and last run times for cron jobs
- Add tests for last and next runs
- Change text for cron job running condition
- Fix option string: `dont_run_if_recent_build_exists`
- [x] Awaiting @joshk review of https://github.com/travis-pro/team-teal/issues/1248
