### PR TITLE
Fix multiple tabs being highlighted

### DIFF
--- a/app/routes/branches.js
+++ b/app/routes/branches.js
@@ -30,11 +30,6 @@ export default TravisRoute.extend({
   },
 
   activate() {
-    Ember.$('.tab.tabs--main li').removeClass('active');
-    Ember.$('#tab_branches').addClass('active');
-  },
-
-  deactivate() {
-    Ember.$('#tab_branches').removeClass('active');
+    this.controllerFor('repo').activate('branches');
   }
 });


### PR DESCRIPTION
The previous implementation was setting DOM classes from the route, which violated separation of concerns.
This now uses the repo controller to set that state, although that will likely be extracted into a service in the future.

This addresses https://github.com/travis-pro/team-teal/issues/1278.