### PR TITLE
Revert V3 API usage for debug builds due to possible regression

### DIFF
--- a/app/models/build.js
+++ b/app/models/build.js
@@ -128,7 +128,7 @@ Build.reopen({
   },
 
   restart() {
-    return this.get('ajax').post(`/v3/build/${this.get('id')}/restart`);
+    return this.get('ajax').post(`/builds/${this.get('id')}/restart`);
   },
 
   canDebug: Ember.computed('jobs.length', function () {

--- a/app/models/job.js
+++ b/app/models/job.js
@@ -124,7 +124,7 @@ export default Model.extend(DurationCalculations, {
   },
 
   restart() {
-    return this.get('ajax').post('/v3/job/' + (this.get('id')) + '/restart');
+    return this.get('ajax').post('/jobs/' + (this.get('id')) + '/restart');
   },
 
   debug() {

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -160,7 +160,7 @@ export default function () {
     return response;
   });
 
-  this.post('/v3/build/:id/restart', (schema, request) => {
+  this.post('/builds/:id/restart', (schema, request) => {
     let build = schema.builds.find(request.params.id);
     if (build) {
       return {
@@ -181,7 +181,7 @@ export default function () {
     }
   });
 
-  this.post('/v3/job/:id/restart', (schema, request) => {
+  this.post('/jobs/:id/restart', (schema, request) => {
     let job = schema.jobs.find(request.params.id);
     if (job) {
       return {
@@ -201,6 +201,7 @@ export default function () {
       return new Mirage.Response(404, {}, {});
     }
   });
+
 
   this.get('/v3/repo/:repo_id/builds', function (schema, request) {
     const branch = schema.branches.where({ name: request.queryParams['branch.name'] }).models[0];


### PR DESCRIPTION
This reverts commit 42a6b3187179507ae0d5ca39a77d5123739d8a8d.

Someone wrote in that some people at their organisation can’t restart jobs. This is a possible temporary fix.