### PR TITLE
Use V3 for cancel/restart and hide buttons when lacking permissions

### DIFF
--- a/app/mixins/repo-actions-item-component-mixin.js
+++ b/app/mixins/repo-actions-item-component-mixin.js
@@ -21,7 +21,7 @@ export default Ember.Mixin.create({
     }
   }),
 
-  userHasPullPermissionForRepo: Ember.computed('user.permissions.[]', 'repo', 'user', function () {
+  userHasPullPermissionForRepo: Ember.computed('user.pullPermissions.[]', 'repo', 'user', function () {
     const repo = this.get('repo');
     const user = this.get('user');
 
@@ -30,7 +30,7 @@ export default Ember.Mixin.create({
     }
   }),
 
-  userHasPushPermissionForRepo: Ember.computed('user.permissions.[]', 'repo', 'user', function () {
+  userHasPushPermissionForRepo: Ember.computed('user.pushPermissions.[]', 'repo', 'user', function () {
     const repo = this.get('repo');
     const user = this.get('user');
 

--- a/app/mixins/repo-actions-item-component-mixin.js
+++ b/app/mixins/repo-actions-item-component-mixin.js
@@ -21,9 +21,27 @@ export default Ember.Mixin.create({
     }
   }),
 
-  canCancel: Ember.computed.and('userHasPermissionForRepo', 'item.canCancel'),
-  canRestart: Ember.computed.and('userHasPermissionForRepo', 'item.canRestart'),
-  canDebug: Ember.computed.and('userHasPermissionForRepo', 'item.canDebug'),
+  userHasPullPermissionForRepo: Ember.computed('user.permissions.[]', 'repo', 'user', function () {
+    const repo = this.get('repo');
+    const user = this.get('user');
+
+    if (user && repo) {
+      return user.hasPullAccessToRepo(repo);
+    }
+  }),
+
+  userHasPushPermissionForRepo: Ember.computed('user.permissions.[]', 'repo', 'user', function () {
+    const repo = this.get('repo');
+    const user = this.get('user');
+
+    if (user && repo) {
+      return user.hasPushAccessToRepo(repo);
+    }
+  }),
+
+  canCancel: Ember.computed.and('userHasPullPermissionForRepo', 'item.canCancel'),
+  canRestart: Ember.computed.and('userHasPullPermissionForRepo', 'item.canRestart'),
+  canDebug: Ember.computed.and('userHasPushPermissionForRepo', 'item.canDebug'),
 
   cancel: task(function * () {
     let type = this.get('type');

--- a/app/mixins/repo-actions-item-component-mixin.js
+++ b/app/mixins/repo-actions-item-component-mixin.js
@@ -45,9 +45,8 @@ export default Ember.Mixin.create({
     yield eventually(this.get('item'), (record) => {
       record.restart().then(() => {
         this.get('flashes').notice(`The ${type} was successfully restarted.`);
-      }, (xhr) => {
+      }, () => {
         this.get('flashes').error(`An error occurred. The ${type} could not be restarted.`);
-        this.displayFlashError(xhr.status, 'restart');
       });
     });
   }).group('restarters'),
@@ -60,10 +59,9 @@ export default Ember.Mixin.create({
         this.get('flashes')
           .notice(`The ${type} was successfully restarted in debug mode.
             Watch the log for a host to connect to.`);
-      }, (xhr) => {
+      }, () => {
         this.get('flashes')
           .error(`An error occurred. The ${type} could not be restarted in debug mode.`);
-        this.displayFlashError(xhr.status, 'debug');
       });
     });
   }).group('restarters'),

--- a/app/mixins/repo-actions-item-component-mixin.js
+++ b/app/mixins/repo-actions-item-component-mixin.js
@@ -21,6 +21,7 @@ export default Ember.Mixin.create({
     }
   }),
 
+  // eslint-disable-next-line
   userHasPullPermissionForRepo: Ember.computed('user.pullPermissions.[]', 'repo', 'user', function () {
     const repo = this.get('repo');
     const user = this.get('user');
@@ -30,6 +31,7 @@ export default Ember.Mixin.create({
     }
   }),
 
+  // eslint-disable-next-line
   userHasPushPermissionForRepo: Ember.computed('user.pushPermissions.[]', 'repo', 'user', function () {
     const repo = this.get('repo');
     const user = this.get('user');

--- a/app/models/build.js
+++ b/app/models/build.js
@@ -128,7 +128,7 @@ Build.reopen({
   },
 
   restart() {
-    return this.get('ajax').post(`/builds/${this.get('id')}/restart`);
+    return this.get('ajax').postV3(`/build/${this.get('id')}/restart`);
   },
 
   canDebug: Ember.computed('jobs.length', function () {

--- a/app/models/build.js
+++ b/app/models/build.js
@@ -124,7 +124,7 @@ Build.reopen({
   canRestart: Ember.computed.alias('isFinished'),
 
   cancel() {
-    return this.get('ajax').post('/builds/' + (this.get('id')) + '/cancel');
+    return this.get('ajax').postV3('/build/' + (this.get('id')) + '/cancel');
   },
 
   restart() {

--- a/app/models/job.js
+++ b/app/models/job.js
@@ -128,13 +128,8 @@ export default Model.extend(DurationCalculations, {
   },
 
   debug() {
-    return this.get('ajax').ajax(`/job/${this.get('id')}/debug`, 'POST', {
-      data: {
-        quiet: true
-      },
-      headers: {
-        'Travis-API-Version': '3'
-      }
+    return this.get('ajax').postV3(`/job/${this.get('id')}/debug`, {
+      quiet: true
     });
   },
 

--- a/app/models/job.js
+++ b/app/models/job.js
@@ -124,7 +124,7 @@ export default Model.extend(DurationCalculations, {
   },
 
   restart() {
-    return this.get('ajax').post('/jobs/' + (this.get('id')) + '/restart');
+    return this.get('ajax').postV3('/job/' + (this.get('id')) + '/restart');
   },
 
   debug() {

--- a/app/models/job.js
+++ b/app/models/job.js
@@ -107,6 +107,7 @@ export default Model.extend(DurationCalculations, {
   }),
 
   canRestart: Ember.computed.alias('isFinished'),
+  canDebug: Ember.computed.alias('isFinished'),
 
   cancel() {
     return this.get('ajax').postV3('/job/' + (this.get('id')) + '/cancel');

--- a/app/models/job.js
+++ b/app/models/job.js
@@ -109,7 +109,7 @@ export default Model.extend(DurationCalculations, {
   canRestart: Ember.computed.alias('isFinished'),
 
   cancel() {
-    return this.get('ajax').post('/jobs/' + (this.get('id')) + '/cancel');
+    return this.get('ajax').postV3('/job/' + (this.get('id')) + '/cancel');
   },
 
   removeLog() {

--- a/app/models/job.js
+++ b/app/models/job.js
@@ -102,10 +102,7 @@ export default Model.extend(DurationCalculations, {
     }
   }),
 
-  canCancel: Ember.computed('isFinished', function () {
-    return !this.get('isFinished');
-  }),
-
+  canCancel: Ember.computed.not('isFinished'),
   canRestart: Ember.computed.alias('isFinished'),
   canDebug: Ember.computed.alias('isFinished'),
 

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -100,6 +100,22 @@ export default Model.extend({
     }
   },
 
+  hasPullAccessToRepo(repo) {
+    const id = repo.get ? repo.get('id') : repo;
+    const permissions = this.get('pullPermissions');
+    if (permissions) {
+      return permissions.contains(parseInt(id));
+    }
+  },
+
+  hasPushAccessToRepo(repo) {
+    const id = repo.get ? repo.get('id') : repo;
+    const permissions = this.get('pushPermissions');
+    if (permissions) {
+      return permissions.contains(parseInt(id));
+    }
+  },
+
   type: Ember.computed(function () {
     return 'user';
   }),

--- a/app/services/ajax.js
+++ b/app/services/ajax.js
@@ -31,6 +31,16 @@ export default Ember.Service.extend({
     });
   },
 
+  postV3(url, data, callback) {
+    return this.ajax(url, 'post', {
+      data: data,
+      success: callback,
+      headers: {
+        'Travis-API-Version': '3'
+      }
+    });
+  },
+
   patch(url, data, callback) {
     return this.ajax(url, 'patch', {
       data: data,

--- a/app/templates/components/job-repo-actions.hbs
+++ b/app/templates/components/job-repo-actions.hbs
@@ -17,7 +17,9 @@
     </a>
 
     {{#if features.proVersion}}
-      <a href="#" {{action (perform debug)}} class="action-button--debug" title="Restart as debug job">Debug job</a>
+      {{#if canDebug}}
+        <a href="#" {{action (perform debug)}} class="action-button--debug" title="Restart as debug job">Debug job</a>
+      {{/if}}
     {{/if}}
   {{/if}}
 {{/if}}

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -160,7 +160,7 @@ export default function () {
     return response;
   });
 
-  this.post('/builds/:id/restart', (schema, request) => {
+  this.post('/build/:id/restart', (schema, request) => {
     let build = schema.builds.find(request.params.id);
     if (build) {
       return {
@@ -181,7 +181,7 @@ export default function () {
     }
   });
 
-  this.post('/jobs/:id/restart', (schema, request) => {
+  this.post('/job/:id/restart', (schema, request) => {
     let job = schema.jobs.find(request.params.id);
     if (job) {
       return {

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -172,7 +172,7 @@ export default function () {
     }
   });
 
-  this.post('/builds/:id/cancel', (schema, request) => {
+  this.post('/build/:id/cancel', (schema, request) => {
     let build = schema.builds.find(request.params.id);
     if (build) {
       return new Mirage.Response(204, {}, {});
@@ -193,7 +193,7 @@ export default function () {
     }
   });
 
-  this.post('/jobs/:id/cancel', (schema, request) => {
+  this.post('/job/:id/cancel', (schema, request) => {
     let job = schema.jobs.find(request.params.id);
     if (job) {
       return new Mirage.Response(204, {}, {});

--- a/tests/unit/components/build-repo-actions-test.js
+++ b/tests/unit/components/build-repo-actions-test.js
@@ -41,35 +41,35 @@ test('it shows restart button if canRestart is true', function () {
   return ok(component.$('a[title="Restart build"]').length, 'restart link should be visible');
 });
 
-test('user can cancel if she has permissions to a repo and build is cancelable', function () {
+test('user can cancel if she has pull permissions to a repo and build is cancelable', function () {
   var build, component;
   build = Ember.Object.create({
     canCancel: false,
-    userHasPermissionForRepo: true
+    userHasPullPermissionForRepo: true
   });
   component = this.subject({
     build: build,
-    userHasPermissionForRepo: false
+    userHasPullPermissionForRepo: false
   });
   ok(!component.get('canCancel'));
-  component.set('userHasPermissionForRepo', true);
+  component.set('userHasPullPermissionForRepo', true);
   ok(!component.get('canCancel'));
   build.set('canCancel', true);
   return ok(component.get('canCancel'));
 });
 
-test('user can restart if she has permissions to a repo and job is restartable', function () {
+test('user can restart if she has pull permissions to a repo and job is restartable', function () {
   var build, component;
   build = Ember.Object.create({
     canRestart: false,
-    userHasPermissionForRepo: true
+    userHasPullPermissionForRepo: true
   });
   component = this.subject({
     build: build,
-    userHasPermissionForRepo: false
+    userHasPullPermissionForRepo: false
   });
   ok(!component.get('canRestart'));
-  component.set('userHasPermissionForRepo', true);
+  component.set('userHasPullPermissionForRepo', true);
   ok(!component.get('canRestart'));
   build.set('canRestart', true);
   return ok(component.get('canRestart'));

--- a/tests/unit/components/job-repo-actions-test.js
+++ b/tests/unit/components/job-repo-actions-test.js
@@ -40,35 +40,35 @@ test('it shows restart button if canRestart is true', function () {
   return ok(component.$('a[title="Restart job"]').length, 'restart link should be visible');
 });
 
-test('user can cancel if she has permissions to a repo and job is cancelable', function () {
+test('user can cancel if she has pull permissions to a repo and job is cancelable', function () {
   var component, job;
   job = Ember.Object.create({
     canCancel: false,
-    userHasPermissionForRepo: true
+    userHasPullPermissionForRepo: true
   });
   component = this.subject({
     job: job,
-    userHasPermissionForRepo: false
+    userHasPullPermissionForRepo: false
   });
   ok(!component.get('canCancel'));
-  component.set('userHasPermissionForRepo', true);
+  component.set('userHasPullPermissionForRepo', true);
   ok(!component.get('canCancel'));
   job.set('canCancel', true);
   return ok(component.get('canCancel'));
 });
 
-test('user can restart if she has permissions to a repo and job is restartable', function () {
+test('user can restart if she has pull permissions to a repo and job is restartable', function () {
   var component, job;
   job = Ember.Object.create({
     canRestart: false,
-    userHasPermissionForRepo: true
+    userHasPullPermissionForRepo: true
   });
   component = this.subject({
     job: job,
-    userHasPermissionForRepo: false
+    userHasPullPermissionForRepo: false
   });
   ok(!component.get('canRestart'));
-  component.set('userHasPermissionForRepo', true);
+  component.set('userHasPullPermissionForRepo', true);
   ok(!component.get('canRestart'));
   job.set('canRestart', true);
   return ok(component.get('canRestart'));


### PR DESCRIPTION
This adapts @clekstro’s 42a6b31, using the V3 header instead of URL path prefix. It also replicates the knowledge of the V3 API’s permissions structure:

* a user must have pull permissions to cancel or restart jobs and builds
* a user must have push permissions to trigger debug jobs

I’m unable to run this locally against the com-staging API for mysterious reasons, so I’ll be deploying manually to web com-staging to try it out.