### PR TITLE
Optional staging PR deployments

### DIFF
--- a/config/deploy.js
+++ b/config/deploy.js
@@ -1,4 +1,5 @@
 var VALID_DEPLOY_TARGETS = [
+  'org-staging-pull-request',
   'org-production-pull-request',
   'com-production-pull-request'
 ];
@@ -26,6 +27,12 @@ module.exports = function(deployTarget) {
   if (deployTarget === 'org-production-pull-request') {
     ENV.s3.bucket = 'travis-web-production-next';
     ENV.redis.url = process.env.ORG_PRODUCTION_REDIS_URL;
+  }
+
+  if (deployTarget === 'org-staging-pull-request') {
+    ENV.s3.bucket = 'travis-web-production-next';
+    ENV.redis.url = process.env.ORG_PRODUCTION_REDIS_URL;
+    ENV.redis.keyPrefix = `${process.env.TRAVIS_PULL_REQUEST_BRANCH}-staging`;
   }
 
   if (deployTarget === 'com-production-pull-request') {

--- a/config/deploy.js
+++ b/config/deploy.js
@@ -1,6 +1,7 @@
 var VALID_DEPLOY_TARGETS = [
   'org-staging-pull-request',
   'org-production-pull-request',
+  'com-staging-pull-request',
   'com-production-pull-request'
 ];
 
@@ -38,6 +39,12 @@ module.exports = function(deployTarget) {
   if (deployTarget === 'com-production-pull-request') {
     ENV.s3.bucket = 'travis-pro-web-production-next';
     ENV.redis.url = process.env.COM_PRODUCTION_REDIS_URL;
+  }
+
+  if (deployTarget === 'com-staging-pull-request') {
+    ENV.s3.bucket = 'travis-pro-web-production-next';
+    ENV.redis.url = process.env.COM_PRODUCTION_REDIS_URL;
+    ENV.redis.keyPrefix = `${process.env.TRAVIS_PULL_REQUEST_BRANCH}-staging`;
   }
 
   return ENV;

--- a/config/deployment/deploy-pull-request.sh
+++ b/config/deployment/deploy-pull-request.sh
@@ -1,5 +1,6 @@
 ./config/deployment/store-pull-request-data.sh
 export TRAVIS_PULL_REQUEST_BRANCH=`jq -r '.head.ref' pull-request.json | tr '.' '-'`
 ember deploy org-production-pull-request --activate --verbose
+API_ENDPOINT=https://api-staging.travis-ci.org ember deploy org-staging-pull-request --activate --verbose
 TRAVIS_PRO=true ember deploy com-production-pull-request --activate --verbose
 ./config/deployment/update-github-status.sh

--- a/config/deployment/deploy-pull-request.sh
+++ b/config/deployment/deploy-pull-request.sh
@@ -1,7 +1,14 @@
 ./config/deployment/store-pull-request-data.sh
+
 export TRAVIS_PULL_REQUEST_BRANCH=`jq -r '.head.ref' pull-request.json | tr '.' '-'`
+
 ember deploy org-production-pull-request --activate --verbose
 API_ENDPOINT=https://api-staging.travis-ci.org ember deploy org-staging-pull-request --activate --verbose
-TRAVIS_PRO=true ember deploy com-production-pull-request --activate --verbose
-API_ENDPOINT=https://api-staging.travis-ci.com TRAVIS_PRO=true ember deploy com-staging-pull-request --activate --verbose
+
+if [[ $TRAVIS_PULL_REQUEST_BRANCH = *staging* ]]
+then
+  TRAVIS_PRO=true ember deploy com-production-pull-request --activate --verbose
+  API_ENDPOINT=https://api-staging.travis-ci.com TRAVIS_PRO=true ember deploy com-staging-pull-request --activate --verbose
+fi
+
 ./config/deployment/update-github-status.sh

--- a/config/deployment/deploy-pull-request.sh
+++ b/config/deployment/deploy-pull-request.sh
@@ -9,6 +9,8 @@ if [[ $TRAVIS_PULL_REQUEST_BRANCH = *staging* ]]
 then
   TRAVIS_PRO=true ember deploy com-production-pull-request --activate --verbose
   API_ENDPOINT=https://api-staging.travis-ci.com TRAVIS_PRO=true ember deploy com-staging-pull-request --activate --verbose
+else
+  echo "Skipping com- and org-staging PR deployments: no 'staging' in branch name."
 fi
 
 ./config/deployment/update-github-status.sh

--- a/config/deployment/deploy-pull-request.sh
+++ b/config/deployment/deploy-pull-request.sh
@@ -3,4 +3,5 @@ export TRAVIS_PULL_REQUEST_BRANCH=`jq -r '.head.ref' pull-request.json | tr '.' 
 ember deploy org-production-pull-request --activate --verbose
 API_ENDPOINT=https://api-staging.travis-ci.org ember deploy org-staging-pull-request --activate --verbose
 TRAVIS_PRO=true ember deploy com-production-pull-request --activate --verbose
+API_ENDPOINT=https://api-staging.travis-ci.com TRAVIS_PRO=true ember deploy com-staging-pull-request --activate --verbose
 ./config/deployment/update-github-status.sh

--- a/config/deployment/deploy-pull-request.sh
+++ b/config/deployment/deploy-pull-request.sh
@@ -3,11 +3,11 @@
 export TRAVIS_PULL_REQUEST_BRANCH=`jq -r '.head.ref' pull-request.json | tr '.' '-'`
 
 ember deploy org-production-pull-request --activate --verbose
-API_ENDPOINT=https://api-staging.travis-ci.org ember deploy org-staging-pull-request --activate --verbose
+TRAVIS_PRO=true ember deploy com-production-pull-request --activate --verbose
 
 if [[ $TRAVIS_PULL_REQUEST_BRANCH = *staging* ]]
 then
-  TRAVIS_PRO=true ember deploy com-production-pull-request --activate --verbose
+  API_ENDPOINT=https://api-staging.travis-ci.org ember deploy org-staging-pull-request --activate --verbose
   API_ENDPOINT=https://api-staging.travis-ci.com TRAVIS_PRO=true ember deploy com-staging-pull-request --activate --verbose
 else
   echo "Skipping com- and org-staging PR deployments: no 'staging' in branch name."

--- a/config/deployment/update-github-status.sh
+++ b/config/deployment/update-github-status.sh
@@ -11,3 +11,7 @@ curl -X POST \
      --data "{\"state\": \"success\", \"target_url\": \"https://`echo $TRAVIS_PULL_REQUEST_BRANCH`.test-deployments.travis-ci.com\", \"description\": \"Visit a com-production deployment for this commit\", \"context\": \"deployments/com-production\"}" \
      -H "Authorization: token $GITHUB_TOKEN" \
      https://api.github.com/repos/travis-ci/travis-web/statuses/$TRAVIS_PULL_REQUEST_COMMIT
+ curl -X POST \
+      --data "{\"state\": \"success\", \"target_url\": \"https://`echo $TRAVIS_PULL_REQUEST_BRANCH`-staging.test-deployments.travis-ci.com\", \"description\": \"Visit a com-staging deployment for this commit\", \"context\": \"deployments/com-staging\"}" \
+      -H "Authorization: token $GITHUB_TOKEN" \
+      https://api.github.com/repos/travis-ci/travis-web/statuses/$TRAVIS_PULL_REQUEST_COMMIT

--- a/config/deployment/update-github-status.sh
+++ b/config/deployment/update-github-status.sh
@@ -4,6 +4,10 @@ curl -X POST \
      -H "Authorization: token $GITHUB_TOKEN" \
      https://api.github.com/repos/travis-ci/travis-web/statuses/$TRAVIS_PULL_REQUEST_COMMIT
 curl -X POST \
+     --data "{\"state\": \"success\", \"target_url\": \"https://`echo $TRAVIS_PULL_REQUEST_BRANCH`-staging.test-deployments.travis-ci.org\", \"description\": \"Visit a org-staging deployment for this commit\", \"context\": \"deployments/org-staging\"}" \
+     -H "Authorization: token $GITHUB_TOKEN" \
+     https://api.github.com/repos/travis-ci/travis-web/statuses/$TRAVIS_PULL_REQUEST_COMMIT
+curl -X POST \
      --data "{\"state\": \"success\", \"target_url\": \"https://`echo $TRAVIS_PULL_REQUEST_BRANCH`.test-deployments.travis-ci.com\", \"description\": \"Visit a com-production deployment for this commit\", \"context\": \"deployments/com-production\"}" \
      -H "Authorization: token $GITHUB_TOKEN" \
      https://api.github.com/repos/travis-ci/travis-web/statuses/$TRAVIS_PULL_REQUEST_COMMIT


### PR DESCRIPTION
This is an idea for optionally creating org- and com-staging PR deployments if the branch name contains `staging`. Staging deployments aren’t useful most of the time so the extra time for the PR build to pass isn’t worth it, but when testing in concert with API changes, it can be helpful.

I’ve pulled this from various branches. Last time I tried it, the com-staging deployment actually used com-production, strangely. Hopefully I can figure out why.