### PR TITLE
Remove API-fetched deployment variables

### DIFF
--- a/config/deployment/deploy-pull-request.sh
+++ b/config/deployment/deploy-pull-request.sh
@@ -1,5 +1,3 @@
-./config/deployment/store-pull-request-data.sh
-export TRAVIS_PULL_REQUEST_BRANCH=`jq -r '.head.ref' pull-request.json | tr '.' '-'`
 ember deploy org-production-pull-request --activate --verbose
 TRAVIS_PRO=true ember deploy com-production-pull-request --activate --verbose
 ./config/deployment/update-github-status.sh

--- a/config/deployment/store-pull-request-data.sh
+++ b/config/deployment/store-pull-request-data.sh
@@ -1,1 +1,0 @@
-curl -sH "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/travis-ci/travis-web/pulls/$TRAVIS_PULL_REQUEST > pull-request.json

--- a/config/deployment/update-github-status.sh
+++ b/config/deployment/update-github-status.sh
@@ -1,9 +1,8 @@
-export TRAVIS_PULL_REQUEST_COMMIT=`jq -r '.head.sha' pull-request.json`
 curl -X POST \
      --data "{\"state\": \"success\", \"target_url\": \"https://`echo $TRAVIS_PULL_REQUEST_BRANCH`.test-deployments.travis-ci.org\", \"description\": \"Visit a org-production deployment for this commit\", \"context\": \"deployments/org-production\"}" \
      -H "Authorization: token $GITHUB_TOKEN" \
-     https://api.github.com/repos/travis-ci/travis-web/statuses/$TRAVIS_PULL_REQUEST_COMMIT
+     https://api.github.com/repos/travis-ci/travis-web/statuses/$TRAVIS_PULL_REQUEST_SHA
 curl -X POST \
      --data "{\"state\": \"success\", \"target_url\": \"https://`echo $TRAVIS_PULL_REQUEST_BRANCH`.test-deployments.travis-ci.com\", \"description\": \"Visit a com-production deployment for this commit\", \"context\": \"deployments/com-production\"}" \
      -H "Authorization: token $GITHUB_TOKEN" \
-     https://api.github.com/repos/travis-ci/travis-web/statuses/$TRAVIS_PULL_REQUEST_COMMIT
+     https://api.github.com/repos/travis-ci/travis-web/statuses/$TRAVIS_PULL_REQUEST_SHA


### PR DESCRIPTION
Thanks to @BanzaiMan’s travis-ci/travis-scheduler#38 and
travis-ci/travis-build#848, these are now present as
environment variables rather than needing to be fetched
via the GitHub API.