### PR TITLE
Improve static title

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>{{title}}</title>
+    <title>Travis CI</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" href="/images/favicon.png" />

--- a/tests/acceptance/builds/branches-tab-test.js
+++ b/tests/acceptance/builds/branches-tab-test.js
@@ -24,6 +24,7 @@ test('visiting /builds/branches-tab', function (assert) {
     .visit();
 
   andThen(function () {
+    assert.equal(document.title, 'travis-ci/travis-web - Travis CI');
     assert.ok(branchesRepoTab.branchesTabActive, 'Branches tab is active when visiting /org/repo/branches');
   });
 });

--- a/tests/acceptance/builds/current-tab-test.js
+++ b/tests/acceptance/builds/current-tab-test.js
@@ -38,6 +38,7 @@ test('renders most recent repository and most recent build when builds present',
     .visit();
 
   andThen(function () {
+    assert.equal(document.title, 'travis-ci/travis-web - Travis CI');
     assert.ok(currentRepoTab.currentTabActive, 'Current tab is active by default when loading dashboard');
   });
 

--- a/tests/acceptance/job/basic-layout-test.js
+++ b/tests/acceptance/job/basic-layout-test.js
@@ -23,6 +23,8 @@ test('visiting job-view', function (assert) {
   visit('/travis-ci/travis-web/jobs/' + job.id);
 
   andThen(() => {
+    assert.equal(document.title, 'Job #1234.1 - travis-ci/travis-web - Travis CI');
+
     assert.equal(jobPage.branch, 'acceptance-tests');
     assert.equal(jobPage.message, 'acceptance-tests This is a message');
     assert.equal(jobPage.state, '#1234.1 passed');

--- a/tests/acceptance/owner/repos-test.js
+++ b/tests/acceptance/owner/repos-test.js
@@ -53,6 +53,8 @@ test('the owner page shows their repositories', (assert) => {
   ownerPage.visit({ username: 'feministkilljoy' });
 
   andThen(() => {
+    assert.equal(document.title, 'Sara Ahmed - Travis CI');
+
     assert.equal(ownerPage.repos().count, 2);
     assert.equal(ownerPage.repos(0).name, 'living-a-feminist-life');
 

--- a/tests/acceptance/profile/basic-layout-test.js
+++ b/tests/acceptance/profile/basic-layout-test.js
@@ -57,6 +57,8 @@ test('view profile', function (assert) {
   profilePage.visit({ username: 'feministkilljoy' });
 
   andThen(function () {
+    assert.equal(document.title, 'Sara Ahmed - Profile - Travis CI');
+
     assert.equal(profilePage.name, 'Sara Ahmed');
 
     assert.equal(profilePage.accounts().count, 2, 'expected two accounts');

--- a/tests/acceptance/repo/builds-test.js
+++ b/tests/acceptance/repo/builds-test.js
@@ -97,6 +97,8 @@ test('view branches', function (assert) {
   branchesPage.visit({ organization: 'killjoys', repo: 'living-a-feminist-life' });
 
   andThen(() => {
+    assert.equal(document.title, 'killjoys/living-a-feminist-life - Travis CI');
+
     assert.equal(branchesPage.defaultBranch.name, 'primary');
     assert.ok(branchesPage.defaultBranch.passed, 'expected default branch last build to have passed');
     assert.equal(branchesPage.defaultBranch.buildCount, '3 builds');


### PR DESCRIPTION
This fixes the flash of `{{title}}` as the document title. Everything is already in place for dynamic titles otherwise.