### PR TITLE
Remove deprecated baseURL setting

### DIFF
--- a/app/adapters/ssh-key.js
+++ b/app/adapters/ssh-key.js
@@ -1,7 +1,7 @@
 import ApplicationAdapter from 'travis/adapters/application';
 
 export default ApplicationAdapter.extend({
-  namespace: 'settings',
+  namespace: '/settings',
 
   findRecord(store, type, id) {
     const url = `${this.urlPrefix()}/ssh_key/${id}`;

--- a/app/adapters/ssh-key.js
+++ b/app/adapters/ssh-key.js
@@ -3,6 +3,16 @@ import ApplicationAdapter from 'travis/adapters/application';
 export default ApplicationAdapter.extend({
   namespace: 'settings',
 
+  urlPrefix() {
+    const prefix = this._super(...arguments);
+
+    if (prefix.indexOf('http') === -1) {
+      return `/${prefix}`;
+    } else {
+      return prefix;
+    }
+  },
+
   findRecord(store, type, id) {
     const url = `${this.urlPrefix()}/ssh_key/${id}`;
     return this.ajax(url, 'GET');

--- a/app/adapters/ssh-key.js
+++ b/app/adapters/ssh-key.js
@@ -1,7 +1,7 @@
 import ApplicationAdapter from 'travis/adapters/application';
 
 export default ApplicationAdapter.extend({
-  namespace: '/settings',
+  namespace: 'settings',
 
   findRecord(store, type, id) {
     const url = `${this.urlPrefix()}/ssh_key/${id}`;

--- a/config/environment.js
+++ b/config/environment.js
@@ -108,7 +108,6 @@ module.exports = function (environment) {
 
   if (environment === 'test') {
     // Testem prefers this...
-    ENV.baseURL = '/';
     ENV.locationType = 'none';
 
     ENV.APP.rootElement = '#ember-testing';

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -3,8 +3,6 @@ import Ember from 'ember';
 import Mirage from 'ember-cli-mirage';
 
 export default function () {
-  this.namespace = '/';
-
   this.get('/accounts', (schema/* , request*/) => {
     const users = schema.users.all().models.map(user => Ember.merge(user.attrs, { type: 'user' }));
     const accounts = schema.accounts.all().models.map(account => account.attrs);

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -3,6 +3,8 @@ import Ember from 'ember';
 import Mirage from 'ember-cli-mirage';
 
 export default function () {
+  this.namespace = '/';
+
   this.get('/accounts', (schema/* , request*/) => {
     const users = schema.users.all().models.map(user => Ember.merge(user.attrs, { type: 'user' }));
     const accounts = schema.accounts.all().models.map(account => account.attrs);

--- a/tests/index.html
+++ b/tests/index.html
@@ -22,7 +22,7 @@
     {{content-for "body"}}
     {{content-for "test-body"}}
 
-    <script src="testem.js" integrity=""></script>
+    <script src="{{rootURL}}testem.js" integrity=""></script>
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/test-support.js"></script>
     <script src="{{rootURL}}assets/travis.js"></script>


### PR DESCRIPTION
This was removed from the blueprint in Ember CLI 2.7:
https://github.com/ember-cli/ember-cli/blob/ad5af6877c44653eaf121e6820f06d280007c93c/blueprints/app/files/config/environment.js#L34-L36

See the blog post:
http://emberjs.com/blog/2016/04/28/baseURL.html

This will remove this bit of log noise:
https://travis-ci.org/travis-ci/travis-web/jobs/166748870#L613