### PR TITLE
Remove compare link in build header for api and cron eventTypes

### DIFF
--- a/app/components/build-header.js
+++ b/app/components/build-header.js
@@ -27,6 +27,15 @@ export default Ember.Component.extend({
     }
   }),
 
+  displayCompare: Ember.computed('item.eventType', function () {
+    let eventType = this.get('item.eventType');
+    if (eventType === 'api' || eventType === 'cron') {
+      return false;
+    } else {
+      return true;
+    }
+  }),
+
   urlGithubCommit: Ember.computed('item', function () {
     return githubCommit(this.get('repo.slug'), this.get('commit.sha'));
   }),

--- a/app/templates/components/build-header.hbs
+++ b/app/templates/components/build-header.hbs
@@ -22,19 +22,21 @@
           <span class="icon-github" aria-hidden="true"></span>
           <span class="label-align">Commit {{format-sha commit.sha}}</span></a>
       </li>
-      <li>
-        {{#if item.pullRequest}}
-          <a class="commit-compare" title="See the commit on GitHub" href={{item.commit.compareUrl}}>
-            <span class="icon-github" aria-hidden="true"></span>
-            <span class="label-align">#{{item.pullRequestNumber}}: {{item.pullRequestTitle}}</span></a>
-        {{else}}
-          {{#if item.commit.compareUrl}}
+      {{#if displayCompare}}
+        <li>
+          {{#if item.pullRequest}}
+            <a class="commit-compare" title="See the commit on GitHub" href={{item.commit.compareUrl}}>
+              <span class="icon-github" aria-hidden="true"></span>
+              <span class="label-align">#{{item.pullRequestNumber}}: {{item.pullRequestTitle}}</span></a>
+          {{else}}
+            {{#if item.commit.compareUrl}}
             <a class="commit-compare" title="See the diff on GitHub" href={{item.commit.compareUrl}}>
               <span class="icon-github" aria-hidden="true"></span>
               <span class="label-align">Compare {{short-compare-shas item.commit.compareUrl}}</span></a>
+            {{/if}}
           {{/if}}
-        {{/if}}
-      </li>
+        </li>
+      {{/if}}
     </ul>
     <p class="commit-author">
       {{#if commit.authorName}}

--- a/tests/integration/components/build-header-test.js
+++ b/tests/integration/components/build-header-test.js
@@ -1,0 +1,49 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('build-header', 'Integration | Component | build header', {
+  integration: true
+});
+
+test('render api build', function (assert) {
+  let repo = {
+    slug: 'travis-ci/travis-web'
+  };
+  let commit = {
+    compareUrl: 'https://github.com/travis-repos/php-test-staging/compare/3d86ee98be2b...a82f6ba76c7b'
+  };
+  let build = {
+    eventType: 'api',
+    status: 'passed',
+    number: '1234',
+    commit: commit
+  };
+
+  this.set('build', build);
+  this.set('repo', repo);
+  this.set('commit', commit);
+
+  this.render(hbs`{{build-header item=build repo=repo commit=commit}}`);
+
+  assert.equal(this.$().find('.commit-compare').length, 0, 'does not display compare link element for api builds');
+  assert.equal(this.$().find('.build-status span').text().trim(), 'API event', 'displays right icon');
+});
+
+
+test('render push build', function (assert) {
+  let commit = {
+    compareUrl: 'https://github.com/travis-repos/php-test-staging/compare/3d86ee98be2b...a82f6ba76c7b'
+  };
+  let build = {
+    eventType: 'push',
+    status: 'passed',
+    number: '1234',
+    commit: commit
+  };
+
+  this.set('build', build);
+  this.render(hbs`{{build-header item=build}}`);
+
+  assert.equal(this.$().find('.commit-compare').length, 1, 'does display compare link element');
+  assert.equal(this.$().find('.commit-compare').text().trim(), 'Compare 3d86ee9..a82f6ba', 'does display compare link for push builds');
+});


### PR DESCRIPTION
There is no new commit API and Cron builds can be compared to and our GH-Url helper often generates falsy urls because of that
