### PR TITLE
Add index to stop splitting same-named folds

### DIFF
--- a/vendor/log.js
+++ b/vendor/log.js
@@ -249,7 +249,7 @@ removeCarriageReturns = function(string) {
   return string.substr(index + 1);
 };
 
-const foldNameCount = {};
+var foldNameCount = {};
 
 Log.Span = function(id, num, text, classes) {
   var fold, time, _ref;
@@ -258,17 +258,17 @@ Log.Span = function(id, num, text, classes) {
     this.fold = true;
     this.event = fold[1];
 
-    const foldName = fold[2];
+    var foldName = fold[2];
     this.text = foldName;
 
     if (!foldNameCount[foldName]) {
       foldNameCount[foldName] = 0;
     }
 
-    const foldCount = foldNameCount[foldName];
+    var foldCount = foldNameCount[foldName];
 
     this.count = foldNameCount[this.name];
-    this.name = `${foldName}-${foldCount}`;
+    this.name = foldName = '-' + foldCount;
     this.visibleName = this.text;
 
     if (this.event === 'end') {

--- a/vendor/log.js
+++ b/vendor/log.js
@@ -266,9 +266,7 @@ Log.Span = function(id, num, text, classes) {
     }
 
     var foldCount = foldNameCount[foldName];
-
-    this.count = foldNameCount[this.name];
-    this.name = foldName = '-' + foldCount;
+    this.name = foldName + '-' + foldCount;
     this.visibleName = this.text;
 
     if (this.event === 'end') {

--- a/vendor/log.js
+++ b/vendor/log.js
@@ -249,13 +249,31 @@ removeCarriageReturns = function(string) {
   return string.substr(index + 1);
 };
 
+const foldNameCount = {};
+
 Log.Span = function(id, num, text, classes) {
   var fold, time, _ref;
   Log.Node.apply(this, arguments);
   if (fold = text.match(Log.FOLD)) {
     this.fold = true;
     this.event = fold[1];
-    this.text = this.name = fold[2];
+
+    const foldName = fold[2];
+    this.text = foldName;
+
+    if (!foldNameCount[foldName]) {
+      foldNameCount[foldName] = 0;
+    }
+
+    const foldCount = foldNameCount[foldName];
+
+    this.count = foldNameCount[this.name];
+    this.name = `${foldName}-${foldCount}`;
+    this.visibleName = this.text;
+
+    if (this.event === 'end') {
+      foldNameCount[foldName]++;
+    }
   } else if (time = text.match(Log.TIME)) {
     this.time = true;
     this.event = time[1];
@@ -426,7 +444,7 @@ Log.extend(Log.Line, {
   create: function(log, spans) {
     var line, span, _i, _len;
     if ((span = spans[0]) && span.fold) {
-      line = new Log.Fold(log, span.event, span.name);
+      line = new Log.Fold(log, span.event, span.name, span.visibleName);
     } else {
       line = new Log.Line(log);
     }
@@ -558,11 +576,12 @@ Object.defineProperty(Log.Line.prototype, 'crs', {
   }
 });
 
-Log.Fold = function(log, event, name) {
+Log.Fold = function(log, event, name, visibleName) {
   Log.Line.apply(this, arguments);
   this.fold = true;
   this.event = event;
   this.name = name;
+  this.visibleName = visibleName;
   return this;
 };
 
@@ -616,7 +635,8 @@ Object.defineProperty(Log.Fold.prototype, 'data', {
       type: 'fold',
       id: this.id,
       event: this.event,
-      name: this.name
+      name: this.name,
+      visibleName: this.visibleName
     };
   }
 });
@@ -991,7 +1011,7 @@ Log.extend(Log.Renderer.prototype, {
     fold.setAttribute('id', data.id || ("fold-" + data.event + "-" + data.name));
     fold.setAttribute('class', "fold-" + data.event);
     if (data.event === 'start') {
-      fold.lastChild.lastChild.nodeValue = data.name;
+      fold.lastChild.lastChild.nodeValue = data.visibleName;
     } else {
       fold.removeChild(fold.lastChild);
     }


### PR DESCRIPTION
This adds a visibleName to a Fold, which is used as the
rendered name in the logs. Under the surface, the name
of each fold now has a numeric suffix appended so
using the same name for a fold multiple times will not
collide and break the log rendering.