### PR TITLE
Don't spin pending icon in created state

### DIFF
--- a/app/styles/app/base.sass
+++ b/app/styles/app/base.sass
@@ -6,17 +6,15 @@
 html,
 body
   height: 100%
-  line-height: 1.45 !important
-  font-size: 14px
-  background: white
-  color: $asphalt-grey
-  background-color: $pebble-grey
   padding: 0
   margin: 0
+  color: $asphalt-grey
+  font-size: 14px
   font-weight: 400
   font-style: normal
-  line-height: 1.45
   font-family: $font-family-sans-serif
+  line-height: 1.45
+  background-color: $pebble-grey
 
 h1, h2, h3, h4, h5, h6
   font-weight: $font-weight-normal

--- a/app/styles/app/layouts/sidebar.sass
+++ b/app/styles/app/layouts/sidebar.sass
@@ -2,6 +2,7 @@
   height: auto
   padding: 0.8em 0.5em 0.8em 1.5em
   margin-bottom: .46rem
+  font-size: 14px
   background-color: white
   border-radius: 0
   li:last-child &
@@ -17,19 +18,14 @@
   @include colorRows($canary-yellow, 'received', 8px, true)
   @include colorRows($canary-yellow, 'created', 8px, true)
 
-  .status-icon .is-rotating
-    width: 17px
-    height: 17px
-    line-height: 1
-
   h2, p
     margin: 0
-    font-size: 14px
-    font-weight: 400
+    font-size: inherit
   h2
     position: relative
     display: inline-block
     margin-bottom: .7em
+    padding-left: 1px
     @media #{$medium-up}
       width: 75%
       white-space: nowrap
@@ -56,7 +52,6 @@
     width: 12px
     height: 16px
 
-
 #tab_new
   a:hover
     .icon--plus:after
@@ -66,14 +61,8 @@
   margin-top: 1.4rem
   ul
     @include resetul
-    border-bottom: .46rem solid $cream-light
-    background-color: $cream-light
+    border-bottom: .46rem solid $pebble-grey
+    background-color: $pebble-grey
 
-.sidebar-seperator
-  width: 90%
-  margin: 1rem auto
-  border: none
-  border-bottom: solid 2px #f2f2f2
-  
 .travistab-nav--sidebar
   padding: 0 1em

--- a/app/styles/app/modules/status-icon.sass
+++ b/app/styles/app/modules/status-icon.sass
@@ -23,13 +23,12 @@
 
 .status-icon
   .is-rotating
-    width: 17px
-    height: 18px
-    line-height: 0.9
+    width: 13px
+    height: 14px
+    line-height: .9
     text-align: center
     transform-origin: center center
     will-change: transform
-    animation: rotation 3s infinite ease
     .circle
       display: inline-block
       vertical-align: middle
@@ -40,9 +39,14 @@
       transform-origin: center center
 
   &.started,
+  &.received
+    animation: rotation 3s infinite ease
+
+  &.started,
   &.received,
-  &.created
-    height: 19px
+  &.created,
+  &.queued
+    height: 18px
 
 @keyframes rotation
   0%


### PR DESCRIPTION
When a job is in `created` it's not doing anything yet. The idea is to only start spinning the icon once it enters `received state`.
