### PR TITLE
Remove `setHash` call from LineSelector

### DIFF
--- a/app/utils/lines-selector.js
+++ b/app/utils/lines-selector.js
@@ -46,7 +46,6 @@ export default (function () {
   }
 
   LinesSelector.prototype.willDestroy = function () {
-    this.location.setHash('');
     return this.destroyed = true;
   };
 


### PR DESCRIPTION
In the original code for the LineSelector we needed to change the URL in
order to remove the selected lines hash from the URL. So for example
when you visitted a job page with a log and you selected the 111th line,
you would be on the URL like /travis-ci/travis-web/jobs/456#L111. When
you navigate away from the page you don't want to still see the selected
line, so we were removing that portion from the URL.

With the current way the location code in Ember.js works, we don't have
to do it, so it's safe to remove the line.
