### PR TITLE
Update title replacement to replace entire element

### DIFF
--- a/waiter/lib/travis/web/app.rb
+++ b/waiter/lib/travis/web/app.rb
@@ -165,7 +165,7 @@ class Travis::Web::App
     end
 
     def set_title(content)
-      content.gsub!(/\{\{title\}\}/, title)
+      content.gsub!(/(<title>).*(<\/title>)/, "\\1#{title}\\2")
     end
 
     def title


### PR DESCRIPTION
I misunderstood this code before, thinking it was replacing
the entire element. Without this change, the SITE_TITLE
environment variable will have no effect.