### PR TITLE
Add auto-cancellation switches when API response includes them

### DIFF
--- a/app/controllers/settings.js
+++ b/app/controllers/settings.js
@@ -23,11 +23,14 @@ export default Ember.Controller.extend({
     }
   }),
 
-  showAutoCancellationSwitches: Ember.computed('model.settings.auto_cancel_branch_builds', 'model.settings.auto_cancel_pr_builds', function() {
-    const settings = this.get('model.settings');
+  showAutoCancellationSwitches: Ember.computed(
+    'model.settings.auto_cancel_branch_builds',
+    'model.settings.auto_cancel_pr_builds', function () {
+      const settings = this.get('model.settings');
 
-    return settings.hasOwnProperty('auto_cancel_pr_builds') || settings.hasOwnProperty('auto_cancel_branch_builds');
-  }),
+      return settings.hasOwnProperty('auto_cancel_pr_builds') ||
+        settings.hasOwnProperty('auto_cancel_branch_builds');
+    }),
 
   actions: {
     sshKeyAdded(sshKey) {

--- a/app/controllers/settings.js
+++ b/app/controllers/settings.js
@@ -23,6 +23,12 @@ export default Ember.Controller.extend({
     }
   }),
 
+  showAutoCancellationSwitches: Ember.computed('model.settings.auto_cancel_branch_builds', 'model.settings.auto_cancel_pr_builds', function() {
+    const settings = this.get('model.settings');
+
+    return settings.hasOwnProperty('auto_cancel_pr_builds') || settings.hasOwnProperty('auto_cancel_branch_builds');
+  }),
+
   actions: {
     sshKeyAdded(sshKey) {
       return this.set('model.customSshKey', sshKey);

--- a/app/styles/app/layouts/settings.sass
+++ b/app/styles/app/layouts/settings.sass
@@ -28,6 +28,13 @@
       display: inline-block
       width: grid-calc(11, 24)
 
+.settings-list--three-columns
+  @extend %settings-list
+  li
+    @media #{$medium-up}
+      display: inline-block
+      width: grid-calc(8, 24)
+
 .settings-list--envvars, .settings-list--crons
   @extend %settings-list
 

--- a/app/styles/app/layouts/settings.sass
+++ b/app/styles/app/layouts/settings.sass
@@ -28,13 +28,6 @@
       display: inline-block
       width: grid-calc(11, 24)
 
-.settings-list--three-columns
-  @extend %settings-list
-  li
-    @media #{$medium-up}
-      display: inline-block
-      width: grid-calc(8, 24)
-
 .settings-list--envvars, .settings-list--crons
   @extend %settings-list
 

--- a/app/templates/settings.hbs
+++ b/app/templates/settings.hbs
@@ -16,7 +16,7 @@
     <section class="settings-section auto-cancellation">
       <h2 class="small-title">Auto Cancellation Settings</h2>
 
-      <p>Some explanatory text.</p>
+      <!-- <p>FIXME Some explanatory text.</p> -->
 
       <ul class="settings-list--columns">
         <li>{{settings-switch active=model.settings.auto_cancel_pushes repo=repo description="Auto cancel pushes" key="auto_cancel_pushes"}}</li>

--- a/app/templates/settings.hbs
+++ b/app/templates/settings.hbs
@@ -19,8 +19,8 @@
       <p>Some explanatory text.</p>
 
       <ul class="settings-list--columns">
-        <li>{{settings-switch active=model.settings.auto_cancel_pushes repo=repo description="Auto cancel pull requests" key="auto_cancel_pushes"}}</li>
-        <li>{{settings-switch active=model.settings.auto_cancel_pull_requests repo=repo description="Auto cancel pushes" key="auto_cancel_pull_requests"}}</li>
+        <li>{{settings-switch active=model.settings.auto_cancel_pushes repo=repo description="Auto cancel pushes" key="auto_cancel_pushes"}}</li>
+        <li>{{settings-switch active=model.settings.auto_cancel_pull_requests repo=repo description="Auto cancel pull requests" key="auto_cancel_pull_requests"}}</li>
       </ul>
     </section>
   {{/if}}

--- a/app/templates/settings.hbs
+++ b/app/templates/settings.hbs
@@ -16,6 +16,8 @@
     <section class="settings-section auto-cancellation">
       <h2 class="small-title">Auto Cancellation Settings</h2>
 
+      <p>Some explanatory text.</p>
+
       <ul class="settings-list--columns">
         <li>{{settings-switch active=model.settings.auto_cancel_branch_builds repo=repo description="Auto cancel branch builds" key="auto_cancel_branch_builds"}}</li>
         <li>{{settings-switch active=model.settings.auto_cancel_pr_builds repo=repo description="Auto cancel pull requests" key="auto_cancel_pr_builds"}}</li>

--- a/app/templates/settings.hbs
+++ b/app/templates/settings.hbs
@@ -5,8 +5,8 @@
 
     <ul class="settings-list--columns">
       {{#if showAutoCancellationSwitches}}
-        <li>{{settings-switch active=model.settings.auto_cancel_pr_builds repo=repo description="FIXMEAutomatically cancel pull request…??" key="auto_cancel_pr_builds"}}</li>
-        <li>{{settings-switch active=model.settings.auto_cancel_branch_builds repo=repo description="FIXME???" key="auto_cancel_branch_builds"}}</li>
+        <li>{{settings-switch active=model.settings.auto_cancel_pr_builds repo=repo description="Auto cancel pushes" key="auto_cancel_pr_builds"}}</li>
+        <li>{{settings-switch active=model.settings.auto_cancel_branch_builds repo=repo description="Auto cancel pull requests" key="auto_cancel_branch_builds"}}</li>
       {{/if}}
 
       <li>{{settings-switch active=model.settings.builds_only_with_travis_yml repo=repo description="Build only if .travis.yml is present" key="builds_only_with_travis_yml"}}</li>

--- a/app/templates/settings.hbs
+++ b/app/templates/settings.hbs
@@ -4,6 +4,11 @@
     <h2 class="small-title">General Settings</h2>
 
     <ul class="settings-list--columns">
+      {{#if showAutoCancellationSwitches}}
+        <li>{{settings-switch active=model.settings.auto_cancel_pr_builds repo=repo description="FIXMEAutomatically cancel pull request…??" key="auto_cancel_pr_builds"}}</li>
+        <li>{{settings-switch active=model.settings.auto_cancel_branch_builds repo=repo description="FIXME???" key="auto_cancel_branch_builds"}}</li>
+      {{/if}}
+
       <li>{{settings-switch active=model.settings.builds_only_with_travis_yml repo=repo description="Build only if .travis.yml is present" key="builds_only_with_travis_yml"}}</li>
       <li>{{settings-switch active=model.settings.build_pushes repo=repo description="Build pushes" key="build_pushes"}}</li>
       <li>{{limit-concurrent-builds value=model.settings.maximum_number_of_builds enabled=concurrentBuildsLimit repo=repo}}</li>

--- a/app/templates/settings.hbs
+++ b/app/templates/settings.hbs
@@ -3,16 +3,20 @@
   <section class="settings-section">
     <h2 class="small-title">General Settings</h2>
 
-    <ul class="settings-list--columns">
+    <ul class="settings-list--{{if showAutoCancellationSwitches 'three-'}}columns">
+      <li>{{settings-switch active=model.settings.builds_only_with_travis_yml repo=repo description="Build only if .travis.yml is present" key="builds_only_with_travis_yml"}}</li>
+      <li>{{settings-switch active=model.settings.build_pushes repo=repo description="Build pushes" key="build_pushes"}}</li>
+
       {{#if showAutoCancellationSwitches}}
-        <li>{{settings-switch active=model.settings.auto_cancel_pr_builds repo=repo description="Auto cancel pushes" key="auto_cancel_pr_builds"}}</li>
         <li>{{settings-switch active=model.settings.auto_cancel_branch_builds repo=repo description="Auto cancel pull requests" key="auto_cancel_branch_builds"}}</li>
       {{/if}}
 
-      <li>{{settings-switch active=model.settings.builds_only_with_travis_yml repo=repo description="Build only if .travis.yml is present" key="builds_only_with_travis_yml"}}</li>
-      <li>{{settings-switch active=model.settings.build_pushes repo=repo description="Build pushes" key="build_pushes"}}</li>
       <li>{{limit-concurrent-builds value=model.settings.maximum_number_of_builds enabled=concurrentBuildsLimit repo=repo}}</li>
       <li>{{settings-switch active=model.settings.build_pull_requests repo=repo description="Build pull requests" key="build_pull_requests"}}</li>
+
+      {{#if showAutoCancellationSwitches}}
+        <li>{{settings-switch active=model.settings.auto_cancel_pr_builds repo=repo description="Auto cancel pushes" key="auto_cancel_pr_builds"}}</li>
+      {{/if}}
     </ul>
 
   </section>

--- a/app/templates/settings.hbs
+++ b/app/templates/settings.hbs
@@ -3,23 +3,25 @@
   <section class="settings-section">
     <h2 class="small-title">General Settings</h2>
 
-    <ul class="settings-list--{{if showAutoCancellationSwitches 'three-'}}columns">
+    <ul class="settings-list--columns">
       <li>{{settings-switch active=model.settings.builds_only_with_travis_yml repo=repo description="Build only if .travis.yml is present" key="builds_only_with_travis_yml"}}</li>
       <li>{{settings-switch active=model.settings.build_pushes repo=repo description="Build pushes" key="build_pushes"}}</li>
-
-      {{#if showAutoCancellationSwitches}}
-        <li>{{settings-switch active=model.settings.auto_cancel_branch_builds repo=repo description="Auto cancel pull requests" key="auto_cancel_branch_builds"}}</li>
-      {{/if}}
-
       <li>{{limit-concurrent-builds value=model.settings.maximum_number_of_builds enabled=concurrentBuildsLimit repo=repo}}</li>
       <li>{{settings-switch active=model.settings.build_pull_requests repo=repo description="Build pull requests" key="build_pull_requests"}}</li>
-
-      {{#if showAutoCancellationSwitches}}
-        <li>{{settings-switch active=model.settings.auto_cancel_pr_builds repo=repo description="Auto cancel pushes" key="auto_cancel_pr_builds"}}</li>
-      {{/if}}
     </ul>
 
   </section>
+
+  {{#if showAutoCancellationSwitches}}
+    <section class="settings-section auto-cancellation">
+      <h2 class="small-title">Auto Cancellation Settings</h2>
+
+      <ul class="settings-list--columns">
+        <li>{{settings-switch active=model.settings.auto_cancel_branch_builds repo=repo description="Auto cancel pull requests" key="auto_cancel_branch_builds"}}</li>
+        <li>{{settings-switch active=model.settings.auto_cancel_pr_builds repo=repo description="Auto cancel pushes" key="auto_cancel_pr_builds"}}</li>
+      </ul>
+    </section>
+  {{/if}}
 
   <section class="settings-section">
     <h2 class="small-title">Environment Variables</h2>

--- a/app/templates/settings.hbs
+++ b/app/templates/settings.hbs
@@ -17,8 +17,8 @@
       <h2 class="small-title">Auto Cancellation Settings</h2>
 
       <ul class="settings-list--columns">
-        <li>{{settings-switch active=model.settings.auto_cancel_branch_builds repo=repo description="Auto cancel pull requests" key="auto_cancel_branch_builds"}}</li>
-        <li>{{settings-switch active=model.settings.auto_cancel_pr_builds repo=repo description="Auto cancel pushes" key="auto_cancel_pr_builds"}}</li>
+        <li>{{settings-switch active=model.settings.auto_cancel_branch_builds repo=repo description="Auto cancel branch builds" key="auto_cancel_branch_builds"}}</li>
+        <li>{{settings-switch active=model.settings.auto_cancel_pr_builds repo=repo description="Auto cancel pull requests" key="auto_cancel_pr_builds"}}</li>
       </ul>
     </section>
   {{/if}}

--- a/tests/acceptance/repo/settings-test.js
+++ b/tests/acceptance/repo/settings-test.js
@@ -126,7 +126,7 @@ test('view settings', function (assert) {
 
     assert.notOk(settingsPage.autoCancellationSection.exists, 'expected auto-cancellation section to not exist');
     assert.notOk(settingsPage.autoCancelPushes.exists, 'expected no auto-cancel pushes switch when flag not present in API response');
-    assert.notOk(settingsPage.autoCancelPullRequests.exists, 'expected no auto-cancel pull_requests switch when flag not present in API response');
+    assert.notOk(settingsPage.autoCancelPullRequests.exists, 'expected no auto-cancel pull requests switch when flag not present in API response');
   });
 });
 
@@ -304,7 +304,7 @@ test('on a repository with auto-cancellation', function (assert) {
   andThen(() => {
     assert.ok(settingsPage.autoCancellationSection.exists, 'expected auto-cancellation section to exist');
     assert.ok(settingsPage.autoCancelPushes.isActive, 'expected auto-cancel pushes to be present and enabled');
-    assert.notOk(settingsPage.autoCancelPullRequests.isActive, 'expected auto-cancel pull_requests to be present but disabled');
+    assert.notOk(settingsPage.autoCancelPullRequests.isActive, 'expected auto-cancel pull requests to be present but disabled');
   });
 
   const settingToRequestBody = {};
@@ -316,7 +316,7 @@ test('on a repository with auto-cancellation', function (assert) {
   settingsPage.autoCancelPullRequests.toggle();
 
   andThen(() => {
-    assert.ok(settingsPage.autoCancelPullRequests.isActive, 'expected auto-cancel pull_requests to be enabled');
+    assert.ok(settingsPage.autoCancelPullRequests.isActive, 'expected auto-cancel pull requests to be enabled');
     assert.deepEqual(settingToRequestBody.auto_cancel_pull_requests, { 'user_setting.value': true });
   });
 

--- a/tests/acceptance/repo/settings-test.js
+++ b/tests/acceptance/repo/settings-test.js
@@ -293,3 +293,15 @@ test('delete and set SSH keys', function (assert) {
     });
   });
 });
+
+test('on a repository with auto-cancellation', function (assert) {
+  this.repository.createSetting({ name: 'auto_cancel_pr_builds', value: false });
+  this.repository.createSetting({ name: 'auto_cancel_branch_builds', value: true });
+
+  settingsPage.visit({ organization: 'killjoys', repo: 'living-a-feminist-life' });
+
+  andThen(() => {
+    assert.notOk(settingsPage.autoCancelPullRequestBuilds.isActive, 'expected auto-cancel PRs to be present but disabled');
+    assert.ok(settingsPage.autoCancelBranchBuilds.isActive, 'expected auto-cancel branches to be present and enabled');
+  });
+});

--- a/tests/acceptance/repo/settings-test.js
+++ b/tests/acceptance/repo/settings-test.js
@@ -123,6 +123,9 @@ test('view settings', function (assert) {
 
     assert.equal(settingsPage.sshKey.name, 'testy');
     assert.equal(settingsPage.sshKey.fingerprint, 'dd:cc:bb:aa');
+
+    assert.notOk(settingsPage.autoCancelPullRequestBuilds.exists, 'expected no auto-cancel PRs switch when flag not present in API response');
+    assert.notOk(settingsPage.autoCancelBranchBuilds.exists, 'expected no auto-cancel branches switch when flag not present in API response');
   });
 });
 

--- a/tests/acceptance/repo/settings-test.js
+++ b/tests/acceptance/repo/settings-test.js
@@ -304,4 +304,24 @@ test('on a repository with auto-cancellation', function (assert) {
     assert.notOk(settingsPage.autoCancelPullRequestBuilds.isActive, 'expected auto-cancel PRs to be present but disabled');
     assert.ok(settingsPage.autoCancelBranchBuilds.isActive, 'expected auto-cancel branches to be present and enabled');
   });
+
+  const settingToRequestBody = {};
+
+  server.patch(`/repo/${this.repository.id}/setting/:setting`, function (schema, request) {
+    settingToRequestBody[request.params.setting] = JSON.parse(request.requestBody);
+  });
+
+  settingsPage.autoCancelPullRequestBuilds.toggle();
+
+  andThen(() => {
+    assert.ok(settingsPage.autoCancelPullRequestBuilds.isActive, 'expected auto-cancel PRs to be enabled');
+    assert.deepEqual(settingToRequestBody.auto_cancel_pr_builds, { 'user_setting.value': true });
+  });
+
+  settingsPage.autoCancelBranchBuilds.toggle();
+
+  andThen(() => {
+    assert.notOk(settingsPage.autoCancelBranchBuilds.isActive, 'expected auto-cancel builds to be disabled');
+    assert.deepEqual(settingToRequestBody.auto_cancel_branch_builds, { 'user_setting.value': false });
+  });
 });

--- a/tests/acceptance/repo/settings-test.js
+++ b/tests/acceptance/repo/settings-test.js
@@ -124,6 +124,7 @@ test('view settings', function (assert) {
     assert.equal(settingsPage.sshKey.name, 'testy');
     assert.equal(settingsPage.sshKey.fingerprint, 'dd:cc:bb:aa');
 
+    assert.notOk(settingsPage.autoCancellationSection.exists, 'expected auto-cancellation section to not exist');
     assert.notOk(settingsPage.autoCancelPullRequestBuilds.exists, 'expected no auto-cancel PRs switch when flag not present in API response');
     assert.notOk(settingsPage.autoCancelBranchBuilds.exists, 'expected no auto-cancel branches switch when flag not present in API response');
   });
@@ -301,6 +302,7 @@ test('on a repository with auto-cancellation', function (assert) {
   settingsPage.visit({ organization: 'killjoys', repo: 'living-a-feminist-life' });
 
   andThen(() => {
+    assert.ok(settingsPage.autoCancellationSection.exists, 'expected auto-cancellation section to exist');
     assert.notOk(settingsPage.autoCancelPullRequestBuilds.isActive, 'expected auto-cancel PRs to be present but disabled');
     assert.ok(settingsPage.autoCancelBranchBuilds.isActive, 'expected auto-cancel branches to be present and enabled');
   });

--- a/tests/pages/settings.js
+++ b/tests/pages/settings.js
@@ -22,7 +22,7 @@ export default PageObject.create({
   },
 
   autoCancelPushes: {
-    scope: 'section.settings-section .auto_cancel_pushes',
+    scope: 'section.settings-section .auto_cancel_pushes.switch',
 
     exists: isVisible(),
     isActive: hasClass('active'),

--- a/tests/pages/settings.js
+++ b/tests/pages/settings.js
@@ -16,6 +16,18 @@ export default PageObject.create({
 
   notification: text('p.flash-message'),
 
+  autoCancelPullRequestBuilds: {
+    scope: 'settings.settings-section .auto_cancel_pr_builds.switch',
+
+    exists: isVisible()
+  },
+
+  autoCancelBranchBuilds: {
+    scope: 'settings.settings-section .auto_cancel_branch_builds',
+
+    exists: isVisible(),
+  },
+
   buildOnlyWithTravisYml: {
     scope: 'section.settings-section .builds_only_with_travis_yml.switch',
 

--- a/tests/pages/settings.js
+++ b/tests/pages/settings.js
@@ -17,15 +17,17 @@ export default PageObject.create({
   notification: text('p.flash-message'),
 
   autoCancelPullRequestBuilds: {
-    scope: 'settings.settings-section .auto_cancel_pr_builds.switch',
+    scope: 'section.settings-section .auto_cancel_pr_builds.switch',
 
-    exists: isVisible()
+    exists: isVisible(),
+    isActive: hasClass('active')
   },
 
   autoCancelBranchBuilds: {
-    scope: 'settings.settings-section .auto_cancel_branch_builds',
+    scope: 'section.settings-section .auto_cancel_branch_builds',
 
     exists: isVisible(),
+    isActive: hasClass('active')
   },
 
   buildOnlyWithTravisYml: {

--- a/tests/pages/settings.js
+++ b/tests/pages/settings.js
@@ -16,6 +16,11 @@ export default PageObject.create({
 
   notification: text('p.flash-message'),
 
+  autoCancellationSection: {
+    scope: 'section.auto-cancellation',
+    exists: isVisible()
+  },
+
   autoCancelPullRequestBuilds: {
     scope: 'section.settings-section .auto_cancel_pr_builds.switch',
 

--- a/tests/pages/settings.js
+++ b/tests/pages/settings.js
@@ -20,14 +20,16 @@ export default PageObject.create({
     scope: 'section.settings-section .auto_cancel_pr_builds.switch',
 
     exists: isVisible(),
-    isActive: hasClass('active')
+    isActive: hasClass('active'),
+    toggle: clickable()
   },
 
   autoCancelBranchBuilds: {
     scope: 'section.settings-section .auto_cancel_branch_builds',
 
     exists: isVisible(),
-    isActive: hasClass('active')
+    isActive: hasClass('active'),
+    toggle: clickable()
   },
 
   buildOnlyWithTravisYml: {


### PR DESCRIPTION
If the `/repo/:repo/settings` response includes `auto_cancel_pr_builds` or `auto_cancel_branch_builds`, this will show switches for them. Labels TBD.