### PR TITLE
Rename auto-cancel settings

### DIFF
--- a/app/controllers/settings.js
+++ b/app/controllers/settings.js
@@ -24,12 +24,12 @@ export default Ember.Controller.extend({
   }),
 
   showAutoCancellationSwitches: Ember.computed(
-    'model.settings.auto_cancel_pushes',
-    'model.settings.auto_cancel_pull_requests', function () {
+    'model.settings.auto_cancel_waiting_pushes',
+    'model.settings.auto_cancel_waiting_pull_requests', function () {
       const settings = this.get('model.settings');
 
-      return settings.hasOwnProperty('auto_cancel_pull_requests') ||
-        settings.hasOwnProperty('auto_cancel_pushes');
+      return settings.hasOwnProperty('auto_cancel_waiting_pull_requests') ||
+        settings.hasOwnProperty('auto_cancel_waiting_pushes');
     }),
 
   actions: {

--- a/app/templates/settings.hbs
+++ b/app/templates/settings.hbs
@@ -19,8 +19,8 @@
       <p>Auto Cancellation allows you to only run builds for the latest commits in the queue. This setting can be applied to builds for Branch builds and Pull Request builds separately. Builds will only be canceled if they are waiting to run, allowing for any running jobs to finish.</p>
 
       <ul class="settings-list--columns">
-        <li>{{settings-switch active=model.settings.auto_cancel_pushes repo=repo description="Auto cancel pushes" key="auto_cancel_pushes"}}</li>
-        <li>{{settings-switch active=model.settings.auto_cancel_pull_requests repo=repo description="Auto cancel pull requests" key="auto_cancel_pull_requests"}}</li>
+        <li>{{settings-switch active=model.settings.auto_cancel_waiting_pushes repo=repo description="Auto cancel pushes" key="auto_cancel_waiting_pushes"}}</li>
+        <li>{{settings-switch active=model.settings.auto_cancel_waiting_pull_requests repo=repo description="Auto cancel pull requests" key="auto_cancel_waiting_pull_requests"}}</li>
       </ul>
     </section>
   {{/if}}

--- a/tests/acceptance/repo/settings-test.js
+++ b/tests/acceptance/repo/settings-test.js
@@ -125,8 +125,8 @@ test('view settings', function (assert) {
     assert.equal(settingsPage.sshKey.fingerprint, 'dd:cc:bb:aa');
 
     assert.notOk(settingsPage.autoCancellationSection.exists, 'expected auto-cancellation section to not exist');
-    assert.notOk(settingsPage.autoCancelPushes.exists, 'expected no auto-cancel pushes switch when flag not present in API response');
-    assert.notOk(settingsPage.autoCancelPullRequests.exists, 'expected no auto-cancel pull requests switch when flag not present in API response');
+    assert.notOk(settingsPage.autoCancelWaitingPushes.exists, 'expected no auto-cancel pushes switch when flag not present in API response');
+    assert.notOk(settingsPage.autoCancelWaitingPullRequests.exists, 'expected no auto-cancel pull requests switch when flag not present in API response');
   });
 });
 
@@ -296,15 +296,15 @@ test('delete and set SSH keys', function (assert) {
 });
 
 test('on a repository with auto-cancellation', function (assert) {
-  this.repository.createSetting({ name: 'auto_cancel_pushes', value: true });
-  this.repository.createSetting({ name: 'auto_cancel_pull_requests', value: false });
+  this.repository.createSetting({ name: 'auto_cancel_waiting_pushes', value: true });
+  this.repository.createSetting({ name: 'auto_cancel_waiting_pull_requests', value: false });
 
   settingsPage.visit({ organization: 'killjoys', repo: 'living-a-feminist-life' });
 
   andThen(() => {
     assert.ok(settingsPage.autoCancellationSection.exists, 'expected auto-cancellation section to exist');
-    assert.ok(settingsPage.autoCancelPushes.isActive, 'expected auto-cancel pushes to be present and enabled');
-    assert.notOk(settingsPage.autoCancelPullRequests.isActive, 'expected auto-cancel pull requests to be present but disabled');
+    assert.ok(settingsPage.autoCancelWaitingPushes.isActive, 'expected auto-cancel pushes to be present and enabled');
+    assert.notOk(settingsPage.autoCancelWaitingPullRequests.isActive, 'expected auto-cancel pull requests to be present but disabled');
   });
 
   const settingToRequestBody = {};
@@ -313,17 +313,17 @@ test('on a repository with auto-cancellation', function (assert) {
     settingToRequestBody[request.params.setting] = JSON.parse(request.requestBody);
   });
 
-  settingsPage.autoCancelPullRequests.toggle();
+  settingsPage.autoCancelWaitingPullRequests.toggle();
 
   andThen(() => {
-    assert.ok(settingsPage.autoCancelPullRequests.isActive, 'expected auto-cancel pull requests to be enabled');
-    assert.deepEqual(settingToRequestBody.auto_cancel_pull_requests, { 'user_setting.value': true });
+    assert.ok(settingsPage.autoCancelWaitingPullRequests.isActive, 'expected auto-cancel pull requests to be enabled');
+    assert.deepEqual(settingToRequestBody.auto_cancel_waiting_pull_requests, { 'user_setting.value': true });
   });
 
-  settingsPage.autoCancelPushes.toggle();
+  settingsPage.autoCancelWaitingPushes.toggle();
 
   andThen(() => {
-    assert.notOk(settingsPage.autoCancelPushes.isActive, 'expected auto-cancel pushes to be disabled');
-    assert.deepEqual(settingToRequestBody.auto_cancel_pushes, { 'user_setting.value': false });
+    assert.notOk(settingsPage.autoCancelWaitingPushes.isActive, 'expected auto-cancel pushes to be disabled');
+    assert.deepEqual(settingToRequestBody.auto_cancel_waiting_pushes, { 'user_setting.value': false });
   });
 });

--- a/tests/pages/settings.js
+++ b/tests/pages/settings.js
@@ -21,16 +21,16 @@ export default PageObject.create({
     exists: isVisible()
   },
 
-  autoCancelPushes: {
-    scope: 'section.settings-section .auto_cancel_pushes.switch',
+  autoCancelWaitingPushes: {
+    scope: 'section.settings-section .auto_cancel_waiting_pushes.switch',
 
     exists: isVisible(),
     isActive: hasClass('active'),
     toggle: clickable()
   },
 
-  autoCancelPullRequests: {
-    scope: 'section.settings-section .auto_cancel_pull_requests.switch',
+  autoCancelWaitingPullRequests: {
+    scope: 'section.settings-section .auto_cancel_waiting_pull_requests.switch',
 
     exists: isVisible(),
     isActive: hasClass('active'),


### PR DESCRIPTION
This future-proofs against a possible variant that will cancel
running jobs rather than waiting ones.
