### PR TITLE
Fix typo in component test

### DIFF
--- a/tests/unit/components/jobs-item-test.js
+++ b/tests/unit/components/jobs-item-test.js
@@ -25,7 +25,7 @@ test('it renders', function () {
   this.render();
   ok(component.$().hasClass('passed'), 'component should have a state class (passed)');
   equal(component.$('.job-number').text().trim(), '2', 'job number should be displayed');
-  equal(component.$('.job-lang').text().trim(), 'JDK: openjdk6 Ruby: 2.1.2', 'langauges list should be displayed');
+  equal(component.$('.job-lang').text().trim(), 'JDK: openjdk6 Ruby: 2.1.2', 'languages list should be displayed');
   equal(component.$('.job-env').text().trim(), 'TESTS=unit', 'env should be displayed');
   ok(component.$('.job-os').hasClass('linux'), 'OS class should be added for OS icon');
   return equal(component.$('.job-duration').text().trim(), '1 min 40 sec', 'duration should be displayed');


### PR DESCRIPTION
Hi all,

`langauges` → `languages` in `jobs-item-test.js`.

Cheers!