### PR TITLE
Fix typo in component test

### DIFF
--- a/tests/unit/components/jobs-item-test.js
+++ b/tests/unit/components/jobs-item-test.js
@@ -59,7 +59,7 @@ test('when env is not set, gemfile is displayed in the env section', function ()
     job: job
   });
   this.render();
-  equal(component.$('.job-lang .label-align').text().trim(), 'Ruby: 2.1.2', 'langauges list should be displayed');
+  equal(component.$('.job-lang .label-align').text().trim(), 'Ruby: 2.1.2', 'languages list should be displayed');
   return equal(component.$('.job-env .label-align').text().trim(), 'Gemfile: foo/Gemfile', 'env should be displayed');
 });
 


### PR DESCRIPTION
Hi all again,

found and fixed another `langauges` → `languages`.

Did a project find and yup, that was the last one.

Thanks always