### PR TITLE
Fix Ember CLI version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "broccoli-funnel": "^1.0.7",
     "broccoli-sass": "0.7.0",
     "ember-ajax": "2.4.1",
-    "ember-cli": "^2.8.0",
+    "ember-cli": "2.8.0",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-autoprefixer": "^0.6.0",
     "ember-cli-babel": "^5.1.6",


### PR DESCRIPTION
I had a CSS rendering crisis locally because of this; Ember CLI
version 2.9.1 matches this semantic versioning string. The
Ember CLI blueprints don’t use the fuzzy matching because of
how easily incompatibilities can creep in, as in this case.

We should be careful in future Ember CLI updates to follow
the blueprint update suggestion.

Thanks to @mixonic for the Yarn reference that helped me
track this down much faster than my painstaking `npm ls`
diff technique was allowing for.