### PR TITLE
Don't display title if there is no build number

### DIFF
--- a/app/components/build-tile.js
+++ b/app/components/build-tile.js
@@ -9,6 +9,10 @@ export default Ember.Component.extend({
     let num, state;
     num = this.get('build.number');
     state = this.get('build.state');
-    return `Build #${num} ${state}`;
+    if (num) {
+      return `Build #${num} ${state}`;
+    } else {
+      return '';
+    }
   })
 });


### PR DESCRIPTION
There is a bug in the build tiles that makes the tooltip display "Build #undefined undefined". 
![screen shot 2016-11-03 at 3 50 37 pm](https://cloud.githubusercontent.com/assets/6986171/19980562/4ae81b4a-a1dd-11e6-98ac-db60658fd1a4.png)
