### PR TITLE
Disable Sentry for beta/canary deployments

### DIFF
--- a/config/deployment/deploy-test-master.sh
+++ b/config/deployment/deploy-test-master.sh
@@ -1,4 +1,5 @@
 export CLEANED_BRANCH_SUBDOMAIN=ember-$EMBER_VERSION
+export DISABLE_SENTRY=true
 
 ember deploy org-$EMBER_VERSION --activate --verbose
 TRAVIS_PRO=true ember deploy com-$EMBER_VERSION --activate --verbose

--- a/config/environment.js
+++ b/config/environment.js
@@ -125,9 +125,15 @@ module.exports = function (environment) {
       enabled: false
     };
 
-    ENV.sentry = {
-      dsn: sentryDSN
-    };
+    if (process.env.DISABLE_SENTRY) {
+      ENV.sentry = {
+        development: true
+      }
+    } else {
+      ENV.sentry = {
+        dsn: sentryDSN
+      };
+    }
 
     ENV.statusPageStatusUrl = statusPageStatusUrl;
   }


### PR DESCRIPTION
Sentry swallows all errors, which makes debugging more difficult.
