### PR TITLE
Fix Pusher errors by pre-authorizing private job channels

### DIFF
--- a/app/models/job.js
+++ b/app/models/job.js
@@ -1,4 +1,5 @@
-/* global moment, Travis */
+/* global moment, Travis, Pusher */
+
 import { compact } from 'travis/utils/helpers';
 import Ember from 'ember';
 import Model from 'ember-data/model';
@@ -140,8 +141,14 @@ export default Model.extend(DurationCalculations, {
       return;
     }
     this.set('subscribed', true);
-    if (Travis.pusher) {
-      return Travis.pusher.subscribe('job-' + (this.get('id')));
+
+    if (Travis.pusher && Travis.pusher.ajaxService) {
+      return Travis.pusher.ajaxService.post(Pusher.channel_auth_endpoint, {
+        socket_id: Travis.pusher.pusherSocketId,
+        channels: ['private-job' + this.get('id')]
+      }).then(() => {
+        return Travis.pusher.subscribe('job-' + (this.get('id')));
+      });
     }
   },
 

--- a/app/models/job.js
+++ b/app/models/job.js
@@ -140,17 +140,27 @@ export default Model.extend(DurationCalculations, {
     if (this.get('subscribed')) {
       return;
     }
+
     this.set('subscribed', true);
 
-    if (Travis.pusher && Travis.pusher.ajaxService) {
-      return Travis.pusher.ajaxService.post(Pusher.channel_auth_endpoint, {
-        socket_id: Travis.pusher.pusherSocketId,
-        channels: ['private-job' + this.get('id')]
-      }).then(() => {
-        return Travis.pusher.subscribe('job-' + (this.get('id')));
-      });
+    if (this.get('features.proVersion')) {
+      if (Travis.pusher && Travis.pusher.ajaxService) {
+        return Travis.pusher.ajaxService.post(Pusher.channel_auth_endpoint, {
+          socket_id: Travis.pusher.pusherSocketId,
+          channels: ['private-job-' + this.get('id')]
+        }).then(() => {
+          return Travis.pusher.subscribe(this.get('channelName'));
+        });
+      }
+    } else {
+      return Travis.pusher.subscribe(this.get('channelName'));
     }
   },
+
+  channelName: Ember.computed('features.proVersion', 'id', function () {
+    const prefix = this.get('features.proVersion') ? 'private-job' : 'job';
+    return `${prefix}-${this.get('id')}`;
+  }),
 
   unsubscribe() {
     if (!this.get('subscribed')) {

--- a/app/utils/pusher.js
+++ b/app/utils/pusher.js
@@ -170,6 +170,7 @@ if (ENV.featureFlags['pro-version']) {
   Pusher.authorizers.bulk_ajax = function (socketId, _callback) {
     var channels, name, names;
     channels = Travis.pusher.pusher.channels;
+    Travis.pusher.pusherSocketId = socketId;
     channels.callbacks = channels.callbacks || [];
     name = this.channel.name;
     names = Object.keys(channels.channels);


### PR DESCRIPTION
Typically, the pusher.js client authorizes requests by hitting a user-defined endpoint,
which tells pusher whether to allow a user to connect. In our case, we've exposed an auth endpoint
at `/auth/push`. When the app boots, we make a single request with all the channels we receive from our `/auth` endpoint, authenticating them so that the client can connect to Pusher successfully.

Unfortunately, when we attempted to subscribe a to a private job channel, we would often (but not always) receive an auth error. 

This change hits our /auth/pusher endpoint with a single job channel to
authorize it before making the subscription call to Pusher.  Now that the subscribe call is
guaranteed to happen after the auth call has succeeded, we shouldn't see this error anymore.

I'm not super pleased about the implementation, but wasn't sure of a
better way to get at the socketId (normally simply yielded as an
argument to the `bulk_ajax` transport that Pusher calls internally) than
by setting it on the global `Travis.pusher`.