### PR TITLE
Add step to save Redis URLs from Heroku

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,7 @@ cache:
     - bower_components
 
 before_install:
-  - mkdir travis-phantomjs
-  - wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
-  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -C $PWD/travis-phantomjs
-  - export PATH=$PWD/travis-phantomjs:$PATH
+  - phantomjs -v
   - "npm config set spin false"
   - "npm install -g npm@^2"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ cache:
     - bower_components
 
 before_install:
-  - phantomjs -v
   - "npm config set spin false"
   - "npm install -g npm@^2"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
   fast_finish: true
 
 sudo: false
+dist: trusty
 
 cache:
   directories:

--- a/config/deployment/deploy-pull-request.sh
+++ b/config/deployment/deploy-pull-request.sh
@@ -1,5 +1,7 @@
 export CLEANED_BRANCH_SUBDOMAIN=`echo $TRAVIS_PULL_REQUEST_BRANCH | tr '.' '-' | tr '[:upper:]' '[:lower:]'`
 
+./config/deployment/store-redis-urls.sh
+
 ember deploy org-production-pull-request --activate --verbose
 TLD=org ENVIRONMENT=production ./config/deployment/update-github-status.sh
 

--- a/config/deployment/deploy-test-master.sh
+++ b/config/deployment/deploy-test-master.sh
@@ -1,5 +1,7 @@
 export CLEANED_BRANCH_SUBDOMAIN=ember-$EMBER_VERSION
 export DISABLE_SENTRY=true
 
+./config/deployment/store-redis-urls.sh
+
 ember deploy org-$EMBER_VERSION --activate --verbose
 TRAVIS_PRO=true ember deploy com-$EMBER_VERSION --activate --verbose

--- a/config/deployment/store-redis-urls.sh
+++ b/config/deployment/store-redis-urls.sh
@@ -1,0 +1,2 @@
+export ORG_PRODUCTION_REDIS_URL=`heroku config:get REDIS_URL -a travis-web-production-next`
+export COM_PRODUCTION_REDIS_URL=`heroku config:get REDIS_URL -a travis-pro-web-production-next`

--- a/config/deployment/store-redis-urls.sh
+++ b/config/deployment/store-redis-urls.sh
@@ -1,5 +1,2 @@
 export ORG_PRODUCTION_REDIS_URL=`heroku config:get REDIS_URL -a travis-web-production-next`
 export COM_PRODUCTION_REDIS_URL=`heroku config:get REDIS_URL -a travis-pro-web-production-next`
-
-echo $ORG_PRODUCTION_REDIS_URL | cut -c1-8
-echo $COM_PRODUCTION_REDIS_URL | cut -c1-8

--- a/config/deployment/store-redis-urls.sh
+++ b/config/deployment/store-redis-urls.sh
@@ -1,2 +1,5 @@
 export ORG_PRODUCTION_REDIS_URL=`heroku config:get REDIS_URL -a travis-web-production-next`
 export COM_PRODUCTION_REDIS_URL=`heroku config:get REDIS_URL -a travis-pro-web-production-next`
+
+echo $ORG_PRODUCTION_REDIS_URL | cut -c1-8
+echo $COM_PRODUCTION_REDIS_URL | cut -c1-8

--- a/config/deployment/store-redis-urls.sh
+++ b/config/deployment/store-redis-urls.sh
@@ -1,3 +1,5 @@
+wget -O- https://toolbelt.heroku.com/install-ubuntu.sh | sh
+
 export ORG_PRODUCTION_REDIS_URL=`heroku config:get REDIS_URL -a travis-web-production-next`
 export COM_PRODUCTION_REDIS_URL=`heroku config:get REDIS_URL -a travis-pro-web-production-next`
 

--- a/config/deployment/store-redis-urls.sh
+++ b/config/deployment/store-redis-urls.sh
@@ -1,5 +1,3 @@
-wget -O- https://toolbelt.heroku.com/install-ubuntu.sh | sh
-
 export ORG_PRODUCTION_REDIS_URL=`heroku config:get REDIS_URL -a travis-web-production-next`
 export COM_PRODUCTION_REDIS_URL=`heroku config:get REDIS_URL -a travis-pro-web-production-next`
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ember-cli-babel": "^5.1.6",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-deploy": "0.6.4",
-    "ember-cli-deploy-lightning-pack": "0.6.4",
+    "ember-cli-deploy-lightning-pack": "0.6.8",
     "ember-cli-deprecation-workflow": "0.2.3",
     "ember-cli-document-title": "0.3.3",
     "ember-cli-eslint": "3.0.0",


### PR DESCRIPTION
The Heroku Redis URLs for the PR/beta/canary deployments change
periodically, which breaks things until I manually update the Redis URL
environment variables for the Travis environment. This obtains them
at build time from Heroku instead.