### PR TITLE
Rename link to button in test

### DIFF
--- a/tests/unit/components/job-repo-actions-test.js
+++ b/tests/unit/components/job-repo-actions-test.js
@@ -29,7 +29,7 @@ test('it shows restart button if canRestart is true', function (assert) {
     canRestart: true
   });
   this.render();
-  assert.ok(component.$('button[title="Restart job"]').length, 'restart link should be visible');
+  assert.ok(component.$('button[title="Restart job"]').length, 'restart button should be visible');
 });
 
 test('user can cancel if she has pull permissions to a repo and job is cancelable', function (assert) {


### PR DESCRIPTION
Hi all,

I think one test had a `link` left over, so I updated that to `button`.

Thanks!