### PR TITLE
Adding some osx image retirement banners

### DIFF
--- a/app/models/job.js
+++ b/app/models/job.js
@@ -207,19 +207,17 @@ export default Model.extend(DurationCalculations, {
   }),
 
   isRetiredMacImageXcode6: Ember.computed('queue', 'config.osx_image', function () {
-    const isMacStadium6 = this.get('queue') === 'builds.macstadium6');
+    const isMacStadium6 = this.get('queue') === 'builds.macstadium6';
     const retiredImages = ['beta-xcode6.1', 'beta-xcode6.2', 'beta-xcode6.3'];
 
     return isMacStadium6 && retiredImages.includes(this.get('config.osx_image'));
-    }
   }),
 
   isRetiredMacImageXcode7: Ember.computed('queue', 'config.osx_image', function () {
-    const isMacStadium6 = this.get('queue') === 'builds.macstadium6');
+    const isMacStadium6 = this.get('queue') === 'builds.macstadium6';
     const retiredImages = ['xcode7', 'xcode7.1', 'xcode7.2'];
 
     return isMacStadium6 && retiredImages.includes(this.get('config.osx_image'));
-    }
   }),
 
   displayGceNotice: Ember.computed('queue', 'config.dist', function () {

--- a/app/models/job.js
+++ b/app/models/job.js
@@ -200,7 +200,27 @@ export default Model.extend(DurationCalculations, {
     }
   }),
 
-  isTrustySudoFalse: Ember.computed.equal('queue', 'builds.ec2'),
+  isTrustySudoFalse: Ember.computed('queue', function () {
+    if (this.get('queue') === 'builds.ec2') {
+      return true;
+    }
+  }),
+
+  isRetiredMacImageXcode6: Ember.computed('queue', 'config.osx_image', function () {
+    const isMacStadium6 = this.get('queue') === 'builds.macstadium6');
+    const retiredImages = ['beta-xcode6.1', 'beta-xcode6.2', 'beta-xcode6.3'];
+
+    return isMacStadium6 && retiredImages.includes(this.get('config.osx_image'));
+    }
+  }),
+
+  isRetiredMacImageXcode7: Ember.computed('queue', 'config.osx_image', function () {
+    const isMacStadium6 = this.get('queue') === 'builds.macstadium6');
+    const retiredImages = ['xcode7', 'xcode7.1', 'xcode7.2'];
+
+    return isMacStadium6 && retiredImages.includes(this.get('config.osx_image'));
+    }
+  }),
 
   displayGceNotice: Ember.computed('queue', 'config.dist', function () {
     if (this.get('queue') === 'builds.gce' && this.get('config.dist') === 'precise') {

--- a/app/models/job.js
+++ b/app/models/job.js
@@ -200,11 +200,7 @@ export default Model.extend(DurationCalculations, {
     }
   }),
 
-  isTrustySudoFalse: Ember.computed('queue', function () {
-    if (this.get('queue') === 'builds.ec2') {
-      return true;
-    }
-  }),
+  isTrustySudoFalse: Ember.computed.equal('queue', 'builds.ec2'),
 
   isRetiredMacImageXcode6: Ember.computed('queue', 'config.osx_image', function () {
     const isMacStadium6 = this.get('queue') === 'builds.macstadium6';

--- a/app/templates/components/log-content.hbs
+++ b/app/templates/components/log-content.hbs
@@ -19,6 +19,18 @@
           This job {{#if job.isFinished}}ran{{else}}is running{{/if}} on our container-based trusty beta.
           Please read <a href="http://blog.travis-ci.com/2016-11-08-trusty-container-public-beta/?utm_source=trusty-container-based-beta-notice&utm_medium=banner&utm_campaign=trusty-container-based-beta" title="Trusty container-based beta">our blog post about the public beta</a>.</span></p>
       {{/if}}
+      {{#if job.isRetiredMacImageXcode6}}
+        <p class="notice"><span class="icon-flag"></span>
+        <span class="label-align">
+          This job is using an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>. After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-6.4">Xcode 6.4 image</a></strong>.
+        </span>
+      {{/if}}
+      {{#if job.isRetiredMacImageXcode7}}
+        <p class="notice"><span class="icon-flag"></span>
+        <span class="label-align">
+          This job is using an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>. After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-7.3.1">Xcode 7.3 image</a></strong>.
+        </span>
+        {{/if}}
     {{/if}}
   {{/unless}}
 

--- a/app/templates/components/log-content.hbs
+++ b/app/templates/components/log-content.hbs
@@ -6,10 +6,10 @@
     {{#if auth.signedIn}}
       {{#if job.isLegacyInfrastructure}}
         {{#if job.isFinished}}
-          <p class="notice"><span class="icon-flag"></span>
+          <p class="notice-banner--yellow"><span class="icon-flag"></span>
           <span class="label-align">This job ran on our legacy infrastructure. Please read <a href="http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade" title="Migrating from legacy">our docs on how to upgrade</a>.</span></p>
         {{else}}
-          <p class="notice"><span class="icon-flag"></span>
+          <p class="notice-banner--yellow"><span class="icon-flag"></span>
           <span class="label-align">This job is running on our legacy infrastructure. Please read <a href="http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade" title="Migrating from legacy">our docs on how to upgrade</a>.</span></p>
         {{/if}}
       {{/if}}
@@ -20,12 +20,12 @@
           Please read <a href="http://blog.travis-ci.com/2016-11-08-trusty-container-public-beta/?utm_source=trusty-container-based-beta-notice&utm_medium=banner&utm_campaign=trusty-container-based-beta" title="Trusty container-based beta">our blog post about the public beta</a>.</span></p>
       {{/if}}
       {{#if job.isRetiredMacImageXcode6}}
-        <p class="notice"><span class="icon-flag"></span>
+        <p class="notice-banner--yellow"><span class="icon-flag"></span>
         <span class="label-align">
           This job is using an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>. After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-6.4">Xcode 6.4 image</a></strong>.</span></p>
       {{/if}}
       {{#if job.isRetiredMacImageXcode7}}
-        <p class="notice"><span class="icon-flag"></span>
+        <p class="notice-banner--yellow"><span class="icon-flag"></span>
         <span class="label-align">
           This job is using an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>. After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-7.3.1">Xcode 7.3 image</a></strong>.</span></p>
         {{/if}}

--- a/app/templates/components/log-content.hbs
+++ b/app/templates/components/log-content.hbs
@@ -22,14 +22,12 @@
       {{#if job.isRetiredMacImageXcode6}}
         <p class="notice"><span class="icon-flag"></span>
         <span class="label-align">
-          This job is using an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>. After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-6.4">Xcode 6.4 image</a></strong>.
-        </span>
+          This job is using an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>. After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-6.4">Xcode 6.4 image</a></strong>.</span></p>
       {{/if}}
       {{#if job.isRetiredMacImageXcode7}}
         <p class="notice"><span class="icon-flag"></span>
         <span class="label-align">
-          This job is using an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>. After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-7.3.1">Xcode 7.3 image</a></strong>.
-        </span>
+          This job is using an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>. After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-7.3.1">Xcode 7.3 image</a></strong>.</span></p>
         {{/if}}
     {{/if}}
   {{/unless}}


### PR DESCRIPTION
We want to display a banner for the following `osx_image` images:

### Xcode 6.x
- `beta-xcode6.1`
- `beta-xcode6.2`
- `beta-xcode6.3`

**Banner text:** This job is using an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>. After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-6.4">Xcode 6.4 image</a></strong>.

### Xcode 7.x
- `xcode7`
- `xcode7.1`
- `xcode7.2`

**Banner text:** This job is using an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>. After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-7.3.1">Xcode 7.3 image</a></strong>