### PR TITLE
Upgrade raven.js (Sentry client) to 3.8.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "lodash": "~4.11.2",
     "Faker": "~3.1.0",
     "ceibo": "2.0.0",
-    "raven-js": "~2.1",
+    "raven-js": "3.8.1",
     "mousetrap": "~1.5.2",
     "prism": "^1.5.1",
     "js-emoji": "~3.0.2",


### PR DESCRIPTION
We were previously on the 2.x series. I tested this locally by triggering an error locally in production mode.
The error was successfully logged.