### PR TITLE
Move infrastructure notice above log/config tabs

### DIFF
--- a/app/components/job-infrastructure-notification.js
+++ b/app/components/job-infrastructure-notification.js
@@ -4,6 +4,14 @@ export default Ember.Component.extend({
   queue: Ember.computed.alias('job.queue'),
   config: Ember.computed.alias('job.config'),
 
+  conjugatedRun: Ember.computed('job.isFinished', function () {
+    if (this.get('job.isFinished')) {
+      return 'ran';
+    } else {
+      return 'is running';
+    }
+  }),
+
   isLegacyInfrastructure: Ember.computed('queue', function () {
     if (this.get('queue') === 'builds.linux') {
       return true;

--- a/app/components/job-infrastructure-notification.js
+++ b/app/components/job-infrastructure-notification.js
@@ -1,0 +1,28 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  queue: Ember.computed.alias('job.queue'),
+  config: Ember.computed.alias('job.config'),
+
+  isLegacyInfrastructure: Ember.computed('queue', function () {
+    if (this.get('queue') === 'builds.linux') {
+      return true;
+    }
+  }),
+
+  isTrustySudoFalse: Ember.computed.equal('queue', 'builds.ec2'),
+
+  isRetiredMacImageXcode6: Ember.computed('queue', 'config.osx_image', function () {
+    const isMacStadium6 = this.get('queue') === 'builds.macstadium6';
+    const retiredImages = ['beta-xcode6.1', 'beta-xcode6.2', 'beta-xcode6.3'];
+
+    return isMacStadium6 && retiredImages.includes(this.get('config.osx_image'));
+  }),
+
+  isRetiredMacImageXcode7: Ember.computed('queue', 'config.osx_image', function () {
+    const isMacStadium6 = this.get('queue') === 'builds.macstadium6';
+    const retiredImages = ['xcode7', 'xcode7.1', 'xcode7.2'];
+
+    return isMacStadium6 && retiredImages.includes(this.get('config.osx_image'));
+  })
+});

--- a/app/components/job-infrastructure-notification.js
+++ b/app/components/job-infrastructure-notification.js
@@ -12,11 +12,7 @@ export default Ember.Component.extend({
     }
   }),
 
-  isLegacyInfrastructure: Ember.computed('queue', function () {
-    if (this.get('queue') === 'builds.linux') {
-      return true;
-    }
-  }),
+  isLegacyInfrastructure: Ember.computed.equal('queue', 'builds.linux'),
 
   isTrustySudoFalse: Ember.computed.equal('queue', 'builds.ec2'),
   isMacStadium6: Ember.computed.equal('queue', 'builds.macstadium6'),

--- a/app/components/job-infrastructure-notification.js
+++ b/app/components/job-infrastructure-notification.js
@@ -19,18 +19,17 @@ export default Ember.Component.extend({
   }),
 
   isTrustySudoFalse: Ember.computed.equal('queue', 'builds.ec2'),
+  isMacStadium6: Ember.computed.equal('queue', 'builds.macstadium6'),
 
-  isRetiredMacImageXcode6: Ember.computed('queue', 'jobConfig.osx_image', function () {
-    const isMacStadium6 = this.get('queue') === 'builds.macstadium6';
+  macOSImage: Ember.computed.alias('jobConfig.osx_image'),
+
+  isRetiredMacImageXcode6: Ember.computed('queue', 'macOSImage', function () {
     const retiredImages = ['beta-xcode6.1', 'beta-xcode6.2', 'beta-xcode6.3'];
-
-    return isMacStadium6 && retiredImages.includes(this.get('jobConfig.osx_image'));
+    return this.get('isMacStadium6') && retiredImages.includes(this.get('macOSImage'));
   }),
 
-  isRetiredMacImageXcode7: Ember.computed('queue', 'jobConfig.osx_image', function () {
-    const isMacStadium6 = this.get('queue') === 'builds.macstadium6';
+  isRetiredMacImageXcode7: Ember.computed('queue', 'macOSImage', function () {
     const retiredImages = ['xcode7', 'xcode7.1', 'xcode7.2'];
-
-    return isMacStadium6 && retiredImages.includes(this.get('jobConfig.osx_image'));
+    return this.get('isMacStadium6') && retiredImages.includes(this.get('macOSImage'));
   })
 });

--- a/app/components/job-infrastructure-notification.js
+++ b/app/components/job-infrastructure-notification.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
   queue: Ember.computed.alias('job.queue'),
-  config: Ember.computed.alias('job.config'),
+  jobConfig: Ember.computed.alias('job.config'),
 
   conjugatedRun: Ember.computed('job.isFinished', function () {
     if (this.get('job.isFinished')) {
@@ -20,17 +20,17 @@ export default Ember.Component.extend({
 
   isTrustySudoFalse: Ember.computed.equal('queue', 'builds.ec2'),
 
-  isRetiredMacImageXcode6: Ember.computed('queue', 'config.osx_image', function () {
+  isRetiredMacImageXcode6: Ember.computed('queue', 'jobConfig.osx_image', function () {
     const isMacStadium6 = this.get('queue') === 'builds.macstadium6';
     const retiredImages = ['beta-xcode6.1', 'beta-xcode6.2', 'beta-xcode6.3'];
 
-    return isMacStadium6 && retiredImages.includes(this.get('config.osx_image'));
+    return isMacStadium6 && retiredImages.includes(this.get('jobConfig.osx_image'));
   }),
 
-  isRetiredMacImageXcode7: Ember.computed('queue', 'config.osx_image', function () {
+  isRetiredMacImageXcode7: Ember.computed('queue', 'jobConfig.osx_image', function () {
     const isMacStadium6 = this.get('queue') === 'builds.macstadium6';
     const retiredImages = ['xcode7', 'xcode7.1', 'xcode7.2'];
 
-    return isMacStadium6 && retiredImages.includes(this.get('config.osx_image'));
+    return isMacStadium6 && retiredImages.includes(this.get('jobConfig.osx_image'));
   })
 });

--- a/app/models/job.js
+++ b/app/models/job.js
@@ -214,13 +214,5 @@ export default Model.extend(DurationCalculations, {
     const retiredImages = ['xcode7', 'xcode7.1', 'xcode7.2'];
 
     return isMacStadium6 && retiredImages.includes(this.get('config.osx_image'));
-  }),
-
-  displayGceNotice: Ember.computed('queue', 'config.dist', function () {
-    if (this.get('queue') === 'builds.gce' && this.get('config.dist') === 'precise') {
-      return true;
-    } else {
-      return false;
-    }
   })
 });

--- a/app/models/job.js
+++ b/app/models/job.js
@@ -192,27 +192,5 @@ export default Model.extend(DurationCalculations, {
 
   slug: Ember.computed(function () {
     return (this.get('repo.slug')) + ' #' + (this.get('number'));
-  }),
-
-  isLegacyInfrastructure: Ember.computed('queue', function () {
-    if (this.get('queue') === 'builds.linux') {
-      return true;
-    }
-  }),
-
-  isTrustySudoFalse: Ember.computed.equal('queue', 'builds.ec2'),
-
-  isRetiredMacImageXcode6: Ember.computed('queue', 'config.osx_image', function () {
-    const isMacStadium6 = this.get('queue') === 'builds.macstadium6';
-    const retiredImages = ['beta-xcode6.1', 'beta-xcode6.2', 'beta-xcode6.3'];
-
-    return isMacStadium6 && retiredImages.includes(this.get('config.osx_image'));
-  }),
-
-  isRetiredMacImageXcode7: Ember.computed('queue', 'config.osx_image', function () {
-    const isMacStadium6 = this.get('queue') === 'builds.macstadium6';
-    const retiredImages = ['xcode7', 'xcode7.1', 'xcode7.2'];
-
-    return isMacStadium6 && retiredImages.includes(this.get('config.osx_image'));
   })
 });

--- a/app/templates/build.hbs
+++ b/app/templates/build.hbs
@@ -15,6 +15,7 @@
       {{/if}}
     {{else}}
 
+      {{job-infrastructure-notification job=build.jobs.firstObject}}
       {{job-tabs job=build.jobs.firstObject repo=repo}}
 
     {{/if}}

--- a/app/templates/components/job-infrastructure-notification.hbs
+++ b/app/templates/components/job-infrastructure-notification.hbs
@@ -1,0 +1,27 @@
+{{#if auth.signedIn}}
+  {{#if job.isLegacyInfrastructure}}
+    {{#if job.isFinished}}
+      <p class="notice-banner--yellow"><span class="icon-flag"></span>
+      <span class="label-align">This job ran on our legacy infrastructure. Please read <a href="http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade" title="Migrating from legacy">our docs on how to upgrade</a>.</span></p>
+    {{else}}
+      <p class="notice-banner--yellow"><span class="icon-flag"></span>
+      <span class="label-align">This job is running on our legacy infrastructure. Please read <a href="http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade" title="Migrating from legacy">our docs on how to upgrade</a>.</span></p>
+    {{/if}}
+  {{/if}}
+  {{#if job.isTrustySudoFalse}}
+    <p class="notice-banner--yellow"><span class="icon-flag"></span>
+    <span class="label-align">
+      This job {{#if job.isFinished}}ran{{else}}is running{{/if}} on our container-based trusty beta.
+      Please read <a href="http://blog.travis-ci.com/2016-11-08-trusty-container-public-beta/?utm_source=trusty-container-based-beta-notice&utm_medium=banner&utm_campaign=trusty-container-based-beta" title="Trusty container-based beta">our blog post about the public beta</a>.</span></p>
+  {{/if}}
+  {{#if job.isRetiredMacImageXcode6}}
+    <p class="notice-banner--yellow"><span class="icon-flag"></span>
+    <span class="label-align">
+      This job is using an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>. After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-6.4">Xcode 6.4 image</a></strong>.</span></p>
+  {{/if}}
+  {{#if job.isRetiredMacImageXcode7}}
+    <p class="notice-banner--yellow"><span class="icon-flag"></span>
+    <span class="label-align">
+      This job is using an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>. After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-7.3.1">Xcode 7.3 image</a></strong>.</span></p>
+    {{/if}}
+{{/if}}

--- a/app/templates/components/job-infrastructure-notification.hbs
+++ b/app/templates/components/job-infrastructure-notification.hbs
@@ -1,29 +1,24 @@
 {{#if auth.signedIn}}
   {{#if isLegacyInfrastructure}}
-    {{#if job.isFinished}}
-      {{#notice-banner}}
-        This job ran on our legacy infrastructure. Please read <a href="http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade" title="Migrating from legacy">our docs on how to upgrade</a>.
-      {{/notice-banner}}
-    {{else}}
-      {{#notice-banner}}
-        This job is running on our legacy infrastructure. Please read <a href="http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade" title="Migrating from legacy">our docs on how to upgrade</a>.
-      {{/notice-banner}}
+    {{#notice-banner}}
+      This job {{conjugatedRun}} on our legacy infrastructure. Please read <a href="http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade" title="Migrating from legacy">our docs on how to upgrade</a>.
+    {{/notice-banner}}
     {{/if}}
   {{/if}}
   {{#if isTrustySudoFalse}}
     {{#notice-banner}}
-      This job {{#if job.isFinished}}ran{{else}}is running{{/if}} on our container-based trusty beta.
+      This job {{conjugatedRun}} on our container-based trusty beta.
       Please read <a href="http://blog.travis-ci.com/2016-11-08-trusty-container-public-beta/?utm_source=trusty-container-based-beta-notice&utm_medium=banner&utm_campaign=trusty-container-based-beta" title="Trusty container-based beta">our blog post about the public beta</a>.
     {{/notice-banner}}
   {{/if}}
   {{#if isRetiredMacImageXcode6}}
     {{#notice-banner}}
-      This job is using an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>. After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-6.4">Xcode 6.4 image</a></strong>.
+      This job {{conjugatedRun}} on an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>. After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-6.4">Xcode 6.4 image</a></strong>.
     {{/notice-banner}}
   {{/if}}
   {{#if isRetiredMacImageXcode7}}
     {{#notice-banner}}
-      This job is using an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>. After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-7.3.1">Xcode 7.3 image</a></strong>.
+      This job {{conjugatedRun}} on an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>. After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-7.3.1">Xcode 7.3 image</a></strong>.
     {{/notice-banner}}
   {{/if}}
 {{/if}}

--- a/app/templates/components/job-infrastructure-notification.hbs
+++ b/app/templates/components/job-infrastructure-notification.hbs
@@ -1,7 +1,8 @@
 {{#if auth.signedIn}}
   {{#if isLegacyInfrastructure}}
     {{#notice-banner}}
-      This job {{conjugatedRun}} on our legacy infrastructure. Please read <a href="http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade" title="Migrating from legacy">our docs on how to upgrade</a>.
+      This job {{conjugatedRun}} on our legacy infrastructure.
+      Please read <a href="http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade" title="Migrating from legacy">our docs on how to upgrade</a>.
     {{/notice-banner}}
     {{/if}}
   {{/if}}
@@ -13,12 +14,14 @@
   {{/if}}
   {{#if isRetiredMacImageXcode6}}
     {{#notice-banner}}
-      This job {{conjugatedRun}} on an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>. After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-6.4">Xcode 6.4 image</a></strong>.
+      This job {{conjugatedRun}} on an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>.
+      After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-6.4">Xcode 6.4 image</a></strong>.
     {{/notice-banner}}
   {{/if}}
   {{#if isRetiredMacImageXcode7}}
     {{#notice-banner}}
-      This job {{conjugatedRun}} on an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>. After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-7.3.1">Xcode 7.3 image</a></strong>.
+      This job {{conjugatedRun}} on an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>.
+      After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-7.3.1">Xcode 7.3 image</a></strong>.
     {{/notice-banner}}
   {{/if}}
 {{/if}}

--- a/app/templates/components/job-infrastructure-notification.hbs
+++ b/app/templates/components/job-infrastructure-notification.hbs
@@ -1,26 +1,28 @@
-{{#if auth.signedIn}}
-  {{#if isLegacyInfrastructure}}
-    {{#notice-banner}}
-      This job {{conjugatedRun}} on our legacy infrastructure.
-      Please read <a href="http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade" title="Migrating from legacy">our docs on how to upgrade</a>.
-    {{/notice-banner}}
+{{#unless config.enterprise}}
+  {{#if auth.signedIn}}
+    {{#if isLegacyInfrastructure}}
+      {{#notice-banner}}
+        This job {{conjugatedRun}} on our legacy infrastructure.
+        Please read <a href="http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade" title="Migrating from legacy">our docs on how to upgrade</a>.
+      {{/notice-banner}}
+    {{/if}}
+    {{#if isTrustySudoFalse}}
+      {{#notice-banner}}
+        This job {{conjugatedRun}} on our container-based trusty beta.
+        Please read <a href="http://blog.travis-ci.com/2016-11-08-trusty-container-public-beta/?utm_source=trusty-container-based-beta-notice&utm_medium=banner&utm_campaign=trusty-container-based-beta" title="Trusty container-based beta">our blog post about the public beta</a>.
+      {{/notice-banner}}
+    {{/if}}
+    {{#if isRetiredMacImageXcode6}}
+      {{#notice-banner}}
+        This job {{conjugatedRun}} on an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>.
+        After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-6.4">Xcode 6.4 image</a></strong>.
+      {{/notice-banner}}
+    {{/if}}
+    {{#if isRetiredMacImageXcode7}}
+      {{#notice-banner}}
+        This job {{conjugatedRun}} on an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>.
+        After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-7.3.1">Xcode 7.3 image</a></strong>.
+      {{/notice-banner}}
+    {{/if}}
   {{/if}}
-  {{#if isTrustySudoFalse}}
-    {{#notice-banner}}
-      This job {{conjugatedRun}} on our container-based trusty beta.
-      Please read <a href="http://blog.travis-ci.com/2016-11-08-trusty-container-public-beta/?utm_source=trusty-container-based-beta-notice&utm_medium=banner&utm_campaign=trusty-container-based-beta" title="Trusty container-based beta">our blog post about the public beta</a>.
-    {{/notice-banner}}
-  {{/if}}
-  {{#if isRetiredMacImageXcode6}}
-    {{#notice-banner}}
-      This job {{conjugatedRun}} on an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>.
-      After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-6.4">Xcode 6.4 image</a></strong>.
-    {{/notice-banner}}
-  {{/if}}
-  {{#if isRetiredMacImageXcode7}}
-    {{#notice-banner}}
-      This job {{conjugatedRun}} on an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>.
-      After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-7.3.1">Xcode 7.3 image</a></strong>.
-    {{/notice-banner}}
-  {{/if}}
-{{/if}}
+{{/unless}}

--- a/app/templates/components/job-infrastructure-notification.hbs
+++ b/app/templates/components/job-infrastructure-notification.hbs
@@ -1,5 +1,5 @@
 {{#if auth.signedIn}}
-  {{#if job.isLegacyInfrastructure}}
+  {{#if isLegacyInfrastructure}}
     {{#if job.isFinished}}
       <p class="notice-banner--yellow"><span class="icon-flag"></span>
       <span class="label-align">This job ran on our legacy infrastructure. Please read <a href="http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade" title="Migrating from legacy">our docs on how to upgrade</a>.</span></p>
@@ -8,18 +8,18 @@
       <span class="label-align">This job is running on our legacy infrastructure. Please read <a href="http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade" title="Migrating from legacy">our docs on how to upgrade</a>.</span></p>
     {{/if}}
   {{/if}}
-  {{#if job.isTrustySudoFalse}}
+  {{#if isTrustySudoFalse}}
     <p class="notice-banner--yellow"><span class="icon-flag"></span>
     <span class="label-align">
       This job {{#if job.isFinished}}ran{{else}}is running{{/if}} on our container-based trusty beta.
       Please read <a href="http://blog.travis-ci.com/2016-11-08-trusty-container-public-beta/?utm_source=trusty-container-based-beta-notice&utm_medium=banner&utm_campaign=trusty-container-based-beta" title="Trusty container-based beta">our blog post about the public beta</a>.</span></p>
   {{/if}}
-  {{#if job.isRetiredMacImageXcode6}}
+  {{#if isRetiredMacImageXcode6}}
     <p class="notice-banner--yellow"><span class="icon-flag"></span>
     <span class="label-align">
       This job is using an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>. After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-6.4">Xcode 6.4 image</a></strong>.</span></p>
   {{/if}}
-  {{#if job.isRetiredMacImageXcode7}}
+  {{#if isRetiredMacImageXcode7}}
     <p class="notice-banner--yellow"><span class="icon-flag"></span>
     <span class="label-align">
       This job is using an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>. After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-7.3.1">Xcode 7.3 image</a></strong>.</span></p>

--- a/app/templates/components/job-infrastructure-notification.hbs
+++ b/app/templates/components/job-infrastructure-notification.hbs
@@ -1,27 +1,29 @@
 {{#if auth.signedIn}}
   {{#if isLegacyInfrastructure}}
     {{#if job.isFinished}}
-      <p class="notice-banner--yellow"><span class="icon-flag"></span>
-      <span class="label-align">This job ran on our legacy infrastructure. Please read <a href="http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade" title="Migrating from legacy">our docs on how to upgrade</a>.</span></p>
+      {{#notice-banner}}
+        This job ran on our legacy infrastructure. Please read <a href="http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade" title="Migrating from legacy">our docs on how to upgrade</a>.
+      {{/notice-banner}}
     {{else}}
-      <p class="notice-banner--yellow"><span class="icon-flag"></span>
-      <span class="label-align">This job is running on our legacy infrastructure. Please read <a href="http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade" title="Migrating from legacy">our docs on how to upgrade</a>.</span></p>
+      {{#notice-banner}}
+        This job is running on our legacy infrastructure. Please read <a href="http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade" title="Migrating from legacy">our docs on how to upgrade</a>.
+      {{/notice-banner}}
     {{/if}}
   {{/if}}
   {{#if isTrustySudoFalse}}
-    <p class="notice-banner--yellow"><span class="icon-flag"></span>
-    <span class="label-align">
+    {{#notice-banner}}
       This job {{#if job.isFinished}}ran{{else}}is running{{/if}} on our container-based trusty beta.
-      Please read <a href="http://blog.travis-ci.com/2016-11-08-trusty-container-public-beta/?utm_source=trusty-container-based-beta-notice&utm_medium=banner&utm_campaign=trusty-container-based-beta" title="Trusty container-based beta">our blog post about the public beta</a>.</span></p>
+      Please read <a href="http://blog.travis-ci.com/2016-11-08-trusty-container-public-beta/?utm_source=trusty-container-based-beta-notice&utm_medium=banner&utm_campaign=trusty-container-based-beta" title="Trusty container-based beta">our blog post about the public beta</a>.
+    {{/notice-banner}}
   {{/if}}
   {{#if isRetiredMacImageXcode6}}
-    <p class="notice-banner--yellow"><span class="icon-flag"></span>
-    <span class="label-align">
-      This job is using an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>. After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-6.4">Xcode 6.4 image</a></strong>.</span></p>
+    {{#notice-banner}}
+      This job is using an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>. After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-6.4">Xcode 6.4 image</a></strong>.
+    {{/notice-banner}}
   {{/if}}
   {{#if isRetiredMacImageXcode7}}
-    <p class="notice-banner--yellow"><span class="icon-flag"></span>
-    <span class="label-align">
-      This job is using an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>. After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-7.3.1">Xcode 7.3 image</a></strong>.</span></p>
-    {{/if}}
+    {{#notice-banner}}
+      This job is using an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>. After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-7.3.1">Xcode 7.3 image</a></strong>.
+    {{/notice-banner}}
+  {{/if}}
 {{/if}}

--- a/app/templates/components/job-infrastructure-notification.hbs
+++ b/app/templates/components/job-infrastructure-notification.hbs
@@ -4,7 +4,6 @@
       This job {{conjugatedRun}} on our legacy infrastructure.
       Please read <a href="http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade" title="Migrating from legacy">our docs on how to upgrade</a>.
     {{/notice-banner}}
-    {{/if}}
   {{/if}}
   {{#if isTrustySudoFalse}}
     {{#notice-banner}}

--- a/app/templates/components/job-tabs.hbs
+++ b/app/templates/components/job-tabs.hbs
@@ -1,31 +1,5 @@
 {{#unless config.enterprise}}
-  {{#if auth.signedIn}}
-    {{#if job.isLegacyInfrastructure}}
-      {{#if job.isFinished}}
-        <p class="notice-banner--yellow"><span class="icon-flag"></span>
-        <span class="label-align">This job ran on our legacy infrastructure. Please read <a href="http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade" title="Migrating from legacy">our docs on how to upgrade</a>.</span></p>
-      {{else}}
-        <p class="notice-banner--yellow"><span class="icon-flag"></span>
-        <span class="label-align">This job is running on our legacy infrastructure. Please read <a href="http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade" title="Migrating from legacy">our docs on how to upgrade</a>.</span></p>
-      {{/if}}
-    {{/if}}
-    {{#if job.isTrustySudoFalse}}
-      <p class="notice-banner--yellow"><span class="icon-flag"></span>
-      <span class="label-align">
-        This job {{#if job.isFinished}}ran{{else}}is running{{/if}} on our container-based trusty beta.
-        Please read <a href="http://blog.travis-ci.com/2016-11-08-trusty-container-public-beta/?utm_source=trusty-container-based-beta-notice&utm_medium=banner&utm_campaign=trusty-container-based-beta" title="Trusty container-based beta">our blog post about the public beta</a>.</span></p>
-    {{/if}}
-    {{#if job.isRetiredMacImageXcode6}}
-      <p class="notice-banner--yellow"><span class="icon-flag"></span>
-      <span class="label-align">
-        This job is using an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>. After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-6.4">Xcode 6.4 image</a></strong>.</span></p>
-    {{/if}}
-    {{#if job.isRetiredMacImageXcode7}}
-      <p class="notice-banner--yellow"><span class="icon-flag"></span>
-      <span class="label-align">
-        This job is using an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>. After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-7.3.1">Xcode 7.3 image</a></strong>.</span></p>
-      {{/if}}
-  {{/if}}
+  {{job-infrastructure-notification job=job}}
 {{/unless}}
 
 <nav class="travistab-nav--secondary">

--- a/app/templates/components/job-tabs.hbs
+++ b/app/templates/components/job-tabs.hbs
@@ -1,3 +1,33 @@
+{{#unless config.enterprise}}
+  {{#if auth.signedIn}}
+    {{#if job.isLegacyInfrastructure}}
+      {{#if job.isFinished}}
+        <p class="notice-banner--yellow"><span class="icon-flag"></span>
+        <span class="label-align">This job ran on our legacy infrastructure. Please read <a href="http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade" title="Migrating from legacy">our docs on how to upgrade</a>.</span></p>
+      {{else}}
+        <p class="notice-banner--yellow"><span class="icon-flag"></span>
+        <span class="label-align">This job is running on our legacy infrastructure. Please read <a href="http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade" title="Migrating from legacy">our docs on how to upgrade</a>.</span></p>
+      {{/if}}
+    {{/if}}
+    {{#if job.isTrustySudoFalse}}
+      <p class="notice-banner--yellow"><span class="icon-flag"></span>
+      <span class="label-align">
+        This job {{#if job.isFinished}}ran{{else}}is running{{/if}} on our container-based trusty beta.
+        Please read <a href="http://blog.travis-ci.com/2016-11-08-trusty-container-public-beta/?utm_source=trusty-container-based-beta-notice&utm_medium=banner&utm_campaign=trusty-container-based-beta" title="Trusty container-based beta">our blog post about the public beta</a>.</span></p>
+    {{/if}}
+    {{#if job.isRetiredMacImageXcode6}}
+      <p class="notice-banner--yellow"><span class="icon-flag"></span>
+      <span class="label-align">
+        This job is using an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>. After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-6.4">Xcode 6.4 image</a></strong>.</span></p>
+    {{/if}}
+    {{#if job.isRetiredMacImageXcode7}}
+      <p class="notice-banner--yellow"><span class="icon-flag"></span>
+      <span class="label-align">
+        This job is using an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>. After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-7.3.1">Xcode 7.3 image</a></strong>.</span></p>
+      {{/if}}
+  {{/if}}
+{{/unless}}
+
 <nav class="travistab-nav--secondary">
   <ul>
     <li>{{link-to 'Job log' 'job.index' repo job id="tab_log" title="Look at this job's log"}}</li>

--- a/app/templates/components/job-tabs.hbs
+++ b/app/templates/components/job-tabs.hbs
@@ -1,7 +1,3 @@
-{{#unless config.enterprise}}
-  {{job-infrastructure-notification job=job}}
-{{/unless}}
-
 <nav class="travistab-nav--secondary">
   <ul>
     <li>{{link-to 'Job log' 'job.index' repo job id="tab_log" title="Look at this job's log"}}</li>

--- a/app/templates/components/log-content.hbs
+++ b/app/templates/components/log-content.hbs
@@ -2,36 +2,6 @@
 
 <section id="log-container" class="log">
 
-  {{#unless config.enterprise}}
-    {{#if auth.signedIn}}
-      {{#if job.isLegacyInfrastructure}}
-        {{#if job.isFinished}}
-          <p class="notice-banner--yellow"><span class="icon-flag"></span>
-          <span class="label-align">This job ran on our legacy infrastructure. Please read <a href="http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade" title="Migrating from legacy">our docs on how to upgrade</a>.</span></p>
-        {{else}}
-          <p class="notice-banner--yellow"><span class="icon-flag"></span>
-          <span class="label-align">This job is running on our legacy infrastructure. Please read <a href="http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade" title="Migrating from legacy">our docs on how to upgrade</a>.</span></p>
-        {{/if}}
-      {{/if}}
-      {{#if job.isTrustySudoFalse}}
-        <p class="notice-banner--yellow"><span class="icon-flag"></span>
-        <span class="label-align">
-          This job {{#if job.isFinished}}ran{{else}}is running{{/if}} on our container-based trusty beta.
-          Please read <a href="http://blog.travis-ci.com/2016-11-08-trusty-container-public-beta/?utm_source=trusty-container-based-beta-notice&utm_medium=banner&utm_campaign=trusty-container-based-beta" title="Trusty container-based beta">our blog post about the public beta</a>.</span></p>
-      {{/if}}
-      {{#if job.isRetiredMacImageXcode6}}
-        <p class="notice-banner--yellow"><span class="icon-flag"></span>
-        <span class="label-align">
-          This job is using an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>. After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-6.4">Xcode 6.4 image</a></strong>.</span></p>
-      {{/if}}
-      {{#if job.isRetiredMacImageXcode7}}
-        <p class="notice-banner--yellow"><span class="icon-flag"></span>
-        <span class="label-align">
-          This job is using an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>. After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-7.3.1">Xcode 7.3 image</a></strong>.</span></p>
-        {{/if}}
-    {{/if}}
-  {{/unless}}
-
   {{#if job.notStarted}}
     <div class="log-notice">Hang tight, the log cannot be shown until the build has started.</div>
   {{/if}}

--- a/app/templates/components/notice-banner.hbs
+++ b/app/templates/components/notice-banner.hbs
@@ -1,0 +1,6 @@
+<p class="notice-banner--yellow">
+  <span class="icon-flag"></span>
+  <span class="label-align">
+    {{yield}}
+  </span>
+</p>

--- a/app/templates/job.hbs
+++ b/app/templates/job.hbs
@@ -3,6 +3,7 @@
 
   {{build-header item=job commit=job.commit repo=repo}}
 
+  {{job-infrastructure-notification job=job}}
   {{job-tabs job=job repo=repo}}
 
 {{else}}


### PR DESCRIPTION
This also extracts some components to contain the job infrastructure
notifications. The `job-infrastructure-notification` component now
contains the computed properties that were formerly on the `job`
model, because this is the only place they’re used.