### PR TITLE
Optimize Github avatar image sizes requested on profile page for user/organizations

### DIFF
--- a/app/components/user-avatar.js
+++ b/app/components/user-avatar.js
@@ -23,8 +23,15 @@ export default Ember.Component.extend({
   avatarUrl: Ember.computed('url', 'size', function () {
     const url = this.get('url');
     const size = this.get('size');
+
     if (size) {
-      return `${url}&s=${size}`;
+      const sizeParam = `&s=${size}`;
+      // ensure version and size set properly
+      if (url.includes('?v=3')) {
+        return `${url}${sizeParam}`;
+      } else {
+        return `${url}?v=3&s=${size}`;
+      }
     } else {
       return url;
     }

--- a/app/components/user-avatar.js
+++ b/app/components/user-avatar.js
@@ -18,5 +18,15 @@ export default Ember.Component.extend({
       }
       return initials;
     }
-  })
+  }),
+
+  avatarUrl: Ember.computed('url', 'size', function () {
+    const url = this.get('url');
+    const size = this.get('size');
+    if (size) {
+      return `${url}&s=${size}`;
+    } else {
+      return url;
+    }
+  }),
 });

--- a/app/templates/components/org-item.hbs
+++ b/app/templates/components/org-item.hbs
@@ -1,5 +1,5 @@
 <div class="media-elem">
-  {{user-avatar url=account.avatarUrl name=name size=32}}
+  {{user-avatar url=account.avatarUrl name=name size=64}}
 </div>
 <div class="media-body">
   {{#link-to "account" account.login}}

--- a/app/templates/components/org-item.hbs
+++ b/app/templates/components/org-item.hbs
@@ -1,5 +1,5 @@
 <div class="media-elem">
-  {{user-avatar url=account.avatarUrl name=name}}
+  {{user-avatar url=account.avatarUrl name=name size=32}}
 </div>
 <div class="media-body">
   {{#link-to "account" account.login}}

--- a/app/templates/components/user-avatar.hbs
+++ b/app/templates/components/user-avatar.hbs
@@ -1,4 +1,4 @@
 <span class="pseudo-avatar" aria-hidden="true" data-initials="{{userInitials}}"></span>
 {{#if url}}
-<img class="real-avatar" src="{{url}}" alt="avatar">
+<img class="real-avatar" src="{{avatarUrl}}" alt="avatar">
 {{/if}}


### PR DESCRIPTION
The current requests we make for the avatar make no specification as to the image size, meaning we by default receive a 460x460 image. However, we're restricting the size of that image to 32x32 in CSS, meaning we're downloading a lot of unnecessary bits. 

This will, of course, hit users worse that have more organizations.

Here's current production (but with the images cached so network captured here):
<img width="576" alt="screenshot 2016-11-23 11 01 17" src="https://cloud.githubusercontent.com/assets/366944/20557572/44aa1938-b16c-11e6-8150-d1e7ea4be788.png">

And with these changes:

<img width="485" alt="screenshot 2016-11-23 10 53 35" src="https://cloud.githubusercontent.com/assets/366944/20557590/5963691a-b16c-11e6-8ad3-24eaf62458e2.png">

This change is Github-specific, but I haven't added any additional logic to check whether we're fetching from gravatar vs. github, simply because the only components currently passing in the `size` parameter are known to just use Github.

@lislis It would be good to get your feedback on this, especially given your upcoming work in https://github.com/travis-pro/team-teal/issues/1495.

Not included in this PR, but also possible: specifying the avatar size for the account dropdown on the top right of the page.

