### PR TITLE
Turn off fingerprinting for team assets

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -9,7 +9,7 @@ module.exports = function () {
     fingerprint = false;
   } else {
     fingerprint = {
-      exclude: ['images/emoji'],
+      exclude: ['images/emoji', 'images/pro-landing/flag*', 'images/team'],
       extensions: ['js', 'css', 'png', 'jpg', 'gif', 'map', 'svg']
     };
 


### PR DESCRIPTION
This should make them appear in PR deployments. But is it
a good idea? ¯\_(ツ)_/¯