### PR TITLE
Add deployment badge to top bar

### DIFF
--- a/app/controllers/top.js
+++ b/app/controllers/top.js
@@ -9,6 +9,7 @@ export default Ember.Controller.extend({
   auth: service(),
   store: service(),
   storage: service(),
+  externalLinks: service(),
 
   user: alias('auth.currentUser'),
 
@@ -74,14 +75,18 @@ export default Ember.Controller.extend({
     }
   }),
 
-  deploymentVersion: Ember.computed(() => {
+  deploymentVersion: Ember.computed(function () {
     if (window && window.location) {
       const hostname = window.location.hostname;
 
       if (hostname.indexOf('ember-beta') === 0 || hostname.indexOf('ember-canary') === 0) {
         return `Ember ${Ember.VERSION}`;
       } else if (hostname.indexOf('test-deployments') > 0) {
-        return `Test deployment ${hostname.split('.')[0]}`;
+        const branchName = hostname.split('.')[0];
+        const branchURL = this.get('externalLinks').travisWebBranch(branchName);
+        const branchLink = `<a href='${branchURL}'><code>${branchName}</code></a>`;
+
+        return Ember.String.htmlSafe(`Test deployment ${branchLink}`);
       } else {
         return false;
       }

--- a/app/controllers/top.js
+++ b/app/controllers/top.js
@@ -74,6 +74,22 @@ export default Ember.Controller.extend({
     }
   }),
 
+  deploymentVersion: Ember.computed(() => {
+    if (window && window.location) {
+      const hostname = window.location.hostname;
+
+      if (hostname.indexOf('ember-beta') === 0 || hostname.indexOf('ember-canary') === 0) {
+        return `Ember ${Ember.VERSION}`;
+      } else if (hostname.indexOf('test-deployments') > 0) {
+        return `Test deployment ${hostname.split('.')[0]}`;
+      } else {
+        return false;
+      }
+    } else {
+      return false;
+    }
+  }),
+
   actions: {
     toggleBurgerMenu() {
       this.toggleProperty('is-open');

--- a/app/services/external-links.js
+++ b/app/services/external-links.js
@@ -26,4 +26,8 @@ export default Ember.Service.extend({
   gravatarImage(email, size) {
     return 'https://www.gravatar.com/avatar/' + (md5(email)) + '?s=' + size + '&d=blank';
   },
+
+  travisWebBranch(branchName) {
+    return `https://github.com/travis-ci/travis-web/tree/${branchName}`;
+  }
 });

--- a/app/styles/app/modules/navigation.sass
+++ b/app/styles/app/modules/navigation.sass
@@ -44,15 +44,15 @@ $nav-line-height: 35px
   @media #{$medium-up}
     line-height: $top-height + 1px // such magic wow
 
-  &.version
-    border: 1px solid $cement-grey
-    font-size: 50%
-    padding: 6px
-    border-radius: 15px
+.deployment-version
+  border: 1px solid $cement-grey
+  font-size: 50%
+  padding: 6px
+  border-radius: 15px
 
-    display: inline
-    position: relative
-    top: -2px
+  display: inline
+  position: relative
+  top: -2px
 
 .navigation-nested
   margin: 0

--- a/app/styles/app/modules/navigation.sass
+++ b/app/styles/app/modules/navigation.sass
@@ -44,6 +44,14 @@ $nav-line-height: 35px
   @media #{$medium-up}
     line-height: $top-height + 1px // such magic wow
 
+  &.version
+    background: $cement-grey
+    font-size: 50%
+    padding: 6px
+    border-radius: 15px
+    color: white
+    display: inline
+
 .navigation-nested
   margin: 0
   padding: 0 0 0 1em

--- a/app/styles/app/modules/navigation.sass
+++ b/app/styles/app/modules/navigation.sass
@@ -45,12 +45,14 @@ $nav-line-height: 35px
     line-height: $top-height + 1px // such magic wow
 
   &.version
-    background: $cement-grey
+    border: 1px solid $cement-grey
     font-size: 50%
     padding: 6px
     border-radius: 15px
-    color: white
+
     display: inline
+    position: relative
+    top: -2px
 
 .navigation-nested
   margin: 0

--- a/app/templates/top.hbs
+++ b/app/templates/top.hbs
@@ -62,7 +62,7 @@
         {{/unless}}
       {{/if}}
 
-      {{#if deploymentVersion}}<li><span class='navigation-anchor version'>{{deploymentVersion}}</span></li>{{/if}}
+      {{#if deploymentVersion}}<li><span class='deployment-version'>{{deploymentVersion}}</span></li>{{/if}}
     {{else}}
       {{#if auth.signedIn}}
         <li><a class="navigation-anchor" title="Documentation" href="https://docs.travis-ci.com">Docs</a></li>

--- a/app/templates/top.hbs
+++ b/app/templates/top.hbs
@@ -61,6 +61,8 @@
           </li>
         {{/unless}}
       {{/if}}
+
+      {{#if deploymentVersion}}<li><span class='navigation-anchor version'>{{deploymentVersion}}</span></li>{{/if}}
     {{else}}
       {{#if auth.signedIn}}
         <li><a class="navigation-anchor" title="Documentation" href="https://docs.travis-ci.com">Docs</a></li>

--- a/tests/unit/services/external-links-test.js
+++ b/tests/unit/services/external-links-test.js
@@ -42,3 +42,10 @@ test('gravatarImage', function (assert) {
   const size = 'large';
   assert.equal(service.gravatarImage(email, size), 'https://www.gravatar.com/avatar/7e04deb54e09fefd971875250cf6b415?s=large&d=blank');
 });
+
+test('travisWebBranch', function (assert) {
+  const service = this.subject();
+  const branchName = 'bd-no-justice-no-peace';
+
+  assert.equal(service.travisWebBranch(branchName), 'https://github.com/travis-ci/travis-web/tree/bd-no-justice-no-peace');
+});


### PR DESCRIPTION
This is an experiment to clearly label if you’re on a non-production version, like one of the Ember beta/canary deployments, or a PR deployment.

The alignment is off, it can be tweaked.

If it’s a PR deployment, I’d like to link to the branch on GitHub. (Ideally the PR, but that’s probably too much work.)