### PR TITLE
Wrap hook switch async behavior in task

### DIFF
--- a/app/components/hook-switch.js
+++ b/app/components/hook-switch.js
@@ -1,10 +1,15 @@
 import Ember from 'ember';
+import { task } from 'ember-concurrency';
 
 export default Ember.Component.extend({
   tagName: 'a',
   classNames: ['switch'],
   classNameBindings: ['hook.active:active', 'disabled:disabled', 'disabled:inline-block'],
   click() {
+    this.get('toggleHook').perform();
+  },
+
+  toggleHook: task(function* () {
     if (!this.get('disabled')) {
       this.sendAction('onToggle');
 
@@ -13,12 +18,12 @@ export default Ember.Component.extend({
       let pusher = this.get('pusher'),
         repoId = hook.get('id');
 
-      return hook.toggle().then(() => {
+      yield hook.toggle().then(() => {
         pusher.subscribe(`repo-${repoId}`);
       }, () => {
         this.toggleProperty('hook.active');
         return this.sendAction('onToggleError', hook);
       });
     }
-  }
+  }),
 });


### PR DESCRIPTION
We are seeing errors in production where `then` is undefined on `hook.toggle()`, which
is a product of the component having been destroyed before our promise can execute.

Wrapping this in a task should fix the error and make this behavior more robust.