### PR TITLE
Move link underline beneath text only

### DIFF
--- a/app/styles/app/modules/build-header.sass
+++ b/app/styles/app/modules/build-header.sass
@@ -20,7 +20,8 @@
 
   a:hover,
   a:active
-    text-decoration: underline
+    .inner-underline
+      text-decoration: underline
 
 .build-commit,
 .build-tools

--- a/app/templates/components/build-header.hbs
+++ b/app/templates/components/build-header.hbs
@@ -20,19 +20,19 @@
       <li>
         <a class="commit-commit" title="See the commit on GitHub" href={{urlGithubCommit}}>
           {{inline-svg 'icon-github' class="icon"}}
-          <span class="label-align">Commit {{format-sha commit.sha}}</span></a>
+          <span class="label-align inner-underline">Commit {{format-sha commit.sha}}</span></a>
       </li>
       {{#if displayCompare}}
         <li>
           {{#if item.pullRequest}}
             <a class="commit-compare" title="See the commit on GitHub" href={{item.commit.compareUrl}}>
               {{inline-svg 'icon-github' class="icon"}}
-              <span class="label-align">#{{item.pullRequestNumber}}: {{item.pullRequestTitle}}</span></a>
+              <span class="label-align inner-underline">#{{item.pullRequestNumber}}: {{item.pullRequestTitle}}</span></a>
           {{else}}
             {{#if item.commit.compareUrl}}
             <a class="commit-compare" title="See the diff on GitHub" href={{item.commit.compareUrl}}>
               {{inline-svg 'icon-github' class="icon"}}
-              <span class="label-align">Compare {{short-compare-shas item.commit.compareUrl}}</span></a>
+              <span class="label-align inner-underline">Compare {{short-compare-shas item.commit.compareUrl}}</span></a>
             {{/if}}
           {{/if}}
         </li>
@@ -41,7 +41,7 @@
       <li>
         <a class="commit-branch-url" href="{{urlGitHubBranch}}" title="Look at the branch on GitHub">
           {{inline-svg 'icon-github' class="icon"}}
-          <span class="label-align">Branch {{commit.branch}}</span>
+          <span class="label-align inner-underline">Branch {{commit.branch}}</span>
         </a>
       </li>
       {{else}}
@@ -67,10 +67,10 @@
   <h3 class="build-status {{item.state}}">
     {{#if isJob}}
       {{#link-to "job" repo item}}
-        {{request-icon event=item.build.eventType state=item.state}} #{{item.number}} {{humanize-state item.state}}{{/link-to}}
+        {{request-icon event=item.build.eventType state=item.state}} <span class='inner-underline'>#{{item.number}} {{humanize-state item.state}}</span>{{/link-to}}
     {{else}}
       {{#link-to "build" repo item}}
-        {{request-icon event=item.eventType state=item.state}} #{{item.number}} {{humanize-state item.state}}{{/link-to}}
+        {{request-icon event=item.eventType state=item.state}} <span class='inner-underline'>#{{item.number}} {{humanize-state item.state}}</span>{{/link-to}}
     {{/if}}
   </h3>
   <ul class="list-icon">

--- a/tests/integration/components/build-header-test.js
+++ b/tests/integration/components/build-header-test.js
@@ -28,7 +28,7 @@ test('render api build', function (assert) {
   this.render(hbs`{{build-header item=build repo=repo commit=commit}}`);
 
   assert.equal(this.$().find('.commit-compare').length, 0, 'does not display compare link element for api builds');
-  assert.equal(this.$().find('.build-status span').text().trim(), 'API event', 'displays right icon');
+  assert.equal(this.$().find('.build-status span.icon').text().trim(), 'API event', 'displays right icon');
   assert.equal(this.$().find('.commit-branch-url').attr('href'), 'https://github.com/travis-ci/travis-web/tree/feature-branch', 'displays branch url');
   assert.equal(this.$().find('.commit-branch-url').text().trim(), 'Branch feature-branch', 'displays link to branch');
 });


### PR DESCRIPTION
The underline was extending to the whitespace between the
text and the icon, which I found quite irksome 😬

![image](https://cloud.githubusercontent.com/assets/43280/20716647/ea520482-b620-11e6-83bf-e05024cd23b6.png)

What do you think of this technique, @lislis? I am somewhat displeased by the `inner-underline` class, I originally had it as `label-align`, but it seemed weird to me to need to use that for the text elements within `build-status`, which don’t currently have any kind of wrapper.

uhhhh apart from the test failure, which I will address haha