### PR TITLE
Update OS X banners

### DIFF
--- a/app/components/job-infrastructure-notification.js
+++ b/app/components/job-infrastructure-notification.js
@@ -19,8 +19,13 @@ export default Ember.Component.extend({
 
   macOSImage: Ember.computed.alias('jobConfig.osx_image'),
 
+  isDeprecatedMacImageXcode6: Ember.computed('queue', 'macOSImage', function () {
+    const retiredImages = ['beta-xcode6.1'];
+    return this.get('isMacStadium6') && retiredImages.includes(this.get('macOSImage'));
+  }),
+
   isRetiredMacImageXcode6: Ember.computed('queue', 'macOSImage', function () {
-    const retiredImages = ['beta-xcode6.1', 'beta-xcode6.2', 'beta-xcode6.3'];
+    const retiredImages = ['beta-xcode6.2', 'beta-xcode6.3'];
     return this.get('isMacStadium6') && retiredImages.includes(this.get('macOSImage'));
   }),
 

--- a/app/templates/components/job-infrastructure-notification.hbs
+++ b/app/templates/components/job-infrastructure-notification.hbs
@@ -12,16 +12,20 @@
         Please read <a href="http://blog.travis-ci.com/2016-11-08-trusty-container-public-beta/?utm_source=trusty-container-based-beta-notice&utm_medium=banner&utm_campaign=trusty-container-based-beta" title="Trusty container-based beta">our blog post about the public beta</a>.
       {{/notice-banner}}
     {{/if}}
+    {{#if isDeprecatedMacImageXcode6}}
+      {{#notice-banner}}
+      This job {{conjugatedRun}} on an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Friday, January 20th at Noon PST</a>.
+      After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-6.4">Xcode 6.4 image</a></strong>.
+      {{/notice-banner}}
+    {{/if}}
     {{#if isRetiredMacImageXcode6}}
       {{#notice-banner}}
-        This job {{conjugatedRun}} on an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>.
-        After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-6.4">Xcode 6.4 image</a></strong>.
+        This job {{conjugatedRun}} on our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-6.4">Xcode 6.4 image</a></strong>. Please update your <i>.travis.yml</i> file accordingly.
       {{/notice-banner}}
     {{/if}}
     {{#if isRetiredMacImageXcode7}}
       {{#notice-banner}}
-        This job {{conjugatedRun}} on an OS X image that <a href="https://blog.travis-ci.com/2016-11-17-retiring-some-osx-images/">will be retired on Monday, Nov 28th at Noon PST</a>.
-        After that this build will be routed to our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-7.3.1">Xcode 7.3 image</a></strong>.
+        This job {{conjugatedRun}} on our <strong><a href="https://docs.travis-ci.com/user/osx-ci-environment/#Xcode-7.3.1">Xcode 7.3 image</a></strong>. Please update your <i>.travis.yml</i> file accordingly.
       {{/notice-banner}}
     {{/if}}
   {{/if}}


### PR DESCRIPTION
Update OS X banners to include:

- beta-xcode6.1 needs to show that it will be retired on Fri, Jan 20, 2017 at Noon PST
- The other Xcode 6.x images warn they are now routed to xcode6.4
- The Xcode 7.x images warn they are now routed to xcode7.3