### PR TITLE
Add alternate determination of commit ID

### DIFF
--- a/app/services/store.js
+++ b/app/services/store.js
@@ -53,7 +53,7 @@ export default DS.Store.extend({
     if (name === 'build' && ((ref2 = data.build) != null ? ref2.commit : void 0)) {
       build = data.build;
       commit = {
-        id: build.commit_id,
+        id: build.commit_id || Ember.get(data, 'commit.id'),
         author_email: build.author_email,
         author_name: build.author_name,
         branch: build.branch,


### PR DESCRIPTION
Gatekeeper includes the commit_id in the build:started event,
but not in the build:created one. This produces Ember Data
errors about the missing ID.