### PR TITLE
Remove .buildpacks because we will no longer use deprecated heroku-bu…

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,0 @@
-https://github.com/heroku/heroku-buildpack-ruby.git
-https://github.com/travis-ci/travis-web-ember-cli-buildpack.git


### PR DESCRIPTION
…ildpack-multi

~The test deployments are expected to be broken~