### PR TITLE
Add crisp edges for SVG in testing

### DIFF
--- a/app/styles/app/layout.sass
+++ b/app/styles/app/layout.sass
@@ -117,3 +117,7 @@
   footer.hidden
     display: block
     margin-top: 5rem
+
+body.testing
+  svg
+    shape-rendering: crispedges

--- a/tests/index.html
+++ b/tests/index.html
@@ -17,7 +17,7 @@
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}
   </head>
-  <body>
+  <body class='testing'>
     {{content-for "body"}}
     {{content-for "test-body"}}
 


### PR DESCRIPTION
This is Firefox-only, it appears, but Percy uses Firefox
for diffs, so that seems fine.