### PR TITLE
Add wildcard error route to avoid raising `UnrecognizedURLError`

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -87,6 +87,7 @@ Router.map(function () {
     this.route('repositories', { path: '/' });
   });
   this.route('error404', { path: '/404' });
+  this.route('page-not-found', { path: '/*wildcard' });
 });
 
 export default Router;

--- a/app/routes/page-not-found.js
+++ b/app/routes/page-not-found.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  renderTemplate() {
+    return this.render('error404');
+  },
+});

--- a/tests/acceptance/non-existent-routes-test.js
+++ b/tests/acceptance/non-existent-routes-test.js
@@ -1,0 +1,14 @@
+import { test } from 'qunit';
+import moduleForAcceptance from 'travis/tests/helpers/module-for-acceptance';
+import page404 from 'travis/tests/pages/404';
+
+moduleForAcceptance('Acceptance | non existent routes');
+
+test('visiting /some/non-existent/route', function (assert) {
+  visit('/some/non-existent/route');
+
+  andThen(() => {
+    assert.equal(currentURL(), '/some/non-existent/route');
+    assert.equal(page404.errorHeader, '404: Something\'s Missing We\'re sorry! It seems like this page cannot be found.');
+  });
+});

--- a/tests/pages/404.js
+++ b/tests/pages/404.js
@@ -1,0 +1,10 @@
+import {
+  create,
+  visitable,
+  text
+} from 'ember-cli-page-object';
+
+export default create({
+  visit: visitable('/404'),
+  errorHeader: text('.error-text'),
+});


### PR DESCRIPTION
I initially assumed that ember-cli-sentry would be able to capture any
error we threw at it. Unfortunately, that isn't true in this case (sentry handles the error before the wrapper service can), so the filtering behavior we built into the service to lighten the error logging load hasn't yet been being triggered.

This change means that users visiting *any* unknown URL within our app
(except `/unknown-org`, which currently redirects to `/404`) will stay at the URL
they entered, but be shown our standard 404 template. I think this
improves UX and should quiet down the error logging significantly.

I also believe that we should revisit the current `/404` redirect
behavior, but will address that in a separate PR.