### PR TITLE
Removes `renderTemplate` that only calls super

### DIFF
--- a/app/routes/simple-layout.js
+++ b/app/routes/simple-layout.js
@@ -6,8 +6,5 @@ export default TravisRoute.extend({
     Ember.$('body').attr('id', 'simple');
     this.controllerFor('repos').activate('owned');
     return this._super(...arguments);
-  },
-  renderTemplate: function () {
-    return this._super(...arguments);
   }
 });


### PR DESCRIPTION
Given that the hook was only calling super, the route should continue working properly if removed.