### PR TITLE
Remove unused `renderDefaultTemplate` method

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -82,12 +82,6 @@ export default TravisRoute.extend(BuildFaviconMixin, KeyboardShortcuts, {
       // do nothing, we handle it only in index path
     },
 
-    renderDefaultTemplate() {
-      if (this.renderDefaultTemplate) {
-        return this.renderDefaultTemplate();
-      }
-    },
-
     error(error) {
       if (error === 'needs-auth') {
         this.set('auth.redirected', true);


### PR DESCRIPTION
GitHub's code search isn't all that, but this method doesn't seem to be called from anywhere, and it's checking if itself exists before calling itself?