### PR TITLE
Remove double space from anchor attributes

### DIFF
--- a/app/templates/components/subscription-status-banner.hbs
+++ b/app/templates/components/subscription-status-banner.hbs
@@ -1,1 +1,1 @@
-{{message}} <a  href={{billingUrl}} title="Go to Travis CI Billing" class="right">{{billingLinkText}}</a>
+{{message}} <a href={{billingUrl}} title="Go to Travis CI Billing" class="right">{{billingLinkText}}</a>


### PR DESCRIPTION
Hi all, noticed a tiny thing:

`<a__href=...>` → `<a href=...`>

Hope it helps.

Cheers!