### PR TITLE
Switch to emberx-select fork to work around Edge bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "ember-prism": "0.0.8",
     "ember-qunit-nice-errors": "1.1.1",
     "ember-resolver": "^2.0.3",
-    "emberx-select": "2.2.2",
+    "emberx-select": "travis-ci/emberx-select#edge-required-default",
     "loader.js": "^4.0.10",
     "visibilityjs": "^1.2.4"
   }


### PR DESCRIPTION
This is an experiment to see whether it will help with a possible
bug in Edge.

I’m unfortunately reduced to testing this via PR deployments, because for whatever reason I’m unable to log in to `travis-web` via the instance I’m running of Edge within a VM. 😠