### PR TITLE
Remove extraneous space from insufficient-oauth-perm

### DIFF
--- a/app/templates/insufficient-oauth-permissions.hbs
+++ b/app/templates/insufficient-oauth-permissions.hbs
@@ -14,7 +14,7 @@
     <p>Luckily, the issue can be easily corrected by going through the login flow
       once again. Make sure the permissions we ask for are all available.</p>
 
-    <p> For more information about the OAuth scopes and what we need them for,
+    <p>For more information about the OAuth scopes and what we need them for,
       <a href="http://docs.travis-ci.com/user/github-oauth-scopes/">check our documentation on this topic</a>.</p>
   </div>
 


### PR DESCRIPTION
Hi all,

another tiny thing: `<p>_For more information…` → `<p>For more information…`

Happy new year!