### PR TITLE
Fix sentry error about undefined `this`

### DIFF
--- a/app/routes/first-sync.js
+++ b/app/routes/first-sync.js
@@ -29,7 +29,7 @@ export default SimpleLayoutRoute.extend({
             return self.transitionTo('profile');
           }
         }).then(null, function (e) {
-          if (this.get('features.debugLogging')) {
+          if (self.get('features.debugLogging')) {
             // eslint-disable-next-line
             return console.log('There was a problem while redirecting from first sync', e);
           }


### PR DESCRIPTION
We now use `self` (bound previously to the outer scope `this`) instead of referencing
`this` directly.  I'm not sure why we pass the null context in, but the
code will likely be changed when converted to ES2015, so not concerned
with it atm.