### PR TITLE
Remove right border on third plan on big displays

### DIFF
--- a/app/styles/app/pages/plans.sass
+++ b/app/styles/app/pages/plans.sass
@@ -59,7 +59,7 @@ $plan-buttons: (green: $turf-green, blue: $oxide-blue, grey: $cement-grey, red: 
       +colorSVG($oxide-blue)
 
   @media screen and (min-width: 50em)
-    .plan:nth-of-type(1)
+    .plan:nth-of-type(1), .plan:nth-of-type(3)
       border-right: none
     .plan:nth-of-type(3)
       border-left: none


### PR DESCRIPTION
Changes this:

![image](https://cloud.githubusercontent.com/assets/43280/21769788/786647c2-d64e-11e6-8ff8-183f0bb91e85.png)

To this:

![image](https://cloud.githubusercontent.com/assets/43280/21769812/8a392dca-d64e-11e6-8760-fb0ccfe4e78d.png)
