### PR TITLE
Fix sign in with ember server and redirect flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,9 @@
     "ember-qunit-nice-errors": "1.1.1",
     "ember-resolver": "^2.0.3",
     "emberx-select": "~3.0.0",
+    "glob": "^4.5.3",
     "loader.js": "^4.0.10",
+    "morgan": "^1.7.0",
     "visibilityjs": "^1.2.4"
   }
 }

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,53 @@
+/*jshint node:true*/
+
+// To use it create some files under `mocks/`
+// e.g. `server/mocks/ember-hamsters.js`
+//
+// module.exports = function(app) {
+//   app.get('/ember-hamsters', function(req, res) {
+//     res.send('hello');
+//   });
+// };
+
+var bodyParser = require('body-parser');
+
+module.exports = function(app) {
+  var globSync   = require('glob').sync;
+  var mocks      = globSync('./mocks/**/*.js', { cwd: __dirname }).map(require);
+  var proxies    = globSync('./proxies/**/*.js', { cwd: __dirname }).map(require);
+
+  // Log proxy requests
+  var morgan  = require('morgan');
+  app.use(morgan('dev'));
+  app.use(bodyParser.urlencoded({ extended: false }));
+
+  mocks.forEach(function(route) { route(app); });
+  proxies.forEach(function(route) { route(app); });
+
+  // this is reimplementation of waiter/lib/travis/web/set_token.rb
+  app.use(function(req, res, next) {
+    var token = req.body['token'];
+    if(req.method == 'POST' && token && token.match(/^[a-zA-Z\-_\d]+$/)) {
+      var storage = req.body['storage'];
+      if(storage !== 'localStorage') {
+        storage = 'sessionStorage';
+      }
+      var user = JSON.stringify(req.body['user']);
+
+      var responseText = `
+        <script>
+          var storage = ${storage};
+          storage.setItem('travis.token', '${token}');
+          storage.setItem('travis.user', ${user});
+          storage.setItem('travis.become', true);
+          window.location = '${req.path}';
+        </script>
+      `;
+
+      res.send(responseText);
+    } else {
+      next();
+    }
+  });
+
+};


### PR DESCRIPTION
Recently GitHub introduced Content Security Policy header that disallows
putting GitHub in an iframe. That's why our iframe sign in flow fails on
browsers that support CSP headers. On top of that the redirect flow that
we used as a fallback didn't work properly when using ember-cli's built
in server, because it didn't know how to handle a POST request that we
get from GitHub.

This commit introduces an Express.js middleware that mimics the logic
we use in a Ruby server.