### PR TITLE
Fix definition of job.canCancel

### DIFF
--- a/app/models/job.js
+++ b/app/models/job.js
@@ -103,7 +103,12 @@ export default Model.extend(DurationCalculations, {
     }
   }),
 
-  canCancel: Ember.computed.not('isFinished'),
+
+  canCancel: Ember.computed('isFinished', 'state', function () {
+    // not(isFinished) is insufficient since it will be true when state is undefined.
+    return !this.get('isFinished') && !!this.get('state');
+  }),
+
   canRestart: Ember.computed.alias('isFinished'),
   canDebug: Ember.computed.alias('isFinished'),
 


### PR DESCRIPTION
The implementation was causing false positives when state
was not yet loaded.

See this screen capture for an example:

![cancancel-delay-elsewhere](https://cloud.githubusercontent.com/assets/43280/21902103/a35db1a0-d8c8-11e6-8590-1cde993fff52.gif)
