### PR TITLE
add beacon instruction

### DIFF
--- a/app/utils/init-hs-beacon.js
+++ b/app/utils/init-hs-beacon.js
@@ -4,6 +4,7 @@ export default function initHsBeacon() {
 
   HS.beacon.config({
     modal: true,
-    attachment: true
+    attachment: true,
+    instructions: 'Please make sure to include a link if your questions involves a specific repo, build or job.'
   });
 }

--- a/app/utils/init-hs-beacon.js
+++ b/app/utils/init-hs-beacon.js
@@ -5,6 +5,6 @@ export default function initHsBeacon() {
   HS.beacon.config({
     modal: true,
     attachment: true,
-    instructions: 'Please make sure to include a link if your questions involves a specific repo, build or job.'
+    instructions: 'Please make sure to include a link if your question involves a specific repo, build or job.'
   });
 }


### PR DESCRIPTION
The HS beacon documentation only offers the 'instruction' property to be set. This is would be the easiest way to inform users to include a link in their message.
![screen shot 2017-01-19 at 16 38 55](https://cloud.githubusercontent.com/assets/1006478/22113323/2813e250-de66-11e6-9864-e2d6e3d11dab.png)
