### PR TITLE
Specify latest Node LTS release (6.9.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "repository": "https://github.com/travis-ci/travis-web",
   "engines": {
-    "node": "5.12.0"
+    "node": "6.9.4"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
This should silence any warnings we received on Heroku.