### PR TITLE
Modify language around SSH keys in repo settings

### DIFF
--- a/app/templates/components/ssh-key.hbs
+++ b/app/templates/components/ssh-key.hbs
@@ -1,6 +1,6 @@
 <div class="ssh-key-name">
   {{inline-svg 'icon-key' class="icon"}}
-  <span>{{if key.isCustom key.description 'no custom key set'}}</span>
+  <span>{{if key.isCustom key.description 'Default'}}</span>
 </div>
 <div class="ssh-key-value">
   {{inline-svg 'icon-fingerprint' class="icon"}}
@@ -31,7 +31,7 @@
   <div class="ssh-key-action">
     <div class="tooltip--height">
       {{inline-svg 'icon-trash-disabled' class="icon ssh-no-delete"}}
-      <div class="tooltip-bubble">Default keys <br>cannot be deleted</div>
+      <div class="tooltip-bubble">Default key <br>cannot be deleted</div>
     </div>
   </div>
 {{/if}}

--- a/tests/acceptance/repo/settings-test.js
+++ b/tests/acceptance/repo/settings-test.js
@@ -272,7 +272,7 @@ test('delete and set SSH keys', function (assert) {
   andThen(() => {
     assert.equal(deletedIds.pop(), this.repository.id, 'expected the server to have received a deletion request for the SSH key');
 
-    assert.equal(settingsPage.sshKey.name, 'no custom key set');
+    assert.equal(settingsPage.sshKey.name, 'Default');
     assert.equal(settingsPage.sshKey.fingerprint, 'aa:bb:cc:dd');
     assert.ok(settingsPage.sshKey.cannotBeDeleted, 'expected default SSH key not to be deletable');
   });

--- a/tests/integration/components/ssh-key-test.js
+++ b/tests/integration/components/ssh-key-test.js
@@ -14,7 +14,7 @@ test('it renders the default ssh key if no custom key is set', function (assert)
   this.set('key', key);
   this.render(hbs`{{ssh-key key=key sshKeyDeleted="sshKeyDeleted"}}`);
 
-  assert.equal(this.$('.ssh-key-name span').text().trim(), 'no custom key set', 'should display that no custom key is set');
+  assert.equal(this.$('.ssh-key-name span').text().trim(), 'Default', 'should display that no custom key is set');
   assert.equal(this.$('.ssh-key-value span').text().trim(), 'fingerprint', 'should display default key fingerprint');
   percySnapshot(assert);
 });
@@ -35,7 +35,6 @@ test('it renders the custom ssh key if custom key is set', function (assert) {
   assert.equal(this.$('.ssh-key-name span').text().trim(), 'fookey', 'should display key description');
   assert.equal(this.$('.ssh-key-value span').text().trim(), 'somethingthing', 'should display custom key fingerprint');
 });
-
 
 test('it deletes a custom key if permissions are right', function (assert) {
   assert.expect(1);


### PR DESCRIPTION
Currently, when displaying a private repo's SSH keys, we tell the user that there isn't any custom key set. To me, that makes it feel as if there's something outstanding that they need to do, when in fact no action is necessary on their part. Instead, I've changed the text to simply give it a default label of `Default`. I also made a small modification to the tooltip.

Here's the before:
![screen shot 2017-01-26 at 2 25 44 pm](https://cloud.githubusercontent.com/assets/366944/22332937/c9072344-e3d3-11e6-9683-ec9c6c59cda7.png)

And what this change would do:
![screen shot 2017-01-26 at 2 21 59 pm](https://cloud.githubusercontent.com/assets/366944/22332947/d1cd6376-e3d3-11e6-83f6-1d06e01ab008.png)

 