### PR TITLE
Ignore failed/aborted adapter errors

### DIFF
--- a/app/services/raven.js
+++ b/app/services/raven.js
@@ -8,7 +8,8 @@ export default RavenLogger.extend({
     'not found',
     'returned a 403',
     'returned a 404',
-    'Adapter operation failed'
+    'operation failed',
+    'operation was aborted'
   ],
 
   unhandledPromiseErrorMessage: '',


### PR DESCRIPTION
This should fix a big chunk of errors that are raised but do not appear to have any user impact.