### PR TITLE
Restore caches tab

### DIFF
--- a/app/components/repo-show-tabs.js
+++ b/app/components/repo-show-tabs.js
@@ -1,8 +1,11 @@
 import Ember from 'ember';
+import config from 'travis/config/environment';
 
 export default Ember.Component.extend({
   tagName: 'nav',
   classNames: ['travistab-nav'],
+
+  config,
 
   classCurrent: Ember.computed('tab', function () {
     if (this.get('tab') === 'current') {

--- a/app/templates/components/repo-show-tabs.hbs
+++ b/app/templates/components/repo-show-tabs.hbs
@@ -60,7 +60,7 @@
       {{/link-to}}
     {{/if}}
   </li>
-  {{#if config.caches_enabled}}
+  {{#if config.endpoints.caches}}
     <li id="tab_caches" class={{classCaches}}>
       {{#if repo.slug}}
         {{#link-to "caches" repo}}

--- a/tests/acceptance/repo/caches-test.js
+++ b/tests/acceptance/repo/caches-test.js
@@ -40,6 +40,7 @@ test('view and delete caches', function (assert) {
 
   andThen(() => {
     assert.equal(page.pushCaches().count, 1, 'expected one push cache');
+    assert.ok(page.tabIsActive, 'expected the caches tab to be active');
 
     const pushCache = page.pushCaches(0);
 

--- a/tests/pages/caches.js
+++ b/tests/pages/caches.js
@@ -3,6 +3,7 @@ import PageObject from 'travis/tests/page-object';
 let {
   clickable,
   collection,
+  hasClass,
   isVisible,
   text,
   visitable
@@ -18,6 +19,8 @@ const cacheComponent = {
 
 export default PageObject.create({
   visit: visitable(':organization/:repo/caches'),
+
+  tabIsActive: hasClass('active', '#tab_caches'),
 
   deleteAllCaches: clickable('.delete-cache-button'),
   noCachesExist: isVisible('p.helptext.no-caches'),


### PR DESCRIPTION
This uses the same mechanism as repo-show-tools.hbs to
determine whether to present a maybe-visible tab for
caches. Perhaps this worked using an injected config
before…? Unclear.

Comparison of current appearance on settings route vs caches:

![image](https://cloud.githubusercontent.com/assets/43280/22606160/aba846b8-ea07-11e6-8cdd-9fd36196f953.png)

![image](https://cloud.githubusercontent.com/assets/43280/22606178/bfe8fa82-ea07-11e6-9b03-ca2896554105.png)
