### PR TITLE
Fix current build view

### DIFF
--- a/app/serializers/build.js
+++ b/app/serializers/build.js
@@ -58,6 +58,12 @@ var Serializer = V2FallbackSerializer.extend({
     // TODO: remove this after switching to V3 entirely
     let type = resourceHash['@type'];
     let commit = resourceHash.commit;
+    if (resourceHash['event_type'] == 'pull_request' &&
+          !resourceHash.hasOwnProperty('pull_request')) {
+      // in V3 we don't return "pull_request" property as we rely on event_type
+      // value. This line makes V3 payloads also populate pull_request property
+      resourceHash['pull_request'] = true;
+    }
     if (!type && commit && commit.hasOwnProperty('branch_is_default')) {
       let build = resourceHash.build,
         commit = resourceHash.commit;

--- a/tests/unit/serializers/build-test.js
+++ b/tests/unit/serializers/build-test.js
@@ -5,6 +5,20 @@ moduleForModel('build', 'Unit | Serializer | build', {
   needs: ['serializer:build', 'model:commit', 'model:job', 'model:branch']
 });
 
+test('it sets "pullRequest" if it is not set', function (assert) {
+  let payload = {
+    '@type': 'build',
+    '@href': '...',
+    event_type: 'pull_request',
+    id: 1
+  };
+
+  let store = this.store();
+  let serializer = store.serializerFor('build');
+  let result = serializer.normalizeResponse(store, store.modelFor('build'), payload, 1, 'findRecord');
+  assert.ok(result.data.attributes.pullRequest);
+});
+
 test('it normalizes the singular response', function (assert) {
   QUnit.dump.maxDepth = 10;
   let payload = {


### PR DESCRIPTION
At the moment we use API V3 to fetch repositories data and along with
repositories we also get data for current_build. Because the payloads
differ between V2 and V3 we need to normalise them in the build
serializer. One thing that was still missing from there was a
pull_request key. We include pull_request key in V2 payloads, but not in
V3 payloads and the build model uses this attribute.