### PR TITLE
Set pro/enterprise feature flags on runtime

### DIFF
--- a/waiter/lib/travis/web/app.rb
+++ b/waiter/lib/travis/web/app.rb
@@ -185,7 +185,17 @@ class Travis::Web::App
       # TODO: clean up
       config = {}
 
-      config['enterprise'] = options[:enterprise] if options[:enterprise]
+      config['featureFlags'] ||= {}
+
+      if options[:pro]
+        config['pro'] = true
+        config['featureFlags']['pro-version'] = true
+      end
+      if options[:enterprise]
+        config['enterprise'] = true
+        config['featureFlags']['enterprise-version'] = true
+      end
+
       if config['enterprise']
         config['pagesEndpoint'] = false
         config['billingEndpoint'] = false
@@ -206,7 +216,6 @@ class Travis::Web::App
       config['pusher'] = pusher
 
       config['gaCode'] = options[:ga_code] if options[:ga_code]
-      config['pro'] = options[:pro] if options[:pro]
 
       config['githubOrgsOauthAccessSettingsUrl'] = options[:github_orgs_oauth_access_settings_url]
       config['ajaxPolling'] = true if options[:ajax_polling]


### PR DESCRIPTION
from the commit message:

```
Historically ENV vars were not enabled when building an app on Heroku,
so we couldn't rely on any checks made in environment.js file (like for
example checking for process.env.TRAVIS_PRO). At some point it must have
changed, because on travis-pro the config is properly compiled with a
proper value for `pro-version` feature flag, but the Travis CI
Enterprise setup relies on the old method of updating the config on
runtime.

This commit makes the ruby server update the pro-version and
enterprise-version feature flags at the time of making request and thus
it remove reliance on availability of ENV vars during build time.

Additionally we don't know if accessing ENV vars when deploying to
heroku is something supported, so this way of doing things is more
future proof. That said, once we confirm that we can rely on availability
of ENV vars during Heroku deploys we could think about simplifying the
config code.
```