### PR TITLE
Remove log fix that broke other logs

### DIFF
--- a/app/utils/log.js
+++ b/app/utils/log.js
@@ -255,8 +255,9 @@ removeCarriageReturns = function (string) {
     return string;
   }
   // FIXME the previous code is below. It surely was this way for a reason!
-  // return string.substr(index + 1);
-  return string.replace('\r', '');
+  return string.substr(index + 1);
+  // FIXME indeed it was, reverting for now…
+  // return string.replace('\r', '');
 };
 
 var foldNameCount = {};

--- a/tests/acceptance/job/basic-layout-test.js
+++ b/tests/acceptance/job/basic-layout-test.js
@@ -156,7 +156,9 @@ Another line that should be replaced.\rAnd another.\rBut not this one!\r${ESCAPE
     assert.equal(jobPage.logLines(15).nextText, 'I am the final replacer.');
     assert.equal(jobPage.logLines(16).text, 'I do not replace because the previous line ended with a line feed.');
 
-    assert.equal(jobPage.logLines(17).text, 'But not this one!');
+    // FIXME this is off pending a bug fix that doesn’t break other things.
+    // See https://github.com/travis-ci/travis-ci/issues/7106
+    // assert.equal(jobPage.logLines(17).text, 'But not this one!');
   });
 
   jobPage.logFolds(0).toggle();


### PR DESCRIPTION
I plan to find a solution that will fix [this](https://github.com/travis-ci/travis-ci/issues/7106) without breaking [this](https://github.com/travis-ci/travis-ci/issues/7293), but for now, this restores things to how they were. No one really knew what the code in question was about, but it was obviously necessary!