### PR TITLE
Extract contents of BasicRoute into BaseRouteMixin

### DIFF
--- a/app/mixins/base-route.js
+++ b/app/mixins/base-route.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 const { service } = Ember.inject;
 
-export default Ember.Route.extend({
+export default Ember.Mixin.create({
   auth: service(),
 
   activate() {

--- a/app/routes/abstract-builds.js
+++ b/app/routes/abstract-builds.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
-import TravisRoute from 'travis/routes/basic';
+import BaseRouteMixin from 'travis/mixins/base-route';
 
-export default TravisRoute.extend({
+export default Ember.Route.extend(BaseRouteMixin, {
   templateName: 'builds',
   controllerName: 'builds',
 

--- a/app/routes/account.js
+++ b/app/routes/account.js
@@ -1,6 +1,7 @@
-import TravisRoute from 'travis/routes/basic';
+import Ember from 'ember';
+import BaseRouteMixin from 'travis/mixins/base-route';
 
-export default TravisRoute.extend({
+export default Ember.Route.extend(BaseRouteMixin, {
   titleToken(model) {
     if (model) {
       return model.get('name') || model.get('login');

--- a/app/routes/accounts.js
+++ b/app/routes/accounts.js
@@ -1,6 +1,7 @@
-import TravisRoute from 'travis/routes/basic';
+import Ember from 'ember';
+import BaseRouteMixin from 'travis/mixins/base-route';
 
-export default TravisRoute.extend({
+export default Ember.Route.extend(BaseRouteMixin, {
   model() {
     return this.store.query('account', {
       all: true

--- a/app/routes/accounts/index.js
+++ b/app/routes/accounts/index.js
@@ -1,9 +1,9 @@
 import Ember from 'ember';
-import TravisRoute from 'travis/routes/basic';
+import BaseRouteMixin from 'travis/mixins/base-route';
 
 const { service } = Ember.inject;
 
-export default TravisRoute.extend({
+export default Ember.Route.extend(BaseRouteMixin, {
   auth: service(),
 
   redirect: function () {

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,14 +1,19 @@
 /* global Travis */
-import TravisRoute from 'travis/routes/basic';
+import Ember from 'ember';
+import BaseRouteMixin from 'travis/mixins/base-route';
 import config from 'travis/config/environment';
 import BuildFaviconMixin from 'travis/mixins/build-favicon';
-import Ember from 'ember';
-
 import KeyboardShortcuts from 'ember-keyboard-shortcuts/mixins/route';
 
 let { service } = Ember.inject;
 
-export default TravisRoute.extend(BuildFaviconMixin, KeyboardShortcuts, {
+const mixins = [
+  BaseRouteMixin,
+  BuildFaviconMixin,
+  KeyboardShortcuts,
+];
+
+export default Ember.Route.extend(...mixins, {
   flashes: service(),
   auth: service(),
 

--- a/app/routes/auth.js
+++ b/app/routes/auth.js
@@ -1,9 +1,9 @@
 import Ember from 'ember';
-import TravisRoute from 'travis/routes/basic';
+import BaseRouteMixin from 'travis/mixins/base-route';
 
 const { service } = Ember.inject;
 
-export default TravisRoute.extend({
+export default Ember.Route.extend(BaseRouteMixin, {
   auth: service(),
 
   needsAuth: false,

--- a/app/routes/branches.js
+++ b/app/routes/branches.js
@@ -1,10 +1,10 @@
 import Ember from 'ember';
-import TravisRoute from 'travis/routes/basic';
+import BaseRouteMixin from 'travis/mixins/base-route';
 import config from 'travis/config/environment';
 
 const { service } = Ember.inject;
 
-export default TravisRoute.extend({
+export default Ember.Route.extend(BaseRouteMixin, {
   tabStates: service(),
 
   model(/* params*/) {

--- a/app/routes/build.js
+++ b/app/routes/build.js
@@ -1,6 +1,7 @@
-import TravisRoute from 'travis/routes/basic';
+import Ember from 'ember';
+import BaseRouteMixin from 'travis/mixins/base-route';
 
-export default TravisRoute.extend({
+export default Ember.Route.extend(BaseRouteMixin, {
   titleToken(model) {
     return 'Build #' + (model.get('number'));
   },

--- a/app/routes/caches.js
+++ b/app/routes/caches.js
@@ -1,9 +1,9 @@
 import Ember from 'ember';
-import TravisRoute from 'travis/routes/basic';
+import BaseRouteMixin from 'travis/mixins/base-route';
 
 const { service } = Ember.inject;
 
-export default TravisRoute.extend({
+export default Ember.Route.extend(BaseRouteMixin, {
   ajax: service(),
   needsAuth: true,
 

--- a/app/routes/dashboard.js
+++ b/app/routes/dashboard.js
@@ -1,5 +1,6 @@
-import TravisRoute from 'travis/routes/basic';
+import Ember from 'ember';
+import BaseRouteMixin from 'travis/mixins/base-route';
 
-export default TravisRoute.extend({
+export default Ember.Route.extend(BaseRouteMixin, {
   needsAuth: true
 });

--- a/app/routes/dashboard/repositories.js
+++ b/app/routes/dashboard/repositories.js
@@ -1,8 +1,8 @@
 import Ember from 'ember';
-import TravisRoute from 'travis/routes/basic';
+import BaseRouteMixin from 'travis/mixins/base-route';
 import config from 'travis/config/environment';
 
-export default TravisRoute.extend({
+export default Ember.Route.extend(BaseRouteMixin, {
   queryParams: {
     filter: {
       replace: true

--- a/app/routes/error.js
+++ b/app/routes/error.js
@@ -1,6 +1,7 @@
-import TravisRoute from 'travis/routes/basic';
+import Ember from 'ember';
+import BaseRouteMixin from 'travis/mixins/base-route';
 
-export default TravisRoute.extend({
+export default Ember.Route.extend(BaseRouteMixin, {
   resetController(controller, isExiting/* , transition*/) {
     if (isExiting) {
       controller.set('message', null);

--- a/app/routes/getting-started.js
+++ b/app/routes/getting-started.js
@@ -1,7 +1,7 @@
-import TravisRoute from 'travis/routes/basic';
 import Ember from 'ember';
+import BaseRouteMixin from 'travis/mixins/base-route';
 
-export default TravisRoute.extend({
+export default Ember.Route.extend(BaseRouteMixin, {
   beforeModel() {
     if (!Ember.isEmpty(this.store.peekAll('repo'))) {
       this.transitionTo('/');

--- a/app/routes/home-pro.js
+++ b/app/routes/home-pro.js
@@ -1,5 +1,6 @@
-import TravisRoute from 'travis/routes/basic';
+import Ember from 'ember';
+import BaseRouteMixin from 'travis/mixins/base-route';
 
-export default TravisRoute.extend({
+export default Ember.Route.extend(BaseRouteMixin, {
   needsAuth: false
 });

--- a/app/routes/home.js
+++ b/app/routes/home.js
@@ -1,6 +1,7 @@
-import BasicRoute from 'travis/routes/basic';
+import Ember from 'ember';
+import BaseRouteMixin from 'travis/mixins/base-route';
 
-export default BasicRoute.extend({
+export default Ember.Route.extend(BaseRouteMixin, {
 
   model() {
     return { landingPage: true };

--- a/app/routes/job.js
+++ b/app/routes/job.js
@@ -1,6 +1,7 @@
-import TravisRoute from 'travis/routes/basic';
+import Ember from 'ember';
+import BaseRouteMixin from 'travis/mixins/base-route';
 
-export default TravisRoute.extend({
+export default Ember.Route.extend(BaseRouteMixin, {
   titleToken(model) {
     return 'Job #' + (model.get('number'));
   },

--- a/app/routes/logo.js
+++ b/app/routes/logo.js
@@ -1,5 +1,6 @@
-import TravisRoute from 'travis/routes/basic';
+import Ember from 'ember';
+import BaseRouteMixin from 'travis/mixins/base-route';
 
-export default TravisRoute.extend({
+export default Ember.Route.extend(BaseRouteMixin, {
   needsAuth: false
 });

--- a/app/routes/main-tab.js
+++ b/app/routes/main-tab.js
@@ -1,6 +1,7 @@
-import TravisRoute from 'travis/routes/basic';
+import Ember from 'ember';
+import BaseRouteMixin from 'travis/mixins/base-route';
 
-export default TravisRoute.extend({
+export default Ember.Route.extend(BaseRouteMixin, {
   renderTemplate() {
     this.render('repo');
     this.render('build', {

--- a/app/routes/main.js
+++ b/app/routes/main.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
-import TravisRoute from 'travis/routes/basic';
+import BaseRouteMixin from 'travis/mixins/base-route';
 
-export default TravisRoute.extend({
+export default Ember.Route.extend(BaseRouteMixin, {
   renderTemplate() {
     Ember.$('body').attr('id', 'home');
 

--- a/app/routes/main/index.js
+++ b/app/routes/main/index.js
@@ -1,6 +1,7 @@
-import TravisRoute from 'travis/routes/basic';
+import Ember from 'ember';
+import BaseRouteMixin from 'travis/mixins/base-route';
 
-export default TravisRoute.extend({
+export default Ember.Route.extend(BaseRouteMixin, {
   redirect() {
     if (this.signedIn()) {
       return this.transitionTo('main.repositories');

--- a/app/routes/main/my-repositories.js
+++ b/app/routes/main/my-repositories.js
@@ -1,6 +1,7 @@
-import TravisRoute from 'travis/routes/basic';
+import Ember from 'ember';
+import BaseRouteMixin from 'travis/mixins/base-route';
 
-export default TravisRoute.extend({
+export default Ember.Route.extend(BaseRouteMixin, {
   redirect() {
     return this.transitionTo('main.repositories');
   }

--- a/app/routes/not-found.js
+++ b/app/routes/not-found.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
-import TravisRoute from 'travis/routes/basic';
+import BaseRouteMixin from 'travis/mixins/base-route';
 
-export default TravisRoute.extend({
+export default Ember.Route.extend(BaseRouteMixin, {
   renderTemplate() {
     Ember.$('body').attr('id', 'not-found');
     return this.render('not_found');

--- a/app/routes/owner.js
+++ b/app/routes/owner.js
@@ -1,8 +1,8 @@
 import Ember from 'ember';
-import TravisRoute from 'travis/routes/basic';
+import BaseRouteMixin from 'travis/mixins/base-route';
 import config from 'travis/config/environment';
 
-export default TravisRoute.extend({
+export default Ember.Route.extend(BaseRouteMixin, {
   deactivate() {
     return this.controllerFor('loading').set('layoutName', null);
   },

--- a/app/routes/owner/repositories.js
+++ b/app/routes/owner/repositories.js
@@ -1,8 +1,8 @@
 import Ember from 'ember';
-import TravisRoute from 'travis/routes/basic';
+import BaseRouteMixin from 'travis/mixins/base-route';
 import config from 'travis/config/environment';
 
-export default TravisRoute.extend({
+export default Ember.Route.extend(BaseRouteMixin, {
   needsAuth: false,
 
   titleToken(model) {

--- a/app/routes/owner/running.js
+++ b/app/routes/owner/running.js
@@ -1,8 +1,8 @@
 import Ember from 'ember';
-import TravisRoute from 'travis/routes/basic';
+import BaseRouteMixin from 'travis/mixins/base-route';
 import config from 'travis/config/environment';
 
-export default TravisRoute.extend({
+export default Ember.Route.extend(BaseRouteMixin, {
   needsAuth: false,
 
   titleToken(model) {

--- a/app/routes/plans.js
+++ b/app/routes/plans.js
@@ -1,6 +1,7 @@
-import BasicRoute from 'travis/routes/basic';
+import Ember from 'ember';
+import BaseRouteMixin from 'travis/mixins/base';
 
-export default BasicRoute.extend({
+export default Ember.Route.extend(BaseRouteMixin, {
   needsAuth: false,
 
   redirect() {

--- a/app/routes/profile.js
+++ b/app/routes/profile.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
-import TravisRoute from 'travis/routes/basic';
+import BaseRouteMixin from 'travis/mixins/base-route';
 
-export default TravisRoute.extend({
+export default Ember.Route.extend(BaseRouteMixin, {
   titleToken: 'Profile',
   needsAuth: true,
 

--- a/app/routes/repo.js
+++ b/app/routes/repo.js
@@ -1,11 +1,16 @@
-import TravisRoute from 'travis/routes/basic';
-import Repo from 'travis/models/repo';
-import ScrollResetMixin from 'travis/mixins/scroll-reset';
 import Ember from 'ember';
+import BaseRouteMixin from 'travis/mixins/base-route';
+import ScrollResetMixin from 'travis/mixins/scroll-reset';
+import Repo from 'travis/models/repo';
 
 const { service } = Ember.inject;
 
-export default TravisRoute.extend(ScrollResetMixin, {
+const mixins = [
+  BaseRouteMixin,
+  ScrollResetMixin,
+];
+
+export default Ember.Route.extend(...mixins, {
   store: service(),
   tabStates: service(),
 

--- a/app/routes/repo/index.js
+++ b/app/routes/repo/index.js
@@ -1,6 +1,7 @@
-import TravisRoute from 'travis/routes/basic';
+import Ember from 'ember';
+import BaseRouteMixin from 'travis/mixins/base-route';
 
-export default TravisRoute.extend({
+export default Ember.Route.extend(BaseRouteMixin, {
   setupController(controller, model) {
     this._super(...arguments);
     this.controllerFor('repo').activate('current');

--- a/app/routes/requests.js
+++ b/app/routes/requests.js
@@ -1,6 +1,7 @@
-import TravisRoute from 'travis/routes/basic';
+import Ember from 'ember';
+import BaseRouteMixin from 'travis/mixins/base-route';
 
-export default TravisRoute.extend({
+export default Ember.Route.extend(BaseRouteMixin, {
   setupController() {
     this._super(...arguments);
     return this.controllerFor('repo').activate('requests');

--- a/app/routes/settings.js
+++ b/app/routes/settings.js
@@ -1,10 +1,10 @@
-import TravisRoute from 'travis/routes/basic';
-import config from 'travis/config/environment';
 import Ember from 'ember';
+import BaseRouteMixin from 'travis/mixins/base-route';
+import config from 'travis/config/environment';
 
 const { service } = Ember.inject;
 
-export default TravisRoute.extend({
+export default Ember.Route.extend(BaseRouteMixin, {
   ajax: service(),
   needsAuth: true,
 

--- a/app/routes/settings/index.js
+++ b/app/routes/settings/index.js
@@ -1,6 +1,7 @@
-import TravisRoute from 'travis/routes/basic';
+import Ember from 'ember';
+import BaseRouteMixin from 'travis/mixins/base-route';
 
-export default TravisRoute.extend({
+export default Ember.Route.extend(BaseRouteMixin, {
   titleToken: 'Settings',
 
   model() {

--- a/app/routes/signin.js
+++ b/app/routes/signin.js
@@ -1,9 +1,9 @@
 import Ember from 'ember';
-import TravisRoute from 'travis/routes/basic';
+import BaseRouteMixin from 'travis/mixins/base-route';
 
 const { service } = Ember.inject;
 
-export default TravisRoute.extend({
+export default Ember.Route.extend(BaseRouteMixin, {
   auth: service(),
   needsAuth: false,
 

--- a/app/routes/simple-layout.js
+++ b/app/routes/simple-layout.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
-import TravisRoute from 'travis/routes/basic';
+import BaseRouteMixin from 'travis/mixins/base-route';
 
-export default TravisRoute.extend({
+export default Ember.Route.extend(BaseRouteMixin, {
   setupController: function () {
     Ember.$('body').attr('id', 'simple');
     this.controllerFor('repos').activate('owned');

--- a/app/routes/team.js
+++ b/app/routes/team.js
@@ -1,6 +1,7 @@
-import TravisRoute from 'travis/routes/basic';
+import Ember from 'ember';
+import BaseRouteMixin from 'travis/mixins/base-route';
 
-export default TravisRoute.extend({
+export default Ember.Route.extend(BaseRouteMixin, {
   needsAuth: false,
 
   model() {


### PR DESCRIPTION
This is the first step in a series of refactorings to hopefully make the
transition to engines a bit easier.  Because we inherited from
`BasicRoute` in the Application route (and that route referenced another
controller), it was impossible to add a routable engine, as you can't
currently share controllers across the app/engine boundary, only
services/components.

This will also ensure that we're not doing more work than we need to. We
currently opt-in to a lot of behavior and overwrite framework hooks when
it's not entirely clear if that has to happen or not. We'll need to look
into this further to see if it's possible to break down the extracted
`BaseRouteMixin` further into even smaller chunks.

This doesn't actually fix the issue I highlighted with the controller
dependency, it's just the first step in that direction. Because I
converted the previous inheritance implementation, this should behave
identically.