### PR TITLE
Remove leading whitespace on feedback link

### DIFF
--- a/app/templates/components/beta-feature.hbs
+++ b/app/templates/components/beta-feature.hbs
@@ -3,8 +3,7 @@
   <span>{{feature.displayName}}</span>
   {{#if feature.feedbackUrl}}
     <small>
-      (<a href="{{feature.feedbackUrl}}" title="See the feedback ticket on GitHub">
-      We'd love some feedback!</a>)
+      (<a href="{{feature.feedbackUrl}}" title="See the feedback ticket on GitHub">We'd love some feedback!</a>)
     </small>
   {{/if}}
 </h2>


### PR DESCRIPTION
This removes the whitespace after the bracket:

![image](https://cloud.githubusercontent.com/assets/43280/23416826/53887f70-fd99-11e6-8b42-5a7157890157.png)
