### PR TITLE
Change the repo endpoint

### DIFF
--- a/app/components/not-active.js
+++ b/app/components/not-active.js
@@ -27,7 +27,7 @@ export default Ember.Component.extend({
     const repoId = this.get('repo.id');
 
     try {
-      const response = yield Ember.$.ajax(`${apiEndpoint}/v3/repo/${repoId}/enable`, {
+      const response = yield Ember.$.ajax(`${apiEndpoint}/v3/repo/${repoId}/activate`, {
         headers: {
           Authorization: `token ${this.get('auth').token()}`
         },


### PR DESCRIPTION
The endpoint for activating a repository changed in API V3 from `enable` to `activate`.

https://github.com/travis-pro/team-teal/issues/1756