### PR TITLE
[Backport] Disable "Debug Build" button in Enterprise (#955)

### DIFF
--- a/app/templates/components/repo-actions.hbs
+++ b/app/templates/components/repo-actions.hbs
@@ -21,16 +21,17 @@
         <span class="label-align">Restart {{type}}</span>
       </button>
     </div>
-
-    {{#if features.proVersion}}
-      {{#if canDebug}}
-        <div class='action-button-container'>
-          <button {{action (perform debug)}} class="action-button--debug tooltip" aria-label="Restart as debug {{type}}" data-tooltip='Restart as debug {{type}}' type="button">
-            {{inline-svg 'icon-debug' class="icon"}}
-            <span class="label-align">Debug {{type}}</span>
-          </button>
-        </div>
+    {{#unless features.enterpriseVersion}}
+      {{#if features.proVersion}}
+        {{#if canDebug}}
+          <div class='action-button-container'>
+            <button {{action (perform debug)}} class="action-button--debug tooltip" aria-label="Restart as debug {{type}}" data-tooltip='Restart as debug {{type}}' type="button">
+              {{inline-svg 'icon-debug' class="icon"}}
+              <span class="label-align">Debug {{type}}</span>
+            </button>
+          </div>
+        {{/if}}
       {{/if}}
-    {{/if}}
+    {{/unless}}
   {{/if}}
 {{/if}}


### PR DESCRIPTION
Backporting #955 for `enterprise-2.1` as Debug builds aren't available yet. 

