### PR TITLE
Remove usage of /v3 prefix

### DIFF
--- a/app/adapters/branch.js
+++ b/app/adapters/branch.js
@@ -1,14 +1,14 @@
-import ApplicationAdapter from 'travis/adapters/application';
+import V3Adapter from 'travis/adapters/v3';
 
-export default ApplicationAdapter.extend({
+export default V3Adapter.extend({
   query(store, type, query) {
     const repoId = query.repository_id;
     delete query.repository_id;
-    const url = `${this.urlPrefix()}/v3/repo/${repoId}/branches`;
+    const url = `${this.urlPrefix()}/repo/${repoId}/branches`;
     return this.ajax(url, 'GET', query);
   },
 
   findRecord(store, type, id) {
     return this.ajax(this.urlPrefix() + id, 'GET');
-  }
+  },
 });

--- a/app/adapters/cron.js
+++ b/app/adapters/cron.js
@@ -19,7 +19,7 @@ export default V3Adapter.extend({
   query(store, type, query) {
     const repoId = query['repository_id'];
     delete query['repository_id'];
-    const url = `${this.urlPrefix()}/v3/repo/${repoId}/crons`;
+    const url = `${this.urlPrefix()}/repo/${repoId}/crons`;
     return this.ajax(url, 'GET', query);
   }
 

--- a/app/components/branch-row.js
+++ b/app/components/branch-row.js
@@ -37,10 +37,11 @@ export default Ember.Component.extend({
       options = {};
       if (this.get('auth.signedIn')) {
         options.headers = {
-          Authorization: `token ${this.auth.token()}`
+          Authorization: `token ${this.auth.token()}`,
+          'Travis-API-Version': '3'
         };
       }
-      let path = `${apiEndpoint}/v3/repo/${repoId}/builds`;
+      let path = `${apiEndpoint}/repo/${repoId}/builds`;
       let params = `?branch.name=${branchName}&limit=5&build.event_type=push,api,cron`;
       let url = `${path}${params}`;
 

--- a/app/components/dashboard-row.js
+++ b/app/components/dashboard-row.js
@@ -42,7 +42,7 @@ export default Ember.Component.extend({
     let data = {};
     data.request = `{ 'branch': '${this.get('repo.defaultBranch.name')}' }`;
 
-    this.get('ajax').ajax(`/v3/repo/${this.get('repo.id')}/requests`, 'POST', { data })
+    this.get('ajax').postV3(`/repo/${this.get('repo.id')}/requests`, data)
       .then(() => {
         self.set('isTriggering', false);
         self.get('flashes')

--- a/app/components/no-builds.js
+++ b/app/components/no-builds.js
@@ -6,9 +6,10 @@ export default Ember.Component.extend({
   triggerBuild: task(function* () {
     const apiEndpoint = config.apiEndpoint;
 
-    yield Ember.$.ajax(`${apiEndpoint}/v3/repo/${this.get('repo.repo.id')}/requests`, {
+    yield Ember.$.ajax(`${apiEndpoint}/repo/${this.get('repo.repo.id')}/requests`, {
       headers: {
-        Authorization: `token ${this.get('repo.auth')}`
+        Authorization: `token ${this.get('repo.auth')}`,
+        'Travis-API-Version': '3'
       },
       type: 'POST'
     });

--- a/app/components/not-active.js
+++ b/app/components/not-active.js
@@ -27,9 +27,10 @@ export default Ember.Component.extend({
     const repoId = this.get('repo.id');
 
     try {
-      const response = yield Ember.$.ajax(`${apiEndpoint}/v3/repo/${repoId}/activate`, {
+      const response = yield Ember.$.ajax(`${apiEndpoint}/repo/${repoId}/activate`, {
         headers: {
-          Authorization: `token ${this.get('auth').token()}`
+          Authorization: `token ${this.get('auth').token()}`,
+          'Travis-API-Version': '3'
         },
         method: 'POST'
       });

--- a/app/components/status-images.js
+++ b/app/components/status-images.js
@@ -30,11 +30,12 @@ export default Ember.Component.extend({
 
       if (this.get('auth.signedIn')) {
         options.headers = {
-          Authorization: `token ${this.auth.token()}`
+          Authorization: `token ${this.auth.token()}`,
+          'Travis-API-Version': '3'
         };
       }
 
-      let url = `${apiEndpoint}/v3/repo/${repoId}/branches?limit=100`;
+      let url = `${apiEndpoint}/repo/${repoId}/branches?limit=100`;
       Ember.$.ajax(url, options).then(response => {
         if (response.branches.length) {
           let branchNames = response.branches.map(branch => branch.name);

--- a/app/controllers/dashboard/repositories.js
+++ b/app/controllers/dashboard/repositories.js
@@ -18,7 +18,7 @@ export default Ember.Controller.extend({
   star: task(function * (repo) {
     repo.set('starred', true);
     try {
-      yield this.get('ajax').ajax(`/v3/repo/${repo.get('id')}/star`, 'POST');
+      yield this.get('ajax').postV3(`/repo/${repo.get('id')}/star`);
     } catch (e) {
       repo.set('starred', false);
       this.get('flashes')
@@ -30,7 +30,7 @@ export default Ember.Controller.extend({
   unstar: task(function * (repo) {
     repo.set('starred', false);
     try {
-      yield this.get('ajax').ajax(`/v3/repo/${repo.get('id')}/unstar`, 'POST');
+      yield this.get('ajax').postV3(`/repo/${repo.get('id')}/unstar`);
     } catch (e) {
       repo.set('starred', true);
       this.get('flashes')

--- a/app/routes/branches.js
+++ b/app/routes/branches.js
@@ -15,11 +15,12 @@ export default TravisRoute.extend({
     options = {};
     if (this.get('auth.signedIn')) {
       options.headers = {
-        Authorization: 'token ' + (this.auth.token())
+        Authorization: 'token ' + (this.auth.token()),
+        'Travis-API-Version': '3'
       };
     }
 
-    let path = `${apiEndpoint}/v3/repo/${repoId}/branches`;
+    let path = `${apiEndpoint}/repo/${repoId}/branches`;
     let includes = 'build.commit&limit=100';
     let url = `${path}?include=${includes}`;
 

--- a/app/routes/owner.js
+++ b/app/routes/owner.js
@@ -12,13 +12,14 @@ export default TravisRoute.extend({
     options = {};
     if (this.get('auth.signedIn')) {
       options.headers = {
-        Authorization: 'token ' + (this.auth.token())
+        Authorization: 'token ' + (this.auth.token()),
+        'Travis-API-Version': '3'
       };
     }
     let { owner } = params;
     let { apiEndpoint } = config;
     let includes = '?include=organization.repositories,repository.default_branch,build.commit';
-    let url = `${apiEndpoint}/v3/owner/${owner}${includes}`;
+    let url = `${apiEndpoint}/owner/${owner}${includes}`;
     return Ember.$.ajax(url, options);
   },
 

--- a/app/routes/owner/repositories.js
+++ b/app/routes/owner/repositories.js
@@ -16,14 +16,15 @@ export default TravisRoute.extend({
 
     if (this.get('auth.signedIn')) {
       options.headers = {
-        Authorization: 'token ' + (this.auth.token())
+        Authorization: 'token ' + (this.auth.token()),
+        'Travis-API-Version': '3'
       };
     }
 
     // eslint-disable-next-line
     let includes = `?include=owner.repositories,repository.default_branch,build.commit,repository.current_build`;
     let { owner } = transition.params.owner;
-    let url = `${config.apiEndpoint}/v3/owner/${owner}${includes}`;
+    let url = `${config.apiEndpoint}/owner/${owner}${includes}`;
     return Ember.$.ajax(url, options);
   }
 });

--- a/app/routes/owner/running.js
+++ b/app/routes/owner/running.js
@@ -13,6 +13,11 @@ export default TravisRoute.extend({
     let includes =
       '?include=user.repositories,organization.repositories,build.commit,repository.active';
     let { owner } = transition.params.owner;
-    return Ember.$.get(`${config.apiEndpoint}/v3/owner/${owner}${includes}`);
+    return Ember.$.ajax({
+      url: `${config.apiEndpoint}/owner/${owner}${includes}`,
+      headers: {
+        'Travis-API-Version': '3'
+      }
+    });
   }
 });

--- a/app/routes/settings.js
+++ b/app/routes/settings.js
@@ -72,9 +72,10 @@ export default TravisRoute.extend({
     const repoId = this.modelFor('repo').get('id');
     const apiEndpoint = config.apiEndpoint;
 
-    return Ember.$.ajax(apiEndpoint + '/v3/repo/' + repoId, {
+    return Ember.$.ajax(apiEndpoint + '/repo/' + repoId, {
       headers: {
-        Authorization: 'token ' + this.auth.token()
+        Authorization: 'token ' + this.auth.token(),
+        'Travis-API-Version': '3'
       }
     }).then(function (response) {
       return response.active;

--- a/app/services/broadcasts.js
+++ b/app/services/broadcasts.js
@@ -22,7 +22,8 @@ export default Ember.Service.extend({
       options = {};
       options.type = 'GET';
       options.headers = {
-        Authorization: `token ${this.get('auth').token()}`
+        Authorization: `token ${this.get('auth').token()}`,
+        'Travis-API-Version': '3'
       };
       seenBroadcasts = this.get('storage').getItem('travis.seen_broadcasts');
       if (seenBroadcasts) {
@@ -30,7 +31,7 @@ export default Ember.Service.extend({
       } else {
         seenBroadcasts = [];
       }
-      Ember.$.ajax(`${apiEndpoint}/v3/broadcasts`, options).then((response) => {
+      Ember.$.ajax(`${apiEndpoint}/broadcasts`, options).then((response) => {
         const receivedBroadcasts = response.broadcasts.reduce((processed, broadcast) => {
           if (!broadcast.expired && seenBroadcasts.indexOf(broadcast.id.toString()) === -1) {
             processed.unshift(Ember.Object.create(broadcast));

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -54,7 +54,7 @@ export default function () {
     }
   });
 
-  this.get('/v3/broadcasts', schema => {
+  this.get('/broadcasts', schema => {
     return schema.broadcasts.all();
   });
 
@@ -62,15 +62,20 @@ export default function () {
     return schema.repositories.all();
   });
 
-  this.get('/repo/:slug', function (schema, request) {
-    let repos = schema.repositories.where({ slug: decodeURIComponent(request.params.slug) });
+  this.get('/repo/:slug_or_id', function (schema, request) {
+    if (request.params.slug_or_id.match(/^\d+$/)) {
+      return schema.repositories.find(request.params.slug_or_id);
+    } else {
+      let slug = request.params.slug_or_id;
+      let repos = schema.repositories.where({ slug: decodeURIComponent(slug) });
 
-    return {
-      repo: repos.models[0].attrs
-    };
+      return {
+        repo: repos.models[0].attrs
+      };
+    }
   });
 
-  this.get('/v3/repo/:repositoryId/crons', function (schema, request) {
+  this.get('/repo/:repositoryId/crons', function (schema, request) {
     const { repositoryId } = request.params;
     return this.serialize(schema.crons.where({ repositoryId }), 'cron');
   });
@@ -106,15 +111,11 @@ export default function () {
     };
   });
 
-  this.get('/v3/repo/:id', function (schema, request) {
-    return schema.repositories.find(request.params.id);
-  });
-
-  this.get('/v3/repo/:repository_id/branches', function (schema) {
+  this.get('/repo/:repository_id/branches', function (schema) {
     return schema.branches.all();
   });
 
-  this.get('/v3/owner/:login', function (schema, request) {
+  this.get('/owner/:login', function (schema, request) {
     return this.serialize(schema.users.where({ login: request.params.login }).models[0], 'owner');
   });
 
@@ -236,7 +237,7 @@ export default function () {
     }
   });
 
-  this.get('/v3/repo/:repo_id/builds', function (schema, request) {
+  this.get('/repo/:repo_id/builds', function (schema, request) {
     const branch = schema.branches.where({ name: request.queryParams['branch.name'] }).models[0];
     const builds = schema.builds.where({ branchId: branch.id });
 


### PR DESCRIPTION
There's a mix of /v3 prefix and Travis-API-Version header usage in the
app, which makes it hard to maintain the mirage config. This commit
unifies usage of V3 calls to always use a header version.