### PR TITLE
Remove isNewSerializerAPI flag from serializers

### DIFF
--- a/app/serializers/application.js
+++ b/app/serializers/application.js
@@ -1,5 +1,4 @@
 import V2FallbackSerializer from 'travis/serializers/v2_fallback';
 
 export default V2FallbackSerializer.extend({
-  isNewSerializerAPI: true
 });

--- a/app/serializers/build.js
+++ b/app/serializers/build.js
@@ -1,7 +1,6 @@
 import V2FallbackSerializer from 'travis/serializers/v2_fallback';
 
 var Serializer = V2FallbackSerializer.extend({
-  isNewSerializerAPI: true,
   attrs: {
     _config: { key: 'config' },
     _finishedAt: { key: 'finished_at' },

--- a/app/serializers/cron.js
+++ b/app/serializers/cron.js
@@ -1,7 +1,6 @@
 import V3Serializer from 'travis/serializers/v3';
 
 const Serializer = V3Serializer.extend({
-  isNewSerializerAPI: true,
 });
 
 export default Serializer;

--- a/app/serializers/job.js
+++ b/app/serializers/job.js
@@ -1,7 +1,6 @@
 import V2FallbackSerializer from 'travis/serializers/v2_fallback';
 
 export default V2FallbackSerializer.extend({
-  isNewSerializerAPI: true,
   attrs: {
     _config: { key: 'config' },
     _finishedAt: { key: 'finished_at' },

--- a/app/serializers/repo.js
+++ b/app/serializers/repo.js
@@ -2,7 +2,6 @@ import V2FallbackSerializer from 'travis/serializers/v2_fallback';
 import EmbeddedRecordsMixin from 'ember-data/serializers/embedded-records-mixin';
 
 var Serializer = V2FallbackSerializer.extend(EmbeddedRecordsMixin, {
-  isNewSerializerAPI: true,
 
   attrs: {
     permissions: { key: '@permissions' }

--- a/app/serializers/request.js
+++ b/app/serializers/request.js
@@ -1,7 +1,6 @@
 import V2FallbackSerializer from 'travis/serializers/v2_fallback';
 
 var Serializer = V2FallbackSerializer.extend({
-  isNewSerializerAPI: true,
 
   keyForV2Relationship: function (key/* , typeClass, method*/) {
     if (key === 'repo') {

--- a/app/serializers/v2_fallback.js
+++ b/app/serializers/v2_fallback.js
@@ -1,7 +1,6 @@
 import V3Serializer from 'travis/serializers/v3';
 
 export default V3Serializer.extend({
-  isNewSerializerAPI: true,
 
   extractRelationships(modelClass, resourceHash) {
     if (resourceHash['@type']) {

--- a/app/serializers/v3.js
+++ b/app/serializers/v3.js
@@ -25,7 +25,6 @@ var traverse = function (object, callback) {
 };
 
 export default JSONSerializer.extend({
-  isNewSerializerAPI: true,
 
   extractRelationship(type, hash) {
     if (hash && !hash.id && hash['@href']) {


### PR DESCRIPTION
This flag is no longer used and new serializer's API is the default