### PR TITLE
Remove optional Mirage logging

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -292,15 +292,6 @@ export default function () {
     feature.update('enabled', requestBody.enabled);
     return this.serialize(feature);
   });
-
-  // UNCOMMENT THIS FOR LOGGING OF HANDLED REQUESTS
-  // this.pretender.handledRequest = function (verb, path, request) {
-  //   console.log('Handled this request:', `${verb} ${path}`, request);
-  //   try {
-  //     const responseJson = JSON.parse(request.responseText);
-  //     console.log(responseJson);
-  //   } catch (e) {}
-  // };
 }
 
 /*


### PR DESCRIPTION
This is superseded by the server.logging = true option:
http://www.ember-cli-mirage.com/docs/v0.2.x/configuration/#logging