### PR TITLE
Fix repo relationship serialization

### DIFF
--- a/app/serializers/v2_fallback.js
+++ b/app/serializers/v2_fallback.js
@@ -94,6 +94,10 @@ export default V3Serializer.extend({
   },
 
   keyForV2Relationship(key/* , typeClass, method*/) {
-    return key.underscore() + '_id';
+    if (key === 'repo') {
+      return 'repository';
+    } else {
+      return key.underscore() + '_id';
+    }
   }
 });

--- a/app/serializers/v3.js
+++ b/app/serializers/v3.js
@@ -33,7 +33,7 @@ export default JSONSerializer.extend({
 
     let relationshipHash = this._super(...arguments);
     if (relationshipHash && relationshipHash['@type']) {
-      relationshipHash.type = relationshipHash['@type'];
+      relationshipHash.type = this.getType(relationshipHash['@type']);
     } else if (relationshipHash && !relationshipHash.type) {
       relationshipHash.type = type;
     }
@@ -41,7 +41,9 @@ export default JSONSerializer.extend({
   },
 
   keyForRelationship(key/* , typeClass, method*/) {
-    if (key && key.underscore) {
+    if (key === 'repo') {
+      return 'repository';
+    } else if (key && key.underscore) {
       return key.underscore();
     } else {
       return key;
@@ -107,13 +109,13 @@ export default JSONSerializer.extend({
     let store = this.store;
 
     if (data.relationships) {
-      Object.keys(data.relationships).forEach(function (key) {
+      Object.keys(data.relationships).forEach((key) => {
         let relationship = data.relationships[key];
-        let process = function (data) {
+        let process = (data) => {
           if (data['@representation'] !== 'standard') {
             return;
           }
-          let type = data['@type'];
+          let type = this.getType(data['@type']);
           let serializer = store.serializerFor(type);
           let modelClass = store.modelFor(type);
           let normalized = serializer.normalize(modelClass, data);
@@ -138,6 +140,10 @@ export default JSONSerializer.extend({
 
   keyForAttribute(key) {
     return Ember.String.underscore(key);
+  },
+
+  getType(type) {
+    return type === 'repository' ? 'repo' : type;
   },
 
   _fixReferences(payload) {

--- a/tests/unit/serializers/env-var-test.js
+++ b/tests/unit/serializers/env-var-test.js
@@ -1,0 +1,44 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('envVar', 'Unit | Serializer | envVar', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:envVar', 'model:commit', 'model:job', 'model:branch', 'model:repo', 'model:envVar']
+});
+
+test('it normalizes a V2 array response', function (assert) {
+  let payload = {
+    'env_vars': [{
+      'id': '7af987bc-412e-4bfd-9654-b4fec2dbadd3',
+      'name': 'FOO',
+      'value': 'bar',
+      'public': true,
+      'repository_id': 1
+    }]
+  };
+
+  let store = this.store();
+  let serializer = store.serializerFor('envVar');
+  let result = serializer.normalize(store.modelFor('envVar'), payload.env_vars[0]);
+  let expectedResult = {
+    'data': {
+      'id': '7af987bc-412e-4bfd-9654-b4fec2dbadd3',
+      'type': 'env-var',
+      'attributes': {
+        'name': 'FOO',
+        'value': 'bar',
+        'public': true
+      },
+      'relationships': {
+        'repo': {
+          'data': {
+            'id': '1',
+            'type': 'repo'
+          }
+        }
+      }
+    },
+    'included': []
+  };
+
+  assert.deepEqual(result, expectedResult);
+});


### PR DESCRIPTION
While working on test's serializers I noticed that when a response
contains nested repository objects (for example when build embeds jobs
with a repository object), the serializer will fail, because it will
mismatch `repository` type that API sends with our model type in
travis-web - `repo`. This is not a problem on production at the moment,
because we don't query any endpoints that return such a result, but it's
still good to handle this situation for future proofing serializers.