### PR TITLE
Try fetching job's config multiple times if it doesn't succeed

### DIFF
--- a/app/models/job.js
+++ b/app/models/job.js
@@ -64,14 +64,26 @@ export default Model.extend(DurationCalculations, {
     let config = this.get('_config');
     if (config) {
       return _object.pickBy(config);
-    } else if (this.get('currentState.stateName') !== 'root.loading') {
-      if (this.get('isFetchingConfig')) {
-        return;
-      }
-      this.set('isFetchingConfig', true);
-      return this.reload();
+    } else {
+      let fetchConfig = () => {
+        if (this.getCurrentState() !== 'root.loading') {
+          if (this.get('isFetchingConfig')) {
+            return;
+          }
+          this.set('isFetchingConfig', true);
+          this.reload();
+        } else {
+          Ember.run.later(fetchConfig, 20);
+        }
+      };
+
+      fetchConfig();
     }
   }),
+
+  getCurrentState() {
+    return this.get('currentState.stateName');
+  },
 
   @computed('state')
   isFinished(state) {

--- a/tests/unit/models/job-test.js
+++ b/tests/unit/models/job-test.js
@@ -5,6 +5,37 @@ moduleForModel('job', 'Unit | Model | job', {
   needs: ['model:repo', 'model:build', 'model:commit']
 });
 
+test('config is fetched if it\'s not available', function (assert) {
+  assert.expect(1);
+  let done = assert.async();
+
+  const model = this.subject();
+  Ember.run(function () {
+    return model.setProperties({
+      _config: null
+    });
+  });
+
+  let oldGetCurrentState = model.getCurrentState;
+  model.getCurrentState = function () {
+    return 'root.loading';
+  };
+
+  model.reload = function () {
+    assert.ok(true);
+  };
+
+  model.get('config');
+
+  setTimeout(function () {
+    model.getCurrentState = oldGetCurrentState;
+  }, 30);
+
+  setTimeout(function () {
+    done();
+  }, 60);
+});
+
 test('created state', function (assert) {
   const model = this.subject();
   Ember.run(function () {


### PR DESCRIPTION
From commit message:

```
Not all of the endpoints return job's config. Because of that we try to
fetch job's config if it doesn't exist. The problem is that till now we
were trying to fetch it only once and we were giving up if the record
was loading. That means that if a config property is accessed while
loading, we will just return it as `undefined` and not attempt a second
try. I haven't noticed this problem in production, but it happened
during tests, so I guess it could happen on production as well.

This commit fixes the situation by retrying until we can do an actual
request.
```

I haven't added tests here, because I'm not sure what would be the best way to reliably test it. I'll think about it.