### PR TITLE
[Enterprise Backport] Use host without path when dealing with hrefs from API V3 (#1006)

### DIFF
--- a/app/adapters/cron.js
+++ b/app/adapters/cron.js
@@ -7,7 +7,7 @@ export default V3Adapter.extend({
     const serializer = store.serializerFor(type.modelName);
     serializer.serializeIntoHash(data, type, record, {});
 
-    const url = `${this.urlPrefix()}${data.branch}/cron`;
+    const url = `${this.getHost()}${data.branch}/cron`;
     return this.ajax(url, 'POST', {
       data: {
         dont_run_if_recent_build_exists: data.dont_run_if_recent_build_exists,

--- a/app/adapters/v3.js
+++ b/app/adapters/v3.js
@@ -54,4 +54,15 @@ export default RESTAdapter.extend({
     const underscored = Ember.String.underscore(modelName);
     return id ? underscored :  Ember.String.pluralize(underscored);
   },
+
+  // Get the host alone, without a path
+  getHost() {
+    let match = this.host.match(/(https?:\/\/)?([^\/]+)/);
+
+    if (match) {
+      return match[0];
+    } else {
+      return config.apiEndpoint;
+    }
+  }
 });


### PR DESCRIPTION
Backporting #1006 for `enterprise-2.1`



--------------------------
We use API's returned `@href` in cron's adapter. As API returns the full
path, it will also return any prefix that server uses, for example if
the API is ran at https://example.com/api, the returned `@href` might look
like `/api/v3/repo/1`. That's why when we use hrefs from the API V3 we
need to attach them to a bare host, without a path prefix.

/cc @drogus - just an FYI since it's your work being backported! <3 