### PR TITLE
Make sure that repo has owner name and name in tests

### DIFF
--- a/mirage/serializers/repository.js
+++ b/mirage/serializers/repository.js
@@ -2,6 +2,8 @@ import V3Serializer from './v3';
 
 export default V3Serializer.extend({
   serializeSingle(repository) {
+    this.fixOwnerAndName(repository);
+
     if (!repository.defaultBranch && repository.branches) {
       let defaultBranch = repository.branches.models.find(branch => branch.default_branch);
       repository.defaultBranch = defaultBranch;
@@ -19,5 +21,27 @@ export default V3Serializer.extend({
     }
 
     return V3Serializer.prototype.serializeSingle.apply(this, arguments);
+  },
+
+  // In most tests we just set slug for the repo. This ensures that we return
+  // also name and owner data to make the payload more similar to what we get in
+  // production.
+  fixOwnerAndName(repository) {
+    let owner, name,
+      attrs = repository.attrs;
+
+    if (attrs.slug) {
+      [owner, name] = attrs.slug.split('/');
+    }
+
+    attrs.owner = attrs.owner || {};
+
+    if (owner && !attrs.owner.login) {
+      attrs.owner.login = owner;
+    }
+
+    if (name && !attrs.name) {
+      attrs.name = name;
+    }
   }
 });


### PR DESCRIPTION
In most tests we only set a slug for a repository. This works fine in
most cases, but has a drawback of not displaying a proper owner name and
name in the UI. This commit fixes the situation by setting owner name and
name based on slug if needed.