### PR TITLE
Fix serializers for nested relationships

### DIFF
--- a/app/serializers/build.js
+++ b/app/serializers/build.js
@@ -63,6 +63,20 @@ var Serializer = V2FallbackSerializer.extend({
       // value. This line makes V3 payloads also populate pull_request property
       resourceHash['pull_request'] = true;
     }
+    // when we get the commit from V3 we need to put a branch on a commit as the
+    // current commit model expects it
+    if (type && commit && resourceHash.branch && !commit.branch) {
+      let name = resourceHash.branch.name;
+      if (!name) {
+        let match = resourceHash.branch['@href'].match(/\/repo\/.*?\/branch\/(.*)/);
+        if (match) {
+          name = match[1];
+        }
+      }
+      if (name) {
+        commit.branch = name;
+      }
+    }
     if (!type && commit && commit.hasOwnProperty('branch_is_default')) {
       let build = resourceHash.build,
         commit = resourceHash.commit;

--- a/app/serializers/build.js
+++ b/app/serializers/build.js
@@ -1,48 +1,11 @@
-import V2FallbackSerializer from 'travis/serializers/v2_fallback';
+import BuildV2FallbackSerializer from 'travis/serializers/build_v2_fallback';
 
-var Serializer = V2FallbackSerializer.extend({
+var Serializer = BuildV2FallbackSerializer.extend({
   attrs: {
     _config: { key: 'config' },
     _finishedAt: { key: 'finished_at' },
     _startedAt: { key: 'started_at' },
     _duration: { key: 'duration' }
-  },
-
-  extractRelationships: function (modelClass, resourceHash) {
-    return this._super(modelClass, resourceHash);
-  },
-
-  normalizeSingleResponse: function (store, primaryModelClass, payload/* , id, requestType*/) {
-    if (payload.commit) {
-      payload.build.commit = payload.commit;
-      delete payload.build.commit_id;
-    }
-    return this._super(...arguments);
-  },
-
-  normalizeArrayResponse: function (store, primaryModelClass, payload/* , id, requestType*/) {
-    if (payload.commits) {
-      payload.builds.forEach(function (build) {
-        let commit = payload.commits.findBy('id', build.commit_id);
-        if (commit) {
-          build.commit = commit;
-          return delete build.commit_id;
-        }
-      });
-    }
-    return this._super(...arguments);
-  },
-
-  keyForV2Relationship: function (key/* , typeClass, method*/) {
-    if (key === 'jobs') {
-      return 'job_ids';
-    } else if (key === 'repo') {
-      return 'repository_id';
-    } else if (key === 'commit') {
-      return key;
-    } else {
-      return this._super(...arguments);
-    }
   },
 
   keyForRelationship(key/* , typeClass, method*/) {
@@ -54,54 +17,11 @@ var Serializer = V2FallbackSerializer.extend({
   },
 
   normalize: function (modelClass, resourceHash) {
-    // TODO: remove this after switching to V3 entirely
-    let type = resourceHash['@type'];
-    let commit = resourceHash.commit;
     if (resourceHash['event_type'] == 'pull_request' &&
           !resourceHash.hasOwnProperty('pull_request')) {
       // in V3 we don't return "pull_request" property as we rely on event_type
       // value. This line makes V3 payloads also populate pull_request property
       resourceHash['pull_request'] = true;
-    }
-    // when we get the commit from V3 we need to put a branch on a commit as the
-    // current commit model expects it
-    if (type && commit && resourceHash.branch && !commit.branch) {
-      let name = resourceHash.branch.name;
-      if (!name) {
-        let match = resourceHash.branch['@href'].match(/\/repo\/.*?\/branch\/(.*)/);
-        if (match) {
-          name = match[1];
-        }
-      }
-      if (name) {
-        commit.branch = name;
-      }
-    }
-    if (!type && commit && commit.hasOwnProperty('branch_is_default')) {
-      let build = resourceHash.build,
-        commit = resourceHash.commit;
-      let branch = {
-        name: commit.branch,
-        default_branch: commit.branch_is_default,
-        '@href': `/repo/${build.repository_id}/branch/${commit.branch}`
-      };
-      resourceHash.build.branch = branch;
-    }
-
-    // fix pusher payload, it doesn't include a branch record:
-    if (!resourceHash['@type'] && resourceHash.build &&
-       resourceHash.repository && resourceHash.repository.default_branch) {
-      let branchName = resourceHash.build.branch,
-        repository = resourceHash.repository,
-        defaultBranchName = repository.default_branch.name;
-
-      resourceHash.build.branch = {
-        name: branchName,
-        default_branch: branchName === defaultBranchName,
-        '@href': `/repo/${repository.id}/branch/${branchName}`
-      };
-
-      repository.default_branch['@href'] = `/repo/${repository.id}/branch/${defaultBranchName}`;
     }
 
     return this._super(modelClass, resourceHash);

--- a/app/serializers/build_v2_fallback.js
+++ b/app/serializers/build_v2_fallback.js
@@ -1,0 +1,86 @@
+import V2FallbackSerializer from 'travis/serializers/v2_fallback';
+
+var Serializer = V2FallbackSerializer.extend({
+  normalizeSingleResponse: function (store, primaryModelClass, payload/* , id, requestType*/) {
+    if (!payload['@type'] && payload.commit) {
+      payload.build.commit = payload.commit;
+      delete payload.build.commit_id;
+    }
+    return this._super(...arguments);
+  },
+
+  normalizeArrayResponse: function (store, primaryModelClass, payload/* , id, requestType*/) {
+    if (payload.commits) {
+      payload.builds.forEach(function (build) {
+        let commit = payload.commits.findBy('id', build.commit_id);
+        if (commit) {
+          build.commit = commit;
+          return delete build.commit_id;
+        }
+      });
+    }
+    return this._super(...arguments);
+  },
+
+  keyForV2Relationship: function (key/* , typeClass, method*/) {
+    if (key === 'jobs') {
+      return 'job_ids';
+    } else if (key === 'repo') {
+      return 'repository_id';
+    } else if (key === 'commit') {
+      return key;
+    } else {
+      return this._super(...arguments);
+    }
+  },
+
+  normalize: function (modelClass, resourceHash) {
+    // TODO: remove this after switching to V3 entirely
+    let type = resourceHash['@type'];
+    let commit = resourceHash.commit;
+    // when we get the commit from V3 we need to put a branch on a commit as the
+    // current commit model expects it
+    if (type && commit && resourceHash.branch && !commit.branch) {
+      let name = resourceHash.branch.name;
+      if (!name) {
+        let match = resourceHash.branch['@href'].match(/\/repo\/.*?\/branch\/(.*)/);
+        if (match) {
+          name = match[1];
+        }
+      }
+      if (name) {
+        commit.branch = name;
+      }
+    }
+    if (!type && commit && commit.hasOwnProperty('branch_is_default')) {
+      let build = resourceHash.build,
+        commit = resourceHash.commit;
+      let branch = {
+        name: commit.branch,
+        default_branch: commit.branch_is_default,
+        '@href': `/repo/${build.repository_id}/branch/${commit.branch}`
+      };
+      resourceHash.build.branch = branch;
+    }
+
+    // fix pusher payload, it doesn't include a branch record:
+    if (!resourceHash['@type'] && resourceHash.build &&
+       resourceHash.repository && resourceHash.repository.default_branch) {
+      let branchName = resourceHash.build.branch,
+        repository = resourceHash.repository,
+        defaultBranchName = repository.default_branch.name;
+
+      resourceHash.build.branch = {
+        name: branchName,
+        default_branch: branchName === defaultBranchName,
+        '@href': `/repo/${repository.id}/branch/${branchName}`
+      };
+
+      repository.default_branch['@href'] = `/repo/${repository.id}/branch/${defaultBranchName}`;
+    }
+
+    return this._super(modelClass, resourceHash);
+  }
+});
+
+export default Serializer;

--- a/app/serializers/commit.js
+++ b/app/serializers/commit.js
@@ -7,8 +7,8 @@ export default V2FallbackSerializer.extend({
       resourceHash.author_avatar_url = resourceHash.author.avatar_url;
     }
     if (resourceHash.committer && resourceHash.committer.name) {
-      resourceHash.committer_name = resourceHash.author.name;
-      resourceHash.committer_avatar_url  = resourceHash.author.avatar_url;
+      resourceHash.committer_name = resourceHash.committer.name;
+      resourceHash.committer_avatar_url  = resourceHash.committer.avatar_url;
     }
     return this._super(...arguments);
   }

--- a/app/serializers/job.js
+++ b/app/serializers/job.js
@@ -1,48 +1,9 @@
-import V2FallbackSerializer from 'travis/serializers/v2_fallback';
+import JobV2FallbackSerializer from 'travis/serializers/job_v2_fallback';
 
-export default V2FallbackSerializer.extend({
+export default JobV2FallbackSerializer.extend({
   attrs: {
     _config: { key: 'config' },
     _finishedAt: { key: 'finished_at' },
     _startedAt: { key: 'started_at' }
-  },
-
-  keyForV2Relationship(key/* , typeClass, method*/) {
-    if (key === 'repo') {
-      return 'repository_id';
-    } else {
-      return this._super(...arguments);
-    }
-  },
-
-  normalize(modelClass, resourceHash) {
-    if (resourceHash.commit) {
-      resourceHash.commit['type'] = 'commit';
-    }
-
-    return this._super(modelClass, resourceHash);
-  },
-
-  normalizeSingleResponse: function (store, primaryModelClass, payload/* , id, requestType*/) {
-    if (payload.commit) {
-      payload.job.commit = payload.commit;
-      delete payload.job.commit_id;
-    }
-    return this._super(...arguments);
-  },
-
-  normalizeArrayResponse: function (store, primaryModelClass, payload/* , id, requestType*/) {
-    if (payload.commits) {
-      payload.jobs.forEach(function (job) {
-        let commit = payload.commits.findBy('id', job.commit_id);
-        if (commit) {
-          job.commit = commit;
-          return delete job.commit_id;
-        }
-      });
-    }
-    return this._super(...arguments);
   }
-
-
 });

--- a/app/serializers/job_v2_fallback.js
+++ b/app/serializers/job_v2_fallback.js
@@ -1,0 +1,42 @@
+import V2FallbackSerializer from 'travis/serializers/v2_fallback';
+
+export default V2FallbackSerializer.extend({
+  keyForV2Relationship(key/* , typeClass, method*/) {
+    if (key === 'repo') {
+      return 'repository_id';
+    } else {
+      return this._super(...arguments);
+    }
+  },
+
+  normalize(modelClass, resourceHash) {
+    if (resourceHash.commit) {
+      resourceHash.commit['type'] = 'commit';
+    }
+
+    return this._super(modelClass, resourceHash);
+  },
+
+  normalizeSingleResponse: function (store, primaryModelClass, payload/* , id, requestType*/) {
+    if (payload.commit) {
+      payload.job.commit = payload.commit;
+      delete payload.job.commit_id;
+    }
+    return this._super(...arguments);
+  },
+
+  normalizeArrayResponse: function (store, primaryModelClass, payload/* , id, requestType*/) {
+    if (payload.commits) {
+      payload.jobs.forEach(function (job) {
+        let commit = payload.commits.findBy('id', job.commit_id);
+        if (commit) {
+          job.commit = commit;
+          return delete job.commit_id;
+        }
+      });
+    }
+    return this._super(...arguments);
+  }
+
+
+});

--- a/app/serializers/v2_fallback.js
+++ b/app/serializers/v2_fallback.js
@@ -1,4 +1,6 @@
+import Ember from 'ember';
 import V3Serializer from 'travis/serializers/v3';
+import wrapWithArray from 'travis/utils/wrap-with-array';
 
 export default V3Serializer.extend({
 
@@ -13,8 +15,8 @@ export default V3Serializer.extend({
         let relationship = null;
         let relationshipKey = this.keyForV2Relationship(key, relationshipMeta.kind, 'deserialize');
         let alternativeRelationshipKey = key.underscore();
-        let hashWithAltRelKey = resourceHash.hasOwnProperty(alternativeRelationshipKey);
-        let hashWithRelKey = resourceHash.hasOwnProperty(relationshipKey);
+        let hashWithAltRelKey = resourceHash[alternativeRelationshipKey];
+        let hashWithRelKey = resourceHash[relationshipKey];
 
         if (hashWithAltRelKey || hashWithRelKey) {
           let data = null;
@@ -27,7 +29,7 @@ export default V3Serializer.extend({
               return this.extractRelationship(relationshipMeta.type, item);
             });
           }
-          relationship = { data };
+          relationship = data;
         }
 
         if (relationship) {
@@ -58,33 +60,37 @@ export default V3Serializer.extend({
       if (!included) {
         included = [];
       }
-      let store = this.store;
 
       if (data.relationships) {
-        Object.keys(data.relationships).forEach(function (key) {
+        Object.keys(data.relationships).forEach((key) => {
           let relationship = data.relationships[key];
-          let process = function (data) {
-            let withOnlyIdAndType = Object.keys(data).sort() + '' !== 'id,type';
-            let branchWithHref = data['@href'] && data.type === 'branch';
-            if (withOnlyIdAndType || branchWithHref) {
-              // no need to add records if they have only id and type
-              let type = key === 'defaultBranch' ? 'branch' : key.singularize();
-              let serializer = store.serializerFor(type);
-              let modelClass = store.modelFor(type);
-              let normalized = serializer.normalize(modelClass, data);
-              included.push(normalized.data);
-              if (normalized.included) {
-                normalized.included.forEach(function (item) {
-                  included.push(item);
-                });
-              }
-            }
-          };
+          let relationshipHashes = wrapWithArray(relationship);
 
-          if (Array.isArray(relationship.data)) {
-            relationship.data.forEach(process);
-          } else if (relationship && relationship.data) {
-            process(relationship.data);
+          relationshipHashes.forEach((relationshipHash) => {
+            let relationshipIncluded = relationshipHash.included || [];
+
+            if (Object.keys(relationshipHash.data.attributes || {}).length === 0) {
+              return;
+            }
+
+            included.push(relationshipHash.data);
+            relationshipIncluded.forEach(function (item) {
+              included.push(item);
+            });
+          });
+
+          if (Ember.isArray(relationship)) {
+            data.relationships[key] = {
+              data: relationship.map(({ data }) => {
+                return { id: data.id, type: data.type };
+              })
+            };
+          } else {
+            data.relationships[key] = {
+              data: {
+                id: relationship.data.id, type: relationship.data.type
+              }
+            };
           }
         });
       }

--- a/app/serializers/v3.js
+++ b/app/serializers/v3.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import JSONSerializer from 'ember-data/serializers/json';
+import wrapWithArray from 'travis/utils/wrap-with-array';
 
 var traverse = function (object, callback) {
   if (!object) {
@@ -24,7 +25,142 @@ var traverse = function (object, callback) {
   }
 };
 
+// Currently the way we normalize payload is as follows:
+//
+// * we extract attributes using a default implementation of `extractAttributes`
+//   from JSON serializer that we inherit from. It just grabs all of the defined
+//   attributes from the payload.
+//   * we also remove any @ attributes before getting them to the attributes
+//   section
+// * then we extract relationships:
+//   * we go through each relationship and get the hash or an array of hashes in
+//     case of a hasMany relationship
+//   * JSON API accepts relationships in a following way:
+//
+//       {
+//         relationships: {
+//           build: {
+//             data: { id: 1, type: 'build' }
+//           },
+//           jobs: {
+//             data: [
+//               { id: 1, type: 'job' },
+//               { id: 2, type: 'job' }
+//             ]
+//           }
+//         }
+//       }
+//   * during a first pass we save relationships as a full record, so instead of
+//     passing just id and type, we also pass attributes, relationships etc. We
+//     also save hasMany relationships a little bit differently, so after
+//     running through `extractRelationships` a record could look like this:
+//
+//       {
+//         relationships: {
+//           build: {
+//             data: {
+//               id: 1,
+//               type: 'build',
+//               attributes: {
+//                 number: '1',
+//                 state: 'passed'
+//               },
+//               relationships: {}
+//             },
+//             included: [],
+//             meta: {
+//               representation: 'standard'
+//             }
+//           },
+//           jobs: [
+//             {
+//               data: {
+//                 id: 1,
+//                 type: 'job',
+//                 attributes: {
+//                   number: '1.1',
+//                   state: 'passed'
+//                 },
+//                 relationships: {},
+//               },
+//               included: [],
+//               meta: {
+//                 representation: 'standard'
+//               }
+//             }
+//           ]
+//         }
+//       }
+//
+//   * note a few things here:
+//     * records inside relationships may also have their own related records,
+//       so we end up with a tree of nested records
+//     * records also have `included` array, which during normalization will be
+//       copied to the top most record
+//     * records also have a meta section that keeps any information that we may
+//       need later (in this case we keep representation to know which records
+//       we should load into the store and which should just be left as
+//       relationship info)
+//     * hasMany relationship structure differs (it's an array of JSON API
+//       records instead of just `data: []`)
+//   * after relationships are extracted this way it will be easier to further
+//     process them in `normalize`
+//   * in `normalize` we loop through each relationship and put any related
+//     records with a `standard` representation to the `included` array. This
+//     ensures that they're loaded into the store
+//     * we ommit other representations, because we don't have any mechanism to
+//       load missing data
+//     * while looping through relationships we also fix relationships to look
+//       like JSON API's relationships: we leave only id and type and for
+//       hasMany relationships we also change the structure
 export default JSONSerializer.extend({
+
+  extractRelationships(modelClass, resourceHash) {
+    var relationships = {};
+
+    modelClass.eachRelationship((key, relationshipMeta) => {
+      var relationship = null;
+      var relationshipKey = this.keyForRelationship(key, relationshipMeta.kind, 'deserialize');
+      var relationshipHash = resourceHash[relationshipKey];
+
+      if (relationshipHash) {
+        var data = null;
+        if (relationshipMeta.kind === 'belongsTo') {
+          if (relationshipMeta.options.polymorphic) {
+            // extracting a polymorphic belongsTo may need more information
+            // than the type and the hash (which might only be an id) for the
+            // relationship, hence we pass the key, resource and
+            // relationshipMeta too
+            let options = {
+              key: key,
+              resourceHash: resourceHash,
+              relationshipMeta: relationshipMeta
+            };
+            data = this.extractPolymorphicRelationship(relationshipMeta.type,
+                                                       relationshipHash,
+                                                       options);
+          } else {
+            data = this.extractRelationship(relationshipMeta.type, relationshipHash);
+          }
+        } else if (relationshipMeta.kind === 'hasMany') {
+          if (!Ember.isNone(relationshipHash)) {
+            data = new Array(relationshipHash.length);
+            for (var i = 0, l = relationshipHash.length; i < l; i++) {
+              var item = relationshipHash[i];
+              data[i] = this.extractRelationship(relationshipMeta.type, item);
+            }
+          }
+        }
+        relationship = data;
+      }
+
+      if (relationship) {
+        relationships[key] = relationship;
+      }
+    });
+
+    return relationships;
+  },
 
   extractRelationship(type, hash) {
     if (hash && !hash.id && hash['@href']) {
@@ -37,7 +173,10 @@ export default JSONSerializer.extend({
     } else if (relationshipHash && !relationshipHash.type) {
       relationshipHash.type = type;
     }
-    return relationshipHash;
+
+    let modelClass = this.store.modelFor(relationshipHash.type);
+    let serializer = this.store.serializerFor(relationshipHash.type);
+    return serializer.normalize(modelClass, relationshipHash);
   },
 
   keyForRelationship(key/* , typeClass, method*/) {
@@ -101,41 +240,56 @@ export default JSONSerializer.extend({
     return documentHash;
   },
 
-  normalize(/* modelClass, resourceHash*/) {
-    let { data, included } = this._super(...arguments);
-    if (!included) {
-      included = [];
+  normalize(modelClass, resourceHash) {
+    let { data, meta, included } = this._super(...arguments);
+
+    if (!resourceHash['@type']) {
+      return { data, included, meta };
     }
-    let store = this.store;
+
+    meta     = meta || {};
+    included = included || [];
+
+    if (!meta['representation']) {
+      meta.representation = resourceHash['@representation'];
+    }
 
     if (data.relationships) {
       Object.keys(data.relationships).forEach((key) => {
         let relationship = data.relationships[key];
-        let process = (data) => {
-          if (data['@representation'] !== 'standard') {
+        let relationshipHashes = wrapWithArray(relationship);
+
+        relationshipHashes.forEach((relationshipHash) => {
+          let meta = relationshipHash.meta || {};
+          let relationshipIncluded = relationshipHash.included || [];
+
+          if (meta.representation !== 'standard') {
             return;
           }
-          let type = this.getType(data['@type']);
-          let serializer = store.serializerFor(type);
-          let modelClass = store.modelFor(type);
-          let normalized = serializer.normalize(modelClass, data);
-          included.push(normalized.data);
-          if (normalized.included) {
-            normalized.included.forEach(function (item) {
-              included.push(item);
-            });
-          }
-        };
 
-        if (Array.isArray(relationship.data)) {
-          relationship.data.forEach(process);
-        } else if (relationship && relationship.data) {
-          process(relationship.data);
+          included.push(relationshipHash.data);
+          relationshipIncluded.forEach(function (item) {
+            included.push(item);
+          });
+        });
+
+        if (Ember.isArray(relationship)) {
+          data.relationships[key] = {
+            data: relationship.map(({ data }) => {
+              return { id: data.id, type: data.type };
+            })
+          };
+        } else {
+          data.relationships[key] = {
+            data: {
+              id: relationship.data.id, type: relationship.data.type
+            }
+          };
         }
       });
     }
 
-    return { data, included };
+    return { data, included, meta };
   },
 
   keyForAttribute(key) {

--- a/app/serializers/v3.js
+++ b/app/serializers/v3.js
@@ -1,29 +1,7 @@
 import Ember from 'ember';
 import JSONSerializer from 'ember-data/serializers/json';
 import wrapWithArray from 'travis/utils/wrap-with-array';
-
-var traverse = function (object, callback) {
-  if (!object) {
-    return;
-  }
-
-  if (typeof(object) === 'object' && !Ember.isArray(object)) {
-    callback(object);
-  }
-
-  if (Ember.isArray(object)) {
-    for (let item of object) {
-      traverse(item, callback);
-    }
-  } else if (typeof object === 'object') {
-    for (let key in object) {
-      if (object.hasOwnProperty(key)) {
-        let item = object[key];
-        traverse(item, callback);
-      }
-    }
-  }
-};
+import traverse from 'travis/utils/traverse-payload';
 
 // Currently the way we normalize payload is as follows:
 //

--- a/app/utils/traverse-payload.js
+++ b/app/utils/traverse-payload.js
@@ -1,0 +1,26 @@
+import Ember from 'ember';
+
+var traverse = function (object, callback) {
+  if (!object) {
+    return;
+  }
+
+  if (typeof(object) === 'object' && !Ember.isArray(object)) {
+    callback(object);
+  }
+
+  if (Ember.isArray(object)) {
+    for (let item of object) {
+      traverse(item, callback);
+    }
+  } else if (typeof object === 'object') {
+    for (let key in object) {
+      if (object.hasOwnProperty(key)) {
+        let item = object[key];
+        traverse(item, callback);
+      }
+    }
+  }
+};
+
+export default traverse;

--- a/app/utils/wrap-with-array.js
+++ b/app/utils/wrap-with-array.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+
+// Wraps a given object with an Array if it's not an array
+// already, otherwise just returns the argument unchanged.
+// In case the argument is not defined or null just return
+// an empty array.
+export default function (object) {
+  if (Ember.isArray(object)) {
+    return object;
+  } else if (object) {
+    return [object];
+  } else {
+    return [];
+  }
+}

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -156,7 +156,7 @@ export default function () {
     let builds;
 
     if (afterNumber) {
-      builds = allBuilds.models.filter(build => build.number < afterNumber);
+      builds = allBuilds.models.filter(build => parseInt(build.number) < parseInt(afterNumber));
     } else if (ids) {
       builds = allBuilds.models.filter(build => ids.indexOf(build.id) > -1);
     } else if (eventType === 'pull_request') {

--- a/tests/acceptance/builds/cancel-test.js
+++ b/tests/acceptance/builds/cancel-test.js
@@ -10,6 +10,7 @@ moduleForAcceptance('Acceptance | builds/cancel', {
 });
 
 test('cancelling build', function (assert) {
+  server.logging = true;
   let repository =  server.create('repository', { slug: 'travis-ci/travis-web' });
 
   server.create('branch', {});

--- a/tests/acceptance/repo/build-list-routes-test.js
+++ b/tests/acceptance/repo/build-list-routes-test.js
@@ -27,7 +27,7 @@ moduleForAcceptance('Acceptance | repo build list routes', {
 
     this.repoId = parseInt(repository.id);
 
-    this.branch = server.create('branch');
+    this.branch = server.create('branch', { name: 'successful-cron-branch' });
 
     const oneYearAgo = new Date();
     oneYearAgo.setYear(oneYearAgo.getFullYear() - 1);

--- a/tests/unit/serializers/build-test.js
+++ b/tests/unit/serializers/build-test.js
@@ -2,7 +2,7 @@ import { moduleForModel, test } from 'ember-qunit';
 
 moduleForModel('build', 'Unit | Serializer | build', {
   // Specify the other units that are required for this test.
-  needs: ['serializer:build', 'model:commit', 'model:job', 'model:branch', 'model:repo']
+  needs: ['serializer:build', 'serializer:commit', 'serializer:job', 'serializer:repo', 'model:commit', 'model:job', 'model:branch', 'model:repo']
 });
 
 test('it normalizes a V3 singular response with nested jobs and repos', function (assert) {
@@ -52,71 +52,74 @@ test('it normalizes a V3 singular response with nested jobs and repos', function
   let result = serializer.normalizeResponse(store, store.modelFor('build'), payload, 1, 'findRecord');
   let expectedResult = {
     'data': {
-      'attributes': {
-        'number': 1,
-        'state': 'passed'
-      },
       'id': '1',
+      'type': 'build',
+      'attributes': {
+        'state': 'passed',
+        'number': 1
+      },
       'relationships': {
-        'jobs': {
-          'data': [{
-            '@type': 'job',
-            '@href': '/v3/job/1',
-            '@representation': 'standard',
-            'id': '1',
-            'number': '1.1',
-            'state': 'passed',
-            'repository': {
-              '@href': '/v3/repo/1',
-              'id': 1
-            },
-            'type': 'job'
-          }, {
-            '@type': 'job',
-            '@href': '/v3/job/2',
-            '@representation': 'standard',
-            'id': '2',
-            'number': '1.2',
-            'state': 'passed',
-            'repository': {
-              '@href': '/v3/repo/1',
-              'id': 1
-            },
-            'type': 'job'
-          }]
-        },
         'repo': {
           'data': {
-            '@href': '/v3/repo/1',
-            '@representation': 'standard',
-            '@type': 'repository',
             'id': '1',
-            'name': 'travis-web',
-            'slug': 'travis-ci/travis-web',
             'type': 'repo'
           }
+        },
+        'jobs': {
+          'data': [
+            {
+              'id': '1',
+              'type': 'job'
+            },
+            {
+              'id': '2',
+              'type': 'job'
+            }
+          ]
         }
-      },
-      'type': 'build'
+      }
     },
     'included': [
       {
-        'attributes': {},
         'id': '1',
-        'relationships': {},
-        'type': 'repo'
+        'type': 'repo',
+        'attributes': {
+          'slug': 'travis-ci/travis-web',
+          'name': 'travis-web'
+        },
+        'relationships': {}
       },
       {
-        'attributes': {},
         'id': '1',
-        'relationships': {},
-        'type': 'job'
+        'type': 'job',
+        'attributes': {
+          'state': 'passed',
+          'number': '1.1'
+        },
+        'relationships': {
+          'repo': {
+            'data': {
+              'id': '1',
+              'type': 'repo'
+            }
+          }
+        }
       },
       {
-        'attributes': {},
         'id': '2',
-        'relationships': {},
-        'type': 'job'
+        'type': 'job',
+        'attributes': {
+          'state': 'passed',
+          'number': '1.2'
+        },
+        'relationships': {
+          'repo': {
+            'data': {
+              'id': '1',
+              'type': 'repo'
+            }
+          }
+        }
       }
     ]
   };
@@ -207,49 +210,31 @@ test('it normalizes a V2 singular response', function (assert) {
 
   let expectedResult = {
     'data': {
-      'id': '1',
-      'type': 'build',
       'attributes': {
-        'state': 'passed',
-        'number': 10,
+        '_config': {
+          'language': 'ruby'
+        },
         '_duration': 72,
-        '_config': { 'language': 'ruby' },
-        '_startedAt': '2016-02-24T16:37:54Z',
         '_finishedAt': '2016-02-24T16:40:10Z',
+        '_startedAt': '2016-02-24T16:37:54Z',
+        'eventType': 'push',
+        'number': 10,
         'pullRequest': false,
-        'pullRequestTitle': null,
         'pullRequestNumber': null,
-        'eventType': 'push'
+        'pullRequestTitle': null,
+        'state': 'passed'
       },
+      'id': '1',
       'relationships': {
         'branch': {
           'data': {
-            'name': 'development',
-            'default_branch': false,
-            '@href': '\/repo\/2\/branch\/development',
-            'id': '\/repo\/2\/branch\/development',
+            'id': '/repo/2/branch/development',
             'type': 'branch'
-          }
-        },
-        'repo': {
-          'data': {
-            'id': '2',
-            'type': 'repo'
           }
         },
         'commit': {
           'data': {
             'id': '3',
-            'sha': '864c69a9588024331ba0190e9d8492ae0b6d5eff',
-            'branch': 'development',
-            'branch_is_default': false,
-            'message': 'A commit',
-            'committed_at': '2016-02-24T16:36:23Z',
-            'author_name': 'Mr. Travis',
-            'author_email': 'nothing@travis-ci.org',
-            'committer_name': 'Mr. Travis',
-            'committer_email': 'nothing@travis-ci.org',
-            'compare_url': 'https:\/\/github.com\/drogus\/test-project-1\/compare\/432d5426aa67...864c69a95880',
             'type': 'commit'
           }
         },
@@ -257,64 +242,113 @@ test('it normalizes a V2 singular response', function (assert) {
           'data': [
             {
               'id': '5',
-              'repository_id': 2,
-              'build_id': 1,
-              'commit_id': 3,
-              'log_id': 7,
-              'state': 'passed',
-              'number': '10.1',
-              'config': { 'language': 'ruby' },
-              'started_at': '2016-02-24T16:37:54Z',
-              'finished_at': '2016-02-24T16:38:19Z',
-              'queue': 'builds.docker',
-              'allow_failure': false,
-              'tags': null,
               'type': 'job'
             },
             {
               'id': '6',
-              'repository_id': 2,
-              'build_id': 1,
-              'commit_id': 3,
-              'log_id': 8,
-              'state': 'passed',
-              'number': '10.2',
-              'config': { 'language': 'ruby' },
-              'started_at': '2016-02-24T16:37:54Z',
-              'finished_at': '2016-02-24T16:38:19Z',
-              'queue': 'builds.docker',
-              'allow_failure': false,
-              'tags': null,
               'type': 'job'
             }
           ]
+        },
+        'repo': {
+          'data': {
+            'id': '2',
+            'type': 'repo'
+          }
         }
-      }
+      },
+      'type': 'build'
     },
     'included': [
       {
-        'id': '\/repo\/2\/branch\/development',
-        'type': 'branch',
-        'attributes': {},
-        'relationships': {}
-      },
-      {
+        'attributes': {
+          'authorEmail': 'nothing@travis-ci.org',
+          'authorName': 'Mr. Travis',
+          'branch': 'development',
+          'committedAt': '2016-02-24T16:36:23Z',
+          'committerEmail': 'nothing@travis-ci.org',
+          'committerName': 'Mr. Travis',
+          'compareUrl': 'https://github.com/drogus/test-project-1/compare/432d5426aa67...864c69a95880',
+          'message': 'A commit',
+          'sha': '864c69a9588024331ba0190e9d8492ae0b6d5eff'
+        },
         'id': '3',
-        'type': 'commit',
-        'attributes': {},
-        'relationships': {}
+        'relationships': {},
+        'type': 'commit'
       },
       {
+        'attributes': {
+          '_config': {
+            'language': 'ruby'
+          },
+          '_finishedAt': '2016-02-24T16:38:19Z',
+          '_startedAt': '2016-02-24T16:37:54Z',
+          'allowFailure': false,
+          'logId': 7,
+          'number': '10.1',
+          'queue': 'builds.docker',
+          'state': 'passed',
+          'tags': null
+        },
         'id': '5',
-        'type': 'job',
-        'attributes': {},
-        'relationships': {}
+        'relationships': {
+          'build': {
+            'data': {
+              'id': '1',
+              'type': 'build'
+            }
+          },
+          'commit': {
+            'data': {
+              'id': '3',
+              'type': 'commit'
+            }
+          },
+          'repo': {
+            'data': {
+              'id': '2',
+              'type': 'repo'
+            }
+          }
+        },
+        'type': 'job'
       },
       {
+        'attributes': {
+          '_config': {
+            'language': 'ruby'
+          },
+          '_finishedAt': '2016-02-24T16:38:19Z',
+          '_startedAt': '2016-02-24T16:37:54Z',
+          'allowFailure': false,
+          'logId': 8,
+          'number': '10.2',
+          'queue': 'builds.docker',
+          'state': 'passed',
+          'tags': null
+        },
         'id': '6',
-        'type': 'job',
-        'attributes': {},
-        'relationships': {}
+        'relationships': {
+          'build': {
+            'data': {
+              'id': '1',
+              'type': 'build'
+            }
+          },
+          'commit': {
+            'data': {
+              'id': '3',
+              'type': 'commit'
+            }
+          },
+          'repo': {
+            'data': {
+              'id': '2',
+              'type': 'repo'
+            }
+          }
+        },
+        'type': 'job'
       }
     ]
   };

--- a/tests/unit/serializers/repo-test.js
+++ b/tests/unit/serializers/repo-test.js
@@ -1,0 +1,68 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('repo', 'Unit | Serializer | repo', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:repo', 'serializer:branch', 'serializer:build',
+    'serializer:commit', 'model:commit', 'model:job', 'model:branch',
+    'model:repo', 'model:build']
+});
+
+test('it includes deep nested relationships in include array', function (assert) {
+  let payload = {
+    '@type': 'repository',
+    '@href': '/repo/1',
+    '@representation': 'standard',
+    'id': 1,
+    'name': 'travis-web',
+    'current_build': {
+      '@href': '/build/1',
+    },
+    'default_branch': {
+      '@href': '/repo/1/branch/master',
+      '@representation': 'standard',
+      '@type': 'branch',
+      'name': 'master',
+      'last_build': {
+        '@type': 'build',
+        '@representation': 'standard',
+        '@href': '/build/1',
+        'id': 1,
+        'number': '1',
+        'commit': {
+          '@type': 'commit',
+          '@representation': 'standard',
+          '@href': '/commit/1',
+          'id': 1,
+          'sha': 'abc123'
+        },
+        'jobs': [{
+          '@type': 'job',
+          '@href': '/job/1',
+          '@representation': 'minimal',
+          'id': 1,
+          'number': '1.1'
+        }]
+      }
+    }
+  };
+
+  let store = this.store();
+  let serializer = store.serializerFor('repo');
+  let result = serializer.normalizeResponse(store, store.modelFor('repo'), payload, 1, 'findRecord');
+  let { type, id, attributes, relationships } = result.data;
+
+  assert.equal(type, 'repo');
+  assert.equal(id, '1');
+  assert.equal(attributes.name, 'travis-web');
+  assert.deepEqual(Object.keys(relationships).sort(), ['currentBuild', 'defaultBranch']);
+
+  let includedRecords = result.included.map(({ id, type }) => { return { id, type }; });
+  let expectedIncludedRecords = [
+    { id: '/repo/1/branch/master', type: 'branch' },
+    { id: '1', type: 'build' },
+    { id: '1', type: 'commit' },
+  ];
+
+  assert.equal(includedRecords.length, 3);
+  assert.deepEqual(includedRecords, expectedIncludedRecords);
+});


### PR DESCRIPTION
This is yet another problem with serializers that I ran into when working on #970. When API returns nested relationships, we should put all of the records with representation set to `standard` into the `included` array. The problem is that with code currently in production it will only do that for relationships in the first level. As with other issues that I found, it doesn't affect us on production, because in all cases that we use V3 API, we don't actually deep nested records to be pushed in the store, but it would be nice to get it working consistently. And I want to fix it before merging #970 to isolate any problems that it might cause.