### PR TITLE
Fix CSP warning for GitHub avatars

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -171,7 +171,7 @@ module.exports = function (environment) {
     'script-src': "'self' https://ssl.google-analytics.com https://djtflbt20bdde.cloudfront.net/ https://js.pusher.com",
     'font-src': "'self' https://fonts.googleapis.com/css https://fonts.gstatic.com",
     'connect-src': "'self' ws://ws.pusherapp.com wss://ws.pusherapp.com https://*.pusher.com https://s3.amazonaws.com/archive.travis-ci.com/ https://s3.amazonaws.com/archive.travis-ci.org/ app.getsentry.com https://pnpcptp8xh9k.statuspage.io/ https://ssl.google-analytics.com",
-    'img-src': "'self' data: https://www.gravatar.com http://www.gravatar.com app.getsentry.com https://avatars.githubusercontent.com https://0.gravatar.com https://ssl.google-analytics.com",
+    'img-src': "'self' data: https://www.gravatar.com http://www.gravatar.com app.getsentry.com https://*.githubusercontent.com https://0.gravatar.com https://ssl.google-analytics.com",
     'style-src': "'self' https://fonts.googleapis.com 'unsafe-inline' https://djtflbt20bdde.cloudfront.net",
     'media-src': "'self'",
     'frame-src': "'self' https://djtflbt20bdde.cloudfront.net",


### PR DESCRIPTION
GitHub uses several servers (such as `avatars3.githubusercontent.com`), so specifying a single server wasn't working as expected.
I simply replaced this with a glob, though it's a little more permissive than I would have liked. Unfortunately, something like `https://avatars*.githubusercontent.com` is invalid:
> The source list for Content Security Policy directive 'img-src' contains an invalid source: 'https://avatars*.githubusercontent.com'. It will be ignored.`