### PR TITLE
Remove ember-cli-pretender

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "ember-cli-inline-images": "^0.0.4",
     "ember-cli-mirage": "0.2.7",
     "ember-cli-page-object": "1.8.0",
-    "ember-cli-pretender": "1.0.1",
     "ember-cli-qunit": "3.1.2",
     "ember-cli-sass": "6.1.2",
     "ember-cli-sentry": "2.4.3",


### PR DESCRIPTION
pretender is already packaged as part of ember-cli-mirage.