### PR TITLE
Remove server logging from acceptance tests

### DIFF
--- a/tests/acceptance/builds/cancel-test.js
+++ b/tests/acceptance/builds/cancel-test.js
@@ -10,7 +10,6 @@ moduleForAcceptance('Acceptance | builds/cancel', {
 });
 
 test('cancelling build', function (assert) {
-  server.logging = true;
   let repository =  server.create('repository', { slug: 'travis-ci/travis-web' });
 
   server.create('branch', {});

--- a/tests/acceptance/home/with-repositories-test.js
+++ b/tests/acceptance/home/with-repositories-test.js
@@ -17,7 +17,6 @@ const repositoryTemplate = {
 
 moduleForAcceptance('Acceptance | home/with repositories', {
   beforeEach() {
-    server.logging = true;
     const currentUser = server.create('user', {
       name: 'Sara Ahmed',
       login: 'feministkilljoy'

--- a/tests/acceptance/repo/build-list-routes-test.js
+++ b/tests/acceptance/repo/build-list-routes-test.js
@@ -8,7 +8,6 @@ import Ember from 'ember';
 
 moduleForAcceptance('Acceptance | repo build list routes', {
   beforeEach() {
-    server.logging = true;
     const currentUser = server.create('user', {
       name: 'Sara Ahmed',
       login: 'feministkilljoy'


### PR DESCRIPTION
This quiets down the test suite (at least when running locally).