### PR TITLE
Remove live network requests from test suite

### DIFF
--- a/app/components/add-ssh-key.js
+++ b/app/components/add-ssh-key.js
@@ -39,12 +39,14 @@ export default Ember.Component.extend({
   }),
 
   addErrorsFromResponse(errArr) {
-    let error = errArr[0].detail;
+    if (errArr !== undefined && errArr.length) {
+      let error = errArr[0].detail;
 
-    if (error.code === 'not_a_private_key') {
-      return this.set('valueError', 'This key is not a private key.');
-    } else if (error.code === 'key_with_a_passphrase') {
-      return this.set('valueError', 'The key can\'t have a passphrase.');
+      if (error.code === 'not_a_private_key') {
+        return this.set('valueError', 'This key is not a private key.');
+      } else if (error.code === 'key_with_a_passphrase') {
+        return this.set('valueError', 'The key can\'t have a passphrase.');
+      }
     }
   },
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -104,7 +104,6 @@ module.exports = function (environment) {
 
     ENV.APP.rootElement = '#ember-testing';
 
-    ENV.apiEndpoint = '';
     ENV.statusPageStatusUrl =  null;
 
     ENV.sentry = {

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -1,8 +1,14 @@
 /* global server */
 import Ember from 'ember';
 import Mirage from 'ember-cli-mirage';
+import config from 'travis/config/environment';
+
+const { apiEndpoint } = config;
 
 export default function () {
+  this.namespace = apiEndpoint;
+
+  this.get('/users/:id');
   this.get('/accounts', (schema/* , request*/) => {
     const users = schema.users.all().models.map(user => Ember.merge(user.attrs, { type: 'user' }));
     const accounts = schema.accounts.all().models.map(account => account.attrs);

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -98,6 +98,29 @@ export default function () {
     return this.serialize(caches, 'v2');
   });
 
+  this.patch('/settings/ssh_key/:repository_id', function (schema, request) {
+    const sshKeys = schema.sshKeys.where({ repositoryId: request.queryParams.repository_id });
+    const [sshKey] = sshKeys.models;
+    if (sshKey) {
+      return {
+        ssh_key: {
+          id: sshKey.id,
+          description: sshKey.description,
+          value: sshKey.value,
+        },
+      };
+    } else {
+      const created = server.create('ssh_key', request.params);
+      return {
+        ssh_key: {
+          id: created.id,
+          description: created.description,
+          value: created.value,
+        }
+      };
+    }
+  });
+
   this.post('/settings/env_vars', function (schema, request) {
     const envVar = server.create('env_var', request.params);
     return {

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -98,6 +98,18 @@ export default function () {
     return this.serialize(caches, 'v2');
   });
 
+  this.post('/settings/env_vars', function (schema, request) {
+    const envVar = server.create('env_var', request.params);
+    return {
+      env_var: {
+        id: envVar.id,
+        name: envVar.name,
+        public: envVar.public,
+        repository_id: request.params.repository_id,
+      },
+    };
+  });
+
   this.get('/settings/env_vars', function (schema, request) {
     const envVars = schema.envVars.where({ repositoryId: request.queryParams.repository_id });
 

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -158,6 +158,15 @@ export default function () {
     return this.serialize(schema.users.where({ login: request.params.login }).models[0], 'owner');
   });
 
+  this.delete('/settings/ssh_key/:repo_id', function (schema, request) {
+    schema.sshKeys
+      .where({ repositoryId: request.queryParams.repository_id })
+      .models
+      .map(sshKey => sshKey.destroyRecord());
+
+    return new Mirage.Response(204, {}, {});
+  });
+
   this.get('/settings/ssh_key/:repo_id', function (schema, request) {
     const repo = schema.repositories.find(request.params.repo_id);
     const { customSshKey } = repo;

--- a/tests/integration/components/add-env-var-test.js
+++ b/tests/integration/components/add-env-var-test.js
@@ -4,16 +4,22 @@ import hbs from 'htmlbars-inline-precompile';
 import fillIn from '../../helpers/fill-in';
 import DS from 'ember-data';
 import { percySnapshot } from 'ember-percy';
+import { startMirage } from 'travis/initializers/ember-cli-mirage';
 
 moduleForComponent('add-env-var', 'Integration | Component | add env-var', {
-  integration: true
+  integration: true,
+  beforeEach() {
+    this.server = startMirage();
+  },
+
+  afterEach() {
+    this.server.shutdown();
+  }
 });
 
 test('it adds an env var on submit', function (assert) {
   assert.expect(6);
 
-  // this shouldn't be needed, probably some bug in tests setup with new ember-data
-  this.registry.register('transform:boolean', DS.BooleanTransform);
   var store = Ember.getOwner(this).lookup('service:store');
   assert.equal(store.peekAll('envVar').get('length'), 0, 'precond: store should be empty');
 

--- a/tests/integration/components/add-ssh-key-test.js
+++ b/tests/integration/components/add-ssh-key-test.js
@@ -4,9 +4,17 @@ import hbs from 'htmlbars-inline-precompile';
 import fillIn from '../../helpers/fill-in';
 import DS from 'ember-data';
 import { percySnapshot } from 'ember-percy';
+import { startMirage } from 'travis/initializers/ember-cli-mirage';
 
 moduleForComponent('add-ssh-key', 'Integration | Component | add ssh-key', {
-  integration: true
+  integration: true,
+  beforeEach() {
+    this.server = startMirage();
+  },
+
+  afterEach() {
+    this.server.shutdown();
+  }
 });
 
 test('it adds an ssh key on submit', function (assert) {

--- a/tests/integration/components/ssh-key-test.js
+++ b/tests/integration/components/ssh-key-test.js
@@ -2,9 +2,17 @@ import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { percySnapshot } from 'ember-percy';
+import { startMirage } from 'travis/initializers/ember-cli-mirage';
 
 moduleForComponent('ssh-key', 'Integration | Component | ssh-key', {
-  integration: true
+  integration: true,
+  beforeEach() {
+    this.server = startMirage();
+  },
+
+  afterEach() {
+    this.server.shutdown();
+  }
 });
 
 test('it renders the default ssh key if no custom key is set', function (assert) {

--- a/tests/unit/services/external-links-test.js
+++ b/tests/unit/services/external-links-test.js
@@ -1,4 +1,7 @@
 import { moduleFor, test } from 'ember-qunit';
+import config from 'travis/config/environment';
+
+const { apiEndpoint } = config;
 
 moduleFor('service:external-links', 'Unit | Service | external-links', {
   beforeEach() {
@@ -12,7 +15,7 @@ moduleFor('service:external-links', 'Unit | Service | external-links', {
 
 test('plainTextLog', function (assert) {
   let service = this.subject();
-  assert.equal(service.plainTextLog(this.id), '/jobs/1/log.txt?deansi=true');
+  assert.equal(service.plainTextLog(this.id), `${apiEndpoint}/jobs/1/log.txt?deansi=true`);
 });
 
 test('githubPullRequest', function (assert) {

--- a/tests/unit/services/status-images-test.js
+++ b/tests/unit/services/status-images-test.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import { moduleFor, test } from 'ember-qunit';
+import config from 'travis/config/environment';
 
 const authServiceStub = Ember.Service.extend({
   assetToken() {
@@ -20,6 +21,8 @@ const secureRoot = `https://${location.host}`;
 
 const slug = 'travis-ci/travis-web';
 const branch = 'primary';
+
+const { apiEndpoint } = config;
 
 test('it generates an image url with a slug', function (assert) {
   const service = this.subject();
@@ -117,13 +120,13 @@ test('it generates a Pod image string with a slug and a branch', function (asser
 test('it generates CCTray url with a slug', function (assert) {
   const service = this.subject();
   let url = service.ccXml(slug);
-  assert.equal(url, '#/repos/travis-ci/travis-web/cc.xml');
+  assert.equal(url, `#${apiEndpoint}/repos/travis-ci/travis-web/cc.xml`);
 });
 
 test('it generates CCTray url with a slug and a branch', function (assert) {
   const service = this.subject();
   let url = service.ccXml(slug, branch);
-  assert.equal(url, '#/repos/travis-ci/travis-web/cc.xml?branch=primary');
+  assert.equal(url, `#${apiEndpoint}/repos/travis-ci/travis-web/cc.xml?branch=primary`);
 });
 
 test('it generaes CCTray url with a slug and a branch and when pro feature flag enabled', function (assert) {
@@ -131,6 +134,6 @@ test('it generaes CCTray url with a slug and a branch and when pro feature flag 
   service.set('features', Ember.Object.create());
   service.set('features.proVersion', true);
   let url = service.ccXml(slug, branch);
-  assert.equal(url, '#/repos/travis-ci/travis-web/cc.xml?branch=primary&token=token-abc-123');
+  assert.equal(url, `#${apiEndpoint}/repos/travis-ci/travis-web/cc.xml?branch=primary&token=token-abc-123`);
   service.set('features.proVersion', false);
 });


### PR DESCRIPTION
The test suite currently hits our production API in a few instances. This addresses most of them, though there's still an outstanding issue with a `DELETE` of an SSH key that I haven't solved yet.