### PR TITLE
Allow unused args

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,9 @@ module.exports = {
     browser: true
   },
   rules: {
+    // Don't allow unused vars, but allow unused arguments
+    "no-unused-vars": ["error", { "vars": "all", "args": "none", "ignoreRestSiblings": false }],
+
     // TODO: Remove this to ensure we handle errors properly in UI
     "no-empty": ["error", { "allowEmptyCatch": true }],
 

--- a/app/adapters/.eslintrc.js
+++ b/app/adapters/.eslintrc.js
@@ -10,6 +10,9 @@ module.exports = {
     'browser': true
   },
   rules: {
+    // Don't allow unused vars, but allow unused arguments
+    "no-unused-vars": ["error", { "vars": "all", "args": "none", "ignoreRestSiblings": false }],
+
     // TODO: Remove this to ensure we handle errors properly in UI
     "no-empty": ["error", { "allowEmptyCatch": true }],
 


### PR DESCRIPTION
I think that not allowing unused vars is not giving us any value and it
usually makes life harder. Despite the fact Javascript has dynamic
signatures, I usually like to still define them even if I don't use all
the args, because the signature hints on how to call the function. This
is especially important when you intend to override a function in
subclasses - you may want to define an empty (or almost empty) default
and start using it by passing all of the arguments and only use some of
the arguments in different subclasses.

The only advantage of not allowing unused arguments is that we will know
when an argument is misspelled, but that should be also caught by other
rules (like: don't allow using undefined variables).