### PR TITLE
Fix broken GitHub issue link in build title

### DIFF
--- a/app/helpers/format-message.js
+++ b/app/helpers/format-message.js
@@ -13,8 +13,14 @@ function formatMessage(message, options) {
     message = message.split(/\n/)[0];
   }
   message = emojiConvertor.replace_colons(_escape(message));
+
+  // TODO: Figure out more permanent fix for teal #1885
   if (options.repo) {
-    message = githubify(message, Ember.get(options.repo, 'owner'), Ember.get(options.repo, 'name'));
+    let owner = Ember.get(options.repo, 'owner');
+    if (typeof owner === 'object') {
+      owner = owner.login;
+    }
+    message = githubify(message, owner, Ember.get(options.repo, 'name'));
   }
   if (options.pre) {
     message = message.replace(/\n/g, '<br/>');


### PR DESCRIPTION
The GitHub issue link (see https://travis-ci.org/travis-ci/travis-web/builds/221251257)
was being incorrectly generated because the `owner` attribute
we were using was assumed to be a string, but was actually an object.

This meant we were generating
`https://github.com/[object%20Object]/travis-web/issues/1047` in
production.

I'm not sure what caused this, but applying this fix corrects the links
without breaking other tests.