### PR TITLE
Directly transition to first_sync instead of invoking action

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -105,10 +105,6 @@ export default TravisRoute.extend(BuildFaviconMixin, KeyboardShortcuts, {
         return true;
       }
     },
-
-    renderFirstSync() {
-      return this.transitionTo('first_sync');
-    },
   },
 
   afterSignIn() {

--- a/app/services/auth.js
+++ b/app/services/auth.js
@@ -6,6 +6,7 @@ import computed, { alias } from 'ember-computed-decorators';
 const { service } = Ember.inject;
 
 export default Ember.Service.extend({
+  routing: service('-routing'),
   flashes: service(),
   store: service(),
   storage: service(),
@@ -200,9 +201,7 @@ export default Ember.Service.extend({
   syncingDidChange: Ember.observer('isSyncing', 'currentUser', function () {
     const user = this.get('currentUser');
     if (user && user.get('isSyncing') && !user.get('syncedAt')) {
-      return Ember.run.scheduleOnce('routerTransitions', this, function () {
-        return Ember.getOwner(this).lookup('router:main').send('renderFirstSync');
-      });
+      return this.get('routing').transitionTo('first_sync');
     }
   }),
 


### PR DESCRIPTION
Based on our previous spelunking (as well as reported errors in Sentry), we currently appear to have a race condition where the first route
transition has not always completed when we attempt to call an action on the `ApplicationRoute`.

Given the `renderFirstSync` action simply redirects, we should be able to use the (currently private) `routing` service as an interim replacement.

If the exception is what is keeping users from proceeding through the typical auth flow, this should hopefully address it.