### PR TITLE
Convert comment-out tests to use skip

### DIFF
--- a/tests/acceptance/auth/automatic-sign-out-test.js
+++ b/tests/acceptance/auth/automatic-sign-out-test.js
@@ -1,7 +1,7 @@
 /* global signInUser */
-// import { test } from 'qunit';
+import { skip } from 'qunit';
 import moduleForAcceptance from 'travis/tests/helpers/module-for-acceptance';
-// import authPage from 'travis/tests/pages/auth';
+import authPage from 'travis/tests/pages/auth';
 
 moduleForAcceptance('Acceptance | automatic sign out', {
   beforeEach() {
@@ -9,8 +9,8 @@ moduleForAcceptance('Acceptance | automatic sign out', {
     signInUser(currentUser);
   }
 });
-/*
-test('when token is invalid user should be signed out', function (assert) {
+
+skip('when token is invalid user should be signed out', function (assert) {
   window.sessionStorage.setItem('travis.token', 'wrong-token');
   window.localStorage.setItem('travis.token', 'wrong-token');
 
@@ -21,4 +21,3 @@ test('when token is invalid user should be signed out', function (assert) {
   });
   percySnapshot(assert);
 });
-*/

--- a/tests/acceptance/dashboard/repositories-test.js
+++ b/tests/acceptance/dashboard/repositories-test.js
@@ -1,6 +1,6 @@
-import { test } from 'qunit';
+import { skip, test } from 'qunit';
 import moduleForAcceptance from 'travis/tests/helpers/module-for-acceptance';
-// import dashboardPage from 'travis/tests/pages/dashboard';
+import dashboardPage from 'travis/tests/pages/dashboard';
 
 moduleForAcceptance('Acceptance | dashboard/repositories', {
   beforeEach() {
@@ -73,8 +73,7 @@ test('visiting /dashboard/ with feature flag disabled', function (assert) {
   });
 });
 
-/*
-test('visiting /dashboard/ with feature flag enabled', function (assert) {
+skip('visiting /dashboard/ with feature flag enabled', function (assert) {
   withFeature('dashboard');
   visit('/');
 
@@ -91,9 +90,8 @@ test('visiting /dashboard/ with feature flag enabled', function (assert) {
     percySnapshot(assert);
   });
 });
-*/
-/*
-test('filtering repos', function (assert) {
+
+skip('filtering repos', function (assert) {
   withFeature('dashboard');
   visit('/dashboard/');
   click(dashboardPage.accountFilter);
@@ -102,10 +100,7 @@ test('filtering repos', function (assert) {
     assert.equal(dashboardPage.activeRepos().count, 2, 'filters repos for accounts');
   });
 });
-*/
 
-/*
-test('triggering a build', function (assert) {
+skip('triggering a build', function () {
 
 });
-*/


### PR DESCRIPTION
This is a bit easier in that it tends to involve less commenting
out of imports etc, and it also reminds everyone that skipped
tests exist.