### PR TITLE
Update tests with page object’s new as property

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-inline-images": "^0.0.4",
     "ember-cli-mirage": "0.2.7",
-    "ember-cli-page-object": "1.8.0",
+    "ember-cli-page-object": "1.9.0",
     "ember-cli-qunit": "3.1.2",
     "ember-cli-sass": "6.1.2",
     "ember-cli-sentry": "2.4.3",

--- a/tests/acceptance/job/build-matrix-test.js
+++ b/tests/acceptance/job/build-matrix-test.js
@@ -25,24 +25,27 @@ test('visiting build matrix', function (assert) {
   andThen(function () {
     assert.equal(buildPage.requiredJobs().count, 2, 'expected two required jobs in the matrix');
 
-    const firstJobRow = buildPage.requiredJobs(0);
-    assert.ok(firstJobRow.state.isPassed, 'expected the first job to have passed');
-    assert.equal(firstJobRow.number, '1234.1');
-    assert.equal(firstJobRow.env, 'JORTS');
-    assert.ok(firstJobRow.os.isLinux, 'expect Linux');
-    assert.equal(firstJobRow.language, 'Node.js: 5');
+    buildPage.requiredJobs(0).as(firstJobRow => {
+      assert.ok(firstJobRow.state.isPassed, 'expected the first job to have passed');
+      assert.equal(firstJobRow.number, '1234.1');
+      assert.equal(firstJobRow.env, 'JORTS');
+      assert.ok(firstJobRow.os.isLinux, 'expect Linux');
+      assert.equal(firstJobRow.language, 'Node.js: 5');
+    });
 
-    const secondJobRow = buildPage.requiredJobs(1);
-    assert.equal(secondJobRow.number, '1234.2');
-    assert.equal(secondJobRow.env, 'JANTS');
-    assert.ok(secondJobRow.os.isMacOS, 'expect MacOS');
-    assert.equal(secondJobRow.language, 'Ruby: 2.2');
+    buildPage.requiredJobs(1).as(secondJobRow => {
+      assert.equal(secondJobRow.number, '1234.2');
+      assert.equal(secondJobRow.env, 'JANTS');
+      assert.ok(secondJobRow.os.isMacOS, 'expect MacOS');
+      assert.equal(secondJobRow.language, 'Ruby: 2.2');
+    });
 
     assert.equal(buildPage.allowedFailureJobs().count, 1, 'expected one allowed failure job');
 
-    const failedJobRow = buildPage.allowedFailureJobs(0);
-    assert.ok(failedJobRow.state.isFailed, 'expected the allowed failure job to have failed');
-    assert.equal(failedJobRow.language, 'Ruby');
+    buildPage.allowedFailureJobs(0).as(failedJobRow => {
+      assert.ok(failedJobRow.state.isFailed, 'expected the allowed failure job to have failed');
+      assert.equal(failedJobRow.language, 'Ruby');
+    });
   });
   percySnapshot(assert);
 });

--- a/tests/acceptance/owner/repos-test.js
+++ b/tests/acceptance/owner/repos-test.js
@@ -56,14 +56,19 @@ test('the owner page shows their repositories', (assert) => {
     assert.equal(document.title, 'Sara Ahmed - Travis CI');
 
     assert.equal(ownerPage.repos().count, 2);
-    assert.equal(ownerPage.repos(0).name, 'living-a-feminist-life');
 
-    assert.equal(ownerPage.repos(0).buildNumber, '1917');
-    assert.equal(ownerPage.repos(0).defaultBranch, 'primary');
-    assert.equal(ownerPage.repos(0).commitSha, 'abc124');
-    assert.equal(ownerPage.repos(0).commitDate, 'about a year ago');
+    ownerPage.repos(0).as(repo => {
+      assert.equal(repo.name, 'living-a-feminist-life');
 
-    assert.equal(ownerPage.repos(1).name, 'willful-subjects');
-    assert.equal(ownerPage.repos(1).noBuildMessage, 'There is no build on the default branch yet.');
+      assert.equal(repo.buildNumber, '1917');
+      assert.equal(repo.defaultBranch, 'primary');
+      assert.equal(repo.commitSha, 'abc124');
+      assert.equal(repo.commitDate, 'about a year ago');
+    });
+
+    ownerPage.repos(1).as(repo => {
+      assert.equal(repo.name, 'willful-subjects');
+      assert.equal(repo.noBuildMessage, 'There is no build on the default branch yet.');
+    });
   });
 });

--- a/tests/acceptance/repo/build-list-routes-test.js
+++ b/tests/acceptance/repo/build-list-routes-test.js
@@ -128,16 +128,16 @@ test('build history shows, more can be loaded, and a created build gets added an
   andThen(() => {
     assert.equal(page.builds().count, 3, 'expected three builds');
 
-    const build = page.builds(0);
-
-    assert.ok(build.passed, 'expected the first build to have passed');
-    assert.equal(build.name, 'successful-cron-branch');
-    assert.equal(build.committer, 'Sara Ahmed');
-    assert.equal(build.commitSha, '1234567');
-    assert.equal(build.commitDate, 'about a year ago');
-    assert.equal(build.requestIconTitle, 'Triggered by a cron job');
-    assert.equal(build.duration, '5 min');
-    assert.equal(build.message, 'cron A generic cron commit message', 'expected a prefixed cron marker');
+    page.builds(0).as(build => {
+      assert.ok(build.passed, 'expected the first build to have passed');
+      assert.equal(build.name, 'successful-cron-branch');
+      assert.equal(build.committer, 'Sara Ahmed');
+      assert.equal(build.commitSha, '1234567');
+      assert.equal(build.commitDate, 'about a year ago');
+      assert.equal(build.requestIconTitle, 'Triggered by a cron job');
+      assert.equal(build.duration, '5 min');
+      assert.equal(build.message, 'cron A generic cron commit message', 'expected a prefixed cron marker');
+    });
 
     assert.ok(page.builds(1).failed, 'expected the second build to have failed');
     assert.ok(page.builds(2).errored, 'expected the third build to have errored');
@@ -207,12 +207,12 @@ test('build history shows, more can be loaded, and a created build gets added an
   andThen(() => {
     assert.equal(page.builds().count, 6, 'expected another build');
 
-    const newBuild = page.builds(0);
-
-    assert.ok(newBuild.created, 'expected the new build to show as created');
-    assert.equal(newBuild.name, 'no-dapl');
-    assert.equal(newBuild.message, 'Standing with Standing Rock');
-    assert.equal(newBuild.requestIconTitle, 'Triggered by a push');
+    page.builds(0).as(newBuild => {
+      assert.ok(newBuild.created, 'expected the new build to show as created');
+      assert.equal(newBuild.name, 'no-dapl');
+      assert.equal(newBuild.message, 'Standing with Standing Rock');
+      assert.equal(newBuild.requestIconTitle, 'Triggered by a push');
+    });
 
     const startedData = {
       build: generatePusherPayload(build, { state: 'started' }),
@@ -245,17 +245,17 @@ test('view and cancel pull requests', function (assert) {
   andThen(() => {
     assert.equal(page.builds().count, 1, 'expected one pull request build');
 
-    const pullRequest = page.builds(0);
+    page.builds(0).as(pullRequest => {
+      assert.ok(pullRequest.started, 'expected the pull request to have started');
+      assert.equal(pullRequest.name, 'PR #2010');
+      assert.equal(pullRequest.message, 'A pull request');
+      assert.equal(pullRequest.committer, 'Sara Ahmed');
+      assert.equal(pullRequest.commitSha, '1234567');
+      assert.equal(pullRequest.commitDate, 'about a year ago');
+      assert.equal(pullRequest.duration, '5 min');
 
-    assert.ok(pullRequest.started, 'expected the pull request to have started');
-    assert.equal(pullRequest.name, 'PR #2010');
-    assert.equal(pullRequest.message, 'A pull request');
-    assert.equal(pullRequest.committer, 'Sara Ahmed');
-    assert.equal(pullRequest.commitSha, '1234567');
-    assert.equal(pullRequest.commitDate, 'about a year ago');
-    assert.equal(pullRequest.duration, '5 min');
-
-    assert.ok(pullRequest.cancelButton.visible, 'expected the cancel button to be visible');
+      assert.ok(pullRequest.cancelButton.visible, 'expected the cancel button to be visible');
+    });
   });
   percySnapshot(assert);
 

--- a/tests/acceptance/repo/caches-test.js
+++ b/tests/acceptance/repo/caches-test.js
@@ -42,19 +42,19 @@ test('view and delete caches', function (assert) {
     assert.equal(page.pushCaches().count, 1, 'expected one push cache');
     assert.ok(page.tabIsActive, 'expected the caches tab to be active');
 
-    const pushCache = page.pushCaches(0);
-
-    assert.equal(pushCache.name, 'a-branch-name');
-    assert.equal(pushCache.lastModified, 'a day ago');
-    assert.equal(pushCache.size, '85.27MB');
-
-    const pullRequestCache = page.pullRequestCaches(0);
+    page.pushCaches(0).as(pushCache => {
+      assert.equal(pushCache.name, 'a-branch-name');
+      assert.equal(pushCache.lastModified, 'a day ago');
+      assert.equal(pushCache.size, '85.27MB');
+    });
 
     assert.equal(page.pullRequestCaches().count, 1, 'expected one pull request cache');
 
-    assert.equal(pullRequestCache.name, 'PR.1919');
-    assert.equal(pullRequestCache.lastModified, '2 days ago');
-    assert.equal(pullRequestCache.size, '19.19MB');
+    page.pullRequestCaches(0).as(pullRequestCache => {
+      assert.equal(pullRequestCache.name, 'PR.1919');
+      assert.equal(pullRequestCache.lastModified, '2 days ago');
+      assert.equal(pullRequestCache.size, '19.19MB');
+    });
 
     assert.notOk(page.noCachesExist, 'expected the message that no caches exist to not be present');
   });

--- a/tests/acceptance/repo/settings-test.js
+++ b/tests/acceptance/repo/settings-test.js
@@ -96,26 +96,34 @@ test('view settings', function (assert) {
 
     assert.ok(settingsPage.buildPullRequests.isActive, 'expected builds for pull requests');
 
-    assert.equal(settingsPage.environmentVariables(0).name, 'intersectionality');
-    assert.ok(settingsPage.environmentVariables(0).isPublic, 'expected environment variable to be public');
-    assert.notOk(settingsPage.environmentVariables(0).isNewlyCreated, 'expected existing variable to not be newly created');
-    assert.equal(settingsPage.environmentVariables(0).value, 'Kimberlé Crenshaw');
+    settingsPage.environmentVariables(0).as(environmentVariable => {
+      assert.equal(environmentVariable.name, 'intersectionality');
+      assert.ok(environmentVariable.isPublic, 'expected environment variable to be public');
+      assert.notOk(environmentVariable.isNewlyCreated, 'expected existing variable to not be newly created');
+      assert.equal(environmentVariable.value, 'Kimberlé Crenshaw');
+    });
 
-    assert.equal(settingsPage.environmentVariables(1).name, 'published');
-    assert.notOk(settingsPage.environmentVariables(1).isPublic, 'expected environment variable to not be public');
-    assert.equal(settingsPage.environmentVariables(1).value, '••••••••••••••••');
+    settingsPage.environmentVariables(1).as(environmentVariable => {
+      assert.equal(environmentVariable.name, 'published');
+      assert.notOk(environmentVariable.isPublic, 'expected environment variable to not be public');
+      assert.equal(environmentVariable.value, '••••••••••••••••');
+    });
 
-    assert.equal(settingsPage.crons(0).branchName, 'Cron job event daily-branch');
-    assert.equal(settingsPage.crons(0).interval, 'Runs daily');
-    assert.equal(settingsPage.crons(0).lastRun, 'Ran less than a minute ago');
-    assert.equal(settingsPage.crons(0).nextRun, 'Scheduled in about 24 hours from now');
-    assert.ok(settingsPage.crons(0).dontRunIfRecentBuildExistsText.indexOf('Always run') === 0, 'expected cron to run even if there is a build in the last 24h');
+    settingsPage.crons(0).as(cron => {
+      assert.equal(cron.branchName, 'Cron job event daily-branch');
+      assert.equal(cron.interval, 'Runs daily');
+      assert.equal(cron.lastRun, 'Ran less than a minute ago');
+      assert.equal(cron.nextRun, 'Scheduled in about 24 hours from now');
+      assert.ok(cron.dontRunIfRecentBuildExistsText.indexOf('Always run') === 0, 'expected cron to run even if there is a build in the last 24h');
+    });
 
-    assert.equal(settingsPage.crons(1).branchName, 'Cron job event weekly-branch');
-    assert.equal(settingsPage.crons(1).interval, 'Runs weekly');
-    assert.equal(settingsPage.crons(1).lastRun, 'Ran less than a minute ago');
-    assert.equal(settingsPage.crons(1).nextRun, 'Scheduled in 7 days from now');
-    assert.ok(settingsPage.crons(1).dontRunIfRecentBuildExistsText.indexOf('Do not run if there has been a build in the last 24h') === 0, 'expected Do not run if there has been a build in the last 24h');
+    settingsPage.crons(1).as(cron => {
+      assert.equal(cron.branchName, 'Cron job event weekly-branch');
+      assert.equal(cron.interval, 'Runs weekly');
+      assert.equal(cron.lastRun, 'Ran less than a minute ago');
+      assert.equal(cron.nextRun, 'Scheduled in 7 days from now');
+      assert.ok(cron.dontRunIfRecentBuildExistsText.indexOf('Do not run if there has been a build in the last 24h') === 0, 'expected Do not run if there has been a build in the last 24h');
+    });
 
     assert.equal(settingsPage.sshKey.name, 'Custom');
     assert.equal(settingsPage.sshKey.fingerprint, 'dd:cc:bb:aa');
@@ -203,10 +211,12 @@ test('delete and create environment variables', function (assert) {
   settingsPage.environmentVariableForm.add();
 
   andThen(() => {
-    assert.equal(settingsPage.environmentVariables(0).name, 'drafted', 'expected leading whitespace to be trimmed');
-    assert.ok(settingsPage.environmentVariables(0).isPublic, 'expected environment variable to be public');
-    assert.ok(settingsPage.environmentVariables(0).isNewlyCreated, 'expected environment variable to be newly created');
-    assert.equal(settingsPage.environmentVariables(0).value, 'true', 'expected leading whitespace to be trimmed');
+    settingsPage.environmentVariables(0).as(environmentVariable => {
+      assert.equal(environmentVariable.name, 'drafted', 'expected leading whitespace to be trimmed');
+      assert.ok(environmentVariable.isPublic, 'expected environment variable to be public');
+      assert.ok(environmentVariable.isNewlyCreated, 'expected environment variable to be newly created');
+      assert.equal(environmentVariable.value, 'true', 'expected leading whitespace to be trimmed');
+    });
 
     assert.deepEqual(requestBodies.pop(), { env_var: {
       id: '1919',


### PR DESCRIPTION
My general approach here was to add this wherever there was
a series of assertions against the same member of a collection,
especially when the member was already stored for that use.