### PR TITLE
Add exclusion of minification for SVGs

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -51,6 +51,11 @@ module.exports = function () {
         'public/images/stroke-icons',
         'public/images/svg'
       ]
+    },
+    minifyJS: {
+      options: {
+        exclude: ['**/svgs.js']
+      }
     }
   });
 


### PR DESCRIPTION
If you look at [this example build](https://travis-ci.org/travis-ci/travis-web/jobs/224201723#L201), you see this warning:

```[BABEL] Note: The code generator has deoptimised the styling of "travis/svgs.js" as it exceeds the max of "100KB".```

I looked into this a bit and it appears that the “styling” it refers to is minification. Since it’s skipping it anyway, this change causes it to not even attempt it. I don’t anticipate the size of that file ever shrinking…

But now [I see that it’s apparently not about minification](https://travis-ci.org/travis-ci/travis-web/jobs/224501408#L203) or my configuration is incorrect so… I’m going to open and then close this.

Maybe this warning can just be ignored; I originally thought that it was wasting time but the wording suggests it’s just skipping it without any processing.