### PR TITLE
Fix normalizing pusher payload for repo

### DIFF
--- a/app/serializers/repo.js
+++ b/app/serializers/repo.js
@@ -1,7 +1,7 @@
-import V2FallbackSerializer from 'travis/serializers/v2_fallback';
+import RepoV2FallbackSerializer from 'travis/serializers/repo_v2_fallback';
 import EmbeddedRecordsMixin from 'ember-data/serializers/embedded-records-mixin';
 
-var Serializer = V2FallbackSerializer.extend(EmbeddedRecordsMixin, {
+var Serializer = RepoV2FallbackSerializer.extend(EmbeddedRecordsMixin, {
   attrs: {
     permissions: { key: '@permissions' }
   },

--- a/app/serializers/repo_v2_fallback.js
+++ b/app/serializers/repo_v2_fallback.js
@@ -1,0 +1,21 @@
+import V2FallbackSerializer from 'travis/serializers/v2_fallback';
+
+var Serializer = V2FallbackSerializer.extend({
+  normalize: function (modelClass, resourceHash) {
+    if (!resourceHash['@type']) {
+      let slug = resourceHash.slug;
+
+      if (slug && !resourceHash.name) {
+        resourceHash.name = slug.split('/')[1];
+      }
+
+      if (slug && !resourceHash.owner) {
+        resourceHash.owner = { login: slug.split('/')[0] };
+      }
+    }
+
+    return this._super(modelClass, resourceHash);
+  }
+});
+
+export default Serializer;

--- a/tests/unit/serializers/pusher-repo-test.js
+++ b/tests/unit/serializers/pusher-repo-test.js
@@ -1,0 +1,58 @@
+import { moduleForModel, test } from 'ember-qunit';
+
+moduleForModel('repo', 'Unit | Serializer | pusher-repo', {
+  // Specify the other units that are required for this test.
+  needs: ['serializer:repo', 'serializer:branch', 'serializer:build',
+    'serializer:commit', 'model:commit', 'model:job', 'model:branch',
+    'model:repo', 'model:build']
+});
+
+test('it serializes pusher payload', function (assert) {
+  let payload = {
+    'id': 1,
+    'slug': 'drogus/test-project-1',
+    'description': 'Test project',
+    'private': false,
+    'last_build_id': 2,
+    'last_build_number': '2',
+    'last_build_state': 'created',
+    'last_build_duration': null,
+    'last_build_language': null,
+    'last_build_started_at': null,
+    'last_build_finished_at': null,
+    'github_language': 'ruby',
+    'default_branch': {
+      'name': 'master',
+      'last_build_id': 2,
+      '@href': '/repo/1/branch/master',
+      'default_branch': true
+    },
+    'active': true,
+    'current_build_id': 2
+  };
+
+  let store = this.store();
+  let result = store.normalize('repo', payload);
+  let { type, id, attributes, relationships } = result.data;
+
+  assert.equal(type, 'repo');
+  assert.equal(id, '1');
+
+  let expectedAttributes = {
+    'slug': 'drogus/test-project-1',
+    'description': 'Test project',
+    'private': false,
+    'githubLanguage': 'ruby',
+    'active': true,
+    'owner': {
+      'login': 'drogus'
+    },
+    'name': 'test-project-1'
+  };
+  assert.deepEqual(attributes, expectedAttributes);
+
+  assert.deepEqual(Object.keys(relationships).sort(), ['currentBuild', 'defaultBranch']);
+
+  assert.deepEqual(relationships.currentBuild.data, { id: '2', type: 'build' });
+  assert.deepEqual(relationships.defaultBranch.data, { id: '/repo/1/branch/master', type: 'branch' });
+});


### PR DESCRIPTION
We get only slug from pusher, so if pusher payload is received for a
repo that's not already in the store, we will miss `name` and
`owner.login` properties.

This commit fixes the problem by adding the `name` and the `owner`
attributes during normalisation. I also created `RepoV2Serializer` to
not clutter regular V3 serializer with pusher stuff.