### PR TITLE
Use Chrome --headless for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,6 @@ cache:
     - bower_components
 
 before_install:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
   - "npm config set spin false"
   - npm install -g bower
   - bower --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ cache:
     - bower_components
 
 before_install:
-  - "npm config set spin false"
+  - npm config set spin false
   - npm install -g bower
   - bower --version
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,22 @@ matrix:
 sudo: false
 dist: trusty
 
+addons:
+  apt:
+    sources:
+    - google-chrome
+    packages:
+    - google-chrome-stable
+
 cache:
   directories:
     - node_modules
     - bower_components
 
 before_install:
-  - npm config set spin false
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - "npm config set spin false"
   - npm install -g bower
   - bower --version
 

--- a/testem.js
+++ b/testem.js
@@ -1,12 +1,11 @@
 /* eslint-env node */
 module.exports = {
-  'test_page': 'tests/index.html?hidepassed',
-  'disable_watching': true,
-  'launch_in_ci': [
-    'PhantomJS'
-  ],
-  'launch_in_dev': [
-    'PhantomJS',
-    'Chrome'
-  ]
+  framework: 'qunit',
+  test_page: 'tests/index.html?hidepassed',
+  disable_watching: true,
+  launch_in_ci: ['Chrome'],
+  launch_in_dev: ['Chrome'],
+  browser_args: {
+    'Chrome': ['--headless', '--disable-gpu', '--remote-debugging-port=9222'],
+  },
 };


### PR DESCRIPTION
Given that phantom.js' maintainer is stepping down and this would enable us to test directly on our most popular browser, this seems like the most sensible path going forward.

I'm able to run tests like this both on macOS and Linux, but not sure of Windows support.