### PR TITLE
Detect OS and set testem browser args accordingly

### DIFF
--- a/testem.js
+++ b/testem.js
@@ -1,4 +1,15 @@
 /* eslint-env node */
+const isMacOS = /^darwin/.test(process.platform);
+const isWindows = /^win/.test(process.platform);
+
+let browserArgs;
+
+if (isMacOS || isWindows) {
+  browserArgs = [];
+} else {
+  browserArgs = ['--headless', '--disable-gpu', '--remote-debugging-port=9222'];
+}
+
 module.exports = {
   framework: 'qunit',
   test_page: 'tests/index.html?hidepassed',
@@ -6,6 +17,6 @@ module.exports = {
   launch_in_ci: ['Chrome'],
   launch_in_dev: ['Chrome'],
   browser_args: {
-    'Chrome': ['--headless', '--disable-gpu', '--remote-debugging-port=9222'],
+    'Chrome': browserArgs,
   },
 };


### PR DESCRIPTION
The use of Chrome --headless breaks on Chrome versions under 59 on macOS/Windows. This detects the OS version and ensures we only run headless on Linux for the time being.