### PR TITLE
Add IE 9 to supported browsers list

### DIFF
--- a/config/targets.js
+++ b/config/targets.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   browsers: [
+    'ie 9',
     'last 2 Chrome versions',
     'last 2 Firefox versions',
     'last 1 Safari versions',


### PR DESCRIPTION
I’ve #1093 to fix this differently, but in the absence of
data about which browsers we should support, I’m going to
merge this one so recent updates can be deployed. This one
is less destructive; we can come back to it. I found out
about the problem via this thread:
https://github.com/ember-cli/ember-cli/issues/7006