### PR TITLE
Use Ember Exam even without concurrency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_script:
   - echo $PERCY_ENABLE
 
 script:
-  - ember try:one $EMBER_VERSION --skip-cleanup=true --- ember test --reporter dot
+  - ember try:one $EMBER_VERSION --skip-cleanup=true --- ember exam --reporter dot --random
 
 before_deploy:
   - ASSETS_HOST=https://s3.amazonaws.com/travis-error-pages ember build --env production


### PR DESCRIPTION
I had a spurious test failure, but no seed to go off of.

Changing to ember exam and passing the `random` option will ensure a seed is logged,
meaning we should be able to reproduce locally and fix once and for all.