### PR TITLE
Improve header/layout assertions for both default/pro

### DIFF
--- a/tests/acceptance/layouts/default-test.js
+++ b/tests/acceptance/layouts/default-test.js
@@ -1,6 +1,7 @@
 import { test } from 'qunit';
 import moduleForAcceptance from 'travis/tests/helpers/module-for-acceptance';
 import defaultHeader from 'travis/tests/pages/header/default';
+import defaultLayout from 'travis/tests/pages/layouts/default';
 
 moduleForAcceptance('Acceptance | layouts/default');
 
@@ -8,6 +9,7 @@ test('header layout when unauthenticated', function (assert) {
   defaultHeader.visit();
 
   andThen(function () {
+    assert.ok(defaultLayout.headerWrapperWhenUnauthenticated, 'Header is wrapped within proper DOM');
     assert.ok(defaultHeader.logoPresent, 'Default header has logo');
     assert.equal(defaultHeader.navigationLinks(0).title, 'Blog', 'Shows link to Blog');
     assert.equal(defaultHeader.navigationLinks(1).title, 'Status', 'Shows link to Status');
@@ -17,5 +19,26 @@ test('header layout when unauthenticated', function (assert) {
     assert.equal(defaultHeader.helpLinks(1).title, 'Imprint', 'Shows Link to Imprint');
 
     assert.ok(defaultHeader.loginLinkPresent, 'Default header has login button');
+  });
+});
+
+test('header layout when authenticated', function (assert) {
+  const currentUser = server.create('user');
+  signInUser(currentUser);
+
+  defaultHeader.visit();
+
+  andThen(function () {
+    assert.ok(defaultLayout.headerWrapperWhenAuthenticated, 'Header is wrapped within proper DOM');
+    assert.ok(defaultHeader.logoPresent, 'Default header has logo');
+    assert.ok(defaultHeader.broadcastsPresent, 'Default header shows broadcasts tower');
+    assert.equal(defaultHeader.navigationLinks(0).title, 'Blog', 'Shows link to Blog');
+    assert.equal(defaultHeader.navigationLinks(1).title, 'Status', 'Shows link to Status');
+
+    assert.ok(defaultHeader.helpDropdownPresent, 'Default header has help dropdown');
+    assert.equal(defaultHeader.helpLinks(0).title, 'Read Our Docs', 'Shows Docs help link');
+    assert.equal(defaultHeader.helpLinks(1).title, 'Imprint', 'Shows Link to Imprint');
+
+    assert.ok(defaultHeader.profileLinkPresent, 'Default header shows profile links');
   });
 });

--- a/tests/acceptance/layouts/pro-test.js
+++ b/tests/acceptance/layouts/pro-test.js
@@ -1,6 +1,7 @@
 import { test } from 'qunit';
 import moduleForAcceptance from 'travis/tests/helpers/module-for-acceptance';
 import proHeader from 'travis/tests/pages/header/pro';
+import proLayout from 'travis/tests/pages/layouts/pro';
 
 moduleForAcceptance('Acceptance | layouts/pro');
 
@@ -10,6 +11,7 @@ test('header layout when unauthenticated', function (assert) {
   proHeader.visit();
 
   andThen(function () {
+    assert.ok(proLayout.headerWrapperWhenUnauthenticated, 'Header is wrapped within proper DOM');
     assert.ok(proHeader.logoPresent, 'Pro header has logo');
 
     assert.equal(proHeader.navigationLinks(0).title, 'About Us', 'Shows link to team page');
@@ -17,5 +19,33 @@ test('header layout when unauthenticated', function (assert) {
     assert.equal(proHeader.navigationLinks(2).title, 'Enterprise', 'Shows link to Enterprise offering');
 
     assert.ok(proHeader.loginLinkPresent, 'Pro header has login button');
+  });
+});
+
+test('header layout when authenticated', function (assert) {
+  withFeature('proVersion');
+
+  const currentUser = server.create('user');
+  signInUser(currentUser);
+
+  proHeader.visit();
+
+  andThen(function () {
+    assert.ok(proLayout.headerWrapperWhenAuthenticated, 'Header is wrapped within proper DOM');
+    assert.ok(proHeader.logoPresent, 'Pro header has logo');
+    assert.ok(proHeader.broadcastsPresent, 'Pro header shows broadcasts tower');
+    assert.equal(proHeader.navigationLinks(0).title, 'Status', 'Shows link to Status');
+
+    assert.equal(proHeader.navDropdowns(0).title, 'Help', 'Shows Help dropdown');
+    assert.equal(proHeader.navDropdowns(0).childLinks(0).title, 'Email Support', 'Shows support link in Help dropdown');
+    assert.equal(proHeader.navDropdowns(0).childLinks(1).title, 'Read Our Docs', 'Shows docs link in Help dropdown');
+    assert.equal(proHeader.navDropdowns(0).childLinks(2).title, 'Twitter', 'Shows Twitter link in Help dropdown');
+
+    assert.equal(proHeader.navDropdowns(1).title, 'Legal', 'Shows Legal dropdown');
+    assert.equal(proHeader.navDropdowns(1).childLinks(0).title, 'Imprint', 'Shows Imprint link in Legal dropdown');
+    assert.equal(proHeader.navDropdowns(1).childLinks(1).title, 'Security', 'Shows Security link in Legal dropdown');
+    assert.equal(proHeader.navDropdowns(1).childLinks(2).title, 'Terms', 'Shows Terms link in Legal dropdown');
+
+    assert.ok(proHeader.profileLinkPresent, 'Pro header shows profile links');
   });
 });

--- a/tests/pages/header/default.js
+++ b/tests/pages/header/default.js
@@ -27,4 +27,6 @@ export default create({
   }),
 
   loginLinkPresent: contains('.auth-button.signed-out', { scope: '.topbar nav#navigation ul li.menu.profile' }),
+  broadcastsPresent: contains('.topbar .broadcast span.icon-broadcast.announcement'),
+  profileLinkPresent: contains('.navigation-anchor.signed-in', { scope: '.topbar nav#navigation ul li.menu.profile.signed-in' }),
 });

--- a/tests/pages/header/pro.js
+++ b/tests/pages/header/pro.js
@@ -17,5 +17,20 @@ export default create({
     },
   }),
 
+  navDropdowns: collection({
+    itemScope: 'nav#navigation ul li:has(span.navigation-anchor)',
+    item: {
+      title: text('span.navigation-anchor'),
+      childLinks: collection({
+        itemScope: 'ul.navigation-nested li',
+        item: {
+          title: text('a'),
+        },
+      }),
+    },
+  }),
+
   loginLinkPresent: contains('.auth-button.signed-out', { scope: '.topbar nav#navigation ul li.menu.profile' }),
+  broadcastsPresent: contains('.topbar .broadcast span.icon-broadcast.announcement'),
+  profileLinkPresent: contains('.navigation-anchor.signed-in', { scope: '.topbar nav#navigation ul li.menu.profile.signed-in' }),
 });

--- a/tests/pages/layouts/default.js
+++ b/tests/pages/layouts/default.js
@@ -1,0 +1,11 @@
+import {
+  create,
+  contains,
+  visitable
+} from 'ember-cli-page-object';
+
+export default create({
+  visit: visitable('/'),
+  headerWrapperWhenUnauthenticated: contains('.topbar', { scope: '.feature-wrapper .top.landing-page header.top' }),
+  headerWrapperWhenAuthenticated: contains('.topbar', { scope: '.feature-wrapper .main .wrapper.non-centered header.top' }),
+});

--- a/tests/pages/layouts/pro.js
+++ b/tests/pages/layouts/pro.js
@@ -1,0 +1,11 @@
+import {
+  create,
+  contains,
+  visitable
+} from 'ember-cli-page-object';
+
+export default create({
+  visit: visitable('/'),
+  headerWrapperWhenUnauthenticated: contains('.topbar', { scope: '.feature-wrapper .top.landing-pro header.top' }),
+  headerWrapperWhenAuthenticated: contains('.topbar', { scope: '.feature-wrapper .main .wrapper.non-centered header.top' }),
+});


### PR DESCRIPTION
This ensures we assert that the DOM wrappers that differ slightly between the two will stay intact. Also, adds assertions for the signed in state of the header. This gives me enough confidence to refactor 😸 .