### PR TITLE
Redirect unauthenticated users performing search to index page

### DIFF
--- a/app/routes/search.js
+++ b/app/routes/search.js
@@ -4,6 +4,7 @@ const { service } = Ember.inject;
 
 export default Ember.Route.extend({
   tabStates: service(),
+  auth: service(),
 
   renderTemplate() {
     this._super(...arguments);
@@ -12,6 +13,12 @@ export default Ember.Route.extend({
       into: 'search',
       outlet: 'left',
     });
+  },
+
+  redirect() {
+    if(!this.get('auth.signedIn')) {
+      this.transitionTo('index');
+    }
   },
 
   activate() {

--- a/app/routes/search.js
+++ b/app/routes/search.js
@@ -16,7 +16,7 @@ export default Ember.Route.extend({
   },
 
   redirect() {
-    if(!this.get('auth.signedIn')) {
+    if (!this.get('auth.signedIn')) {
       this.transitionTo('index');
     }
   },

--- a/tests/acceptance/search/flow-test.js
+++ b/tests/acceptance/search/flow-test.js
@@ -2,14 +2,12 @@ import { test } from 'qunit';
 import moduleForAcceptance from 'travis/tests/helpers/module-for-acceptance';
 import sidebarPage from 'travis/tests/pages/sidebar';
 
-moduleForAcceptance('Acceptance | search/flow', {
-  beforeEach() {
-    const currentUser = server.create('user');
-    signInUser(currentUser);
-  },
-});
+moduleForAcceptance('Acceptance | search/flow');
 
 test('searching from index page transitions to search page', function (assert) {
+  const currentUser = server.create('user');
+  signInUser(currentUser);
+
   server.create('repository');
 
   sidebarPage
@@ -19,5 +17,13 @@ test('searching from index page transitions to search page', function (assert) {
 
   andThen(function () {
     assert.equal(currentURL(), '/search/foo');
+  });
+});
+
+test('searching while unauthenticated redirects to landing page', function (assert) {
+  visit('/search/foo');
+
+  andThen(() => {
+    assert.equal(currentURL(), '/');
   });
 });


### PR DESCRIPTION
If an unauthenticated user attempts to perform a search, they're greeted with a broken page, as the API returns a 403. Given the API doesn't consider this a valid request, it makes sense to redirect users away from this screen.