### PR TITLE
Restore header/footer on landing pages

### DIFF
--- a/app/templates/layouts/landing-page.hbs
+++ b/app/templates/layouts/landing-page.hbs
@@ -1,0 +1,9 @@
+<div id="top" class="top landing-page">
+  {{top-bar landingPage=model.landingPage}}
+</div>
+
+{{flash-display}}
+
+{{yield}}
+
+{{page-footer}}

--- a/config/environment.js
+++ b/config/environment.js
@@ -37,7 +37,8 @@ module.exports = function (environment) {
     githubOrgsOauthAccessSettingsUrl: 'https://github.com/settings/connections/applications/f244293c729d5066cf27',
     ajaxPolling: false,
     logLimit: 10000,
-    emojiPrepend: ''
+    emojiPrepend: '',
+    statusPageStatusUrl: 'https://pnpcptp8xh9k.statuspage.io/api/v2/status.json'
   };
 
   ENV.featureFlags = {
@@ -46,7 +47,6 @@ module.exports = function (environment) {
     'enterprise-version': !!process.env.TRAVIS_ENTERPRISE || false
   };
 
-  var statusPageStatusUrl = 'https://pnpcptp8xh9k.statuspage.io/api/v2/status.json';
   var sentryDSN = 'https://e775f26d043843bdb7ae391dc0f2487a@app.getsentry.com/75334';
   ENV.enterprise = ENV.featureFlags['enterprise-version'];
 
@@ -62,7 +62,6 @@ module.exports = function (environment) {
       ENV.pusher.channelPrefix = 'private-';
       ENV.pagesEndpoint = 'https://billing.travis-ci.com';
       ENV.billingEndpoint = 'https://billing.travis-ci.com';
-      ENV.statusPageStatusUrl = statusPageStatusUrl;
       ENV.sentry = {
         dsn: sentryDSN
       };
@@ -97,8 +96,6 @@ module.exports = function (environment) {
     ENV.sentry = {
       development: true
     };
-
-    ENV.statusPageStatusUrl = statusPageStatusUrl;
   }
 
   if (environment === 'test') {
@@ -108,8 +105,6 @@ module.exports = function (environment) {
     ENV.intervals.searchDebounceRate = 0;
 
     ENV.APP.rootElement = '#ember-testing';
-
-    ENV.statusPageStatusUrl =  null;
 
     ENV.sentry = {
       development: true
@@ -152,8 +147,6 @@ module.exports = function (environment) {
         dsn: sentryDSN
       };
     }
-
-    ENV.statusPageStatusUrl = statusPageStatusUrl;
   }
 
   if (process.env.DEPLOY_TARGET) {

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -305,10 +305,10 @@ export default function () {
       });
     }
 
-    /**
-      * TODO remove this once the seializers/build is removed.
-      * The modelName causes Mirage to know how to serialise it.
-      */
+    /*
+     * TODO remove this once the seializers/build is removed.
+     * The modelName causes Mirage to know how to serialise it.
+     */
     return this.serialize(builds, 'build');
   });
 

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -6,6 +6,21 @@ import config from 'travis/config/environment';
 const { apiEndpoint } = config;
 
 export default function () {
+  this.get('https://pnpcptp8xh9k.statuspage.io/api/v2/status.json', function () {
+    return {
+      'page': {
+        'id': 'pnpcptp8xh9k',
+        'name': 'Travis CI',
+        'url': 'https://www.traviscistatus.com',
+        'updated_at': '2017-06-06T09:49:24.032Z'
+      },
+      'status': {
+        'indicator': 'none',
+        'description': 'AllSystems Operational'
+      }
+    };
+  });
+
   this.namespace = apiEndpoint;
 
   this.get('/users/:id');

--- a/tests/acceptance/layouts/about-test.js
+++ b/tests/acceptance/layouts/about-test.js
@@ -1,6 +1,7 @@
 import { test } from 'qunit';
 import moduleForAcceptance from 'travis/tests/helpers/module-for-acceptance';
 import defaultHeader from 'travis/tests/pages/header/default';
+import footer from 'travis/tests/pages/footer';
 
 moduleForAcceptance('Acceptance | layouts/about page');
 
@@ -19,5 +20,9 @@ test('about page renders correct header/footer', function (assert) {
     assert.equal(defaultHeader.helpLinks(1).title, 'Imprint', 'Shows Link to Imprint');
 
     assert.ok(defaultHeader.loginLinkPresent, 'Default header has login button');
+
+    assert.equal(footer.sections(1).title, '©Travis CI, GmbH', 'Shows company info section');
+    assert.equal(footer.sections(2).title, 'Help', 'Shows help info section');
+    assert.equal(footer.sections(3).title, 'Travis CI Status', 'Shows status info section');
   });
 });

--- a/tests/acceptance/layouts/about-test.js
+++ b/tests/acceptance/layouts/about-test.js
@@ -1,0 +1,23 @@
+import { test } from 'qunit';
+import moduleForAcceptance from 'travis/tests/helpers/module-for-acceptance';
+import defaultHeader from 'travis/tests/pages/header/default';
+
+moduleForAcceptance('Acceptance | layouts/about page');
+
+test('about page renders correct header/footer', function (assert) {
+  visit('/about');
+
+  andThen(function () {
+    assert.equal(currentURL(), '/about');
+
+    assert.ok(defaultHeader.logoPresent, 'Default header has logo');
+    assert.equal(defaultHeader.navigationLinks(0).title, 'Blog', 'Shows link to Blog');
+    assert.equal(defaultHeader.navigationLinks(1).title, 'Status', 'Shows link to Status');
+
+    assert.ok(defaultHeader.helpDropdownPresent, 'Default header has help dropdown');
+    assert.equal(defaultHeader.helpLinks(0).title, 'Read Our Docs', 'Shows Docs help link');
+    assert.equal(defaultHeader.helpLinks(1).title, 'Imprint', 'Shows Link to Imprint');
+
+    assert.ok(defaultHeader.loginLinkPresent, 'Default header has login button');
+  });
+});

--- a/tests/acceptance/layouts/logo-test.js
+++ b/tests/acceptance/layouts/logo-test.js
@@ -1,6 +1,7 @@
 import { test } from 'qunit';
 import moduleForAcceptance from 'travis/tests/helpers/module-for-acceptance';
 import defaultHeader from 'travis/tests/pages/header/default';
+import footer from 'travis/tests/pages/footer';
 
 moduleForAcceptance('Acceptance | layouts/logo page');
 
@@ -19,5 +20,9 @@ test('logo page renders correct header/footer', function (assert) {
     assert.equal(defaultHeader.helpLinks(1).title, 'Imprint', 'Shows Link to Imprint');
 
     assert.ok(defaultHeader.loginLinkPresent, 'Default header has login button');
+
+    assert.equal(footer.sections(1).title, '©Travis CI, GmbH', 'Shows company info section');
+    assert.equal(footer.sections(2).title, 'Help', 'Shows help info section');
+    assert.equal(footer.sections(3).title, 'Travis CI Status', 'Shows status info section');
   });
 });

--- a/tests/acceptance/layouts/logo-test.js
+++ b/tests/acceptance/layouts/logo-test.js
@@ -1,0 +1,23 @@
+import { test } from 'qunit';
+import moduleForAcceptance from 'travis/tests/helpers/module-for-acceptance';
+import defaultHeader from 'travis/tests/pages/header/default';
+
+moduleForAcceptance('Acceptance | layouts/logo page');
+
+test('logo page renders correct header/footer', function (assert) {
+  visit('/logo');
+
+  andThen(function () {
+    assert.equal(currentURL(), '/logo');
+
+    assert.ok(defaultHeader.logoPresent, 'Default header has logo');
+    assert.equal(defaultHeader.navigationLinks(0).title, 'Blog', 'Shows link to Blog');
+    assert.equal(defaultHeader.navigationLinks(1).title, 'Status', 'Shows link to Status');
+
+    assert.ok(defaultHeader.helpDropdownPresent, 'Default header has help dropdown');
+    assert.equal(defaultHeader.helpLinks(0).title, 'Read Our Docs', 'Shows Docs help link');
+    assert.equal(defaultHeader.helpLinks(1).title, 'Imprint', 'Shows Link to Imprint');
+
+    assert.ok(defaultHeader.loginLinkPresent, 'Default header has login button');
+  });
+});

--- a/tests/acceptance/layouts/plans-test.js
+++ b/tests/acceptance/layouts/plans-test.js
@@ -1,6 +1,7 @@
 import { test } from 'qunit';
 import moduleForAcceptance from 'travis/tests/helpers/module-for-acceptance';
 import proHeader from 'travis/tests/pages/header/pro';
+import footer from 'travis/tests/pages/footer';
 
 moduleForAcceptance('Acceptance | layouts/plans page');
 
@@ -19,6 +20,10 @@ test('plans page renders correct header/footer', function (assert) {
     assert.equal(proHeader.navigationLinks(2).title, 'Enterprise', 'Shows link to Enterprise offering');
 
     assert.ok(proHeader.loginLinkPresent, 'Pro header has login button');
+    assert.equal(footer.sections(1).title, '©Travis CI, GmbH', 'Shows company info section');
+    assert.equal(footer.sections(2).title, 'Help', 'Shows help info section');
+    assert.equal(footer.sections(3).title, 'Legal', 'Shows legal info section');
+    assert.equal(footer.sections(4).title, 'Travis CI Status', 'Shows status info section');
   });
 });
 

--- a/tests/acceptance/layouts/plans-test.js
+++ b/tests/acceptance/layouts/plans-test.js
@@ -1,0 +1,31 @@
+import { test } from 'qunit';
+import moduleForAcceptance from 'travis/tests/helpers/module-for-acceptance';
+import proHeader from 'travis/tests/pages/header/pro';
+
+moduleForAcceptance('Acceptance | layouts/plans page');
+
+test('plans page renders correct header/footer', function (assert) {
+  withFeature('proVersion');
+
+  visit('/plans');
+
+  andThen(function () {
+    assert.equal(currentURL(), '/plans');
+
+    assert.ok(proHeader.logoPresent, 'Pro header has logo');
+
+    assert.equal(proHeader.navigationLinks(0).title, 'About Us', 'Shows link to team page');
+    assert.equal(proHeader.navigationLinks(1).title, 'Plans & Pricing', 'Shows link to plans page');
+    assert.equal(proHeader.navigationLinks(2).title, 'Enterprise', 'Shows link to Enterprise offering');
+
+    assert.ok(proHeader.loginLinkPresent, 'Pro header has login button');
+  });
+});
+
+test('plans page redirects unless pro enabled', function (assert) {
+  visit('/plans');
+
+  andThen(function () {
+    assert.equal(currentURL(), '/');
+  });
+});

--- a/tests/pages/footer.js
+++ b/tests/pages/footer.js
@@ -1,0 +1,14 @@
+import {
+  create,
+  collection,
+  text,
+} from 'ember-cli-page-object';
+
+export default create({
+  sections: collection({
+    itemScope: 'footer.footer .inner .footer-elem',
+    item: {
+      title: text('h3.footer-title'),
+    },
+  }),
+});


### PR DESCRIPTION
This was inadvertently removed as part of the Ember 2.13 release.