### PR TITLE
Mark ember-concurrency `TaskInstance` errors as benign

### DIFF
--- a/app/services/raven.js
+++ b/app/services/raven.js
@@ -4,6 +4,7 @@ import config from 'travis/config/environment';
 export default RavenLogger.extend({
   benignErrors: [
     'TransitionAborted',
+    'TaskInstance'
     'UnrecognizedURLError',
     'not found',
     'returned a 403',


### PR DESCRIPTION
The error messages we are seeing appears to be just expected behavior. We would expect a task to be dropped if a second task is created when one is already running