### PR TITLE
Ignore `needs-auth` error

### DIFF
--- a/app/services/raven.js
+++ b/app/services/raven.js
@@ -10,7 +10,8 @@ export default RavenLogger.extend({
     'returned a 403',
     'returned a 404',
     'operation failed',
-    'operation was aborted'
+    'operation was aborted',
+    'needs-auth'
   ],
 
   unhandledPromiseErrorMessage: '',


### PR DESCRIPTION
This is not an exceptional case.