### PR TITLE
Update build header to use lone job status

### DIFF
--- a/app/components/build-header.js
+++ b/app/components/build-header.js
@@ -66,8 +66,12 @@ export default Ember.Component.extend({
     return this.get('externalLinks').githubBranch(slug, branchName);
   },
 
-  @computed('item.jobs.firstObject.state', 'item.state')
-  singleJobStateWithFallback(jobState, buildState) {
-    return jobState || buildState;
+  @computed('item.jobs.firstObject.state', 'item.state', 'isMatrix')
+  singleJobStateWithFallback(jobState, buildState, isMatrix) {
+    if (isMatrix) {
+      return buildState;
+    } else {
+      return jobState || buildState;
+    }
   }
 });

--- a/app/components/build-header.js
+++ b/app/components/build-header.js
@@ -64,5 +64,10 @@ export default Ember.Component.extend({
   @computed('item.repo.slug', 'build.branchName')
   urlGitHubBranch(slug, branchName) {
     return this.get('externalLinks').githubBranch(slug, branchName);
+  },
+
+  @computed('item.jobs.firstObject.state', 'item.state')
+  singleJobStateWithFallback(jobState, buildState) {
+    return jobState || buildState;
   }
 });

--- a/app/components/build-header.js
+++ b/app/components/build-header.js
@@ -67,7 +67,7 @@ export default Ember.Component.extend({
   },
 
   @computed('item.jobs.firstObject.state', 'item.state', 'isMatrix')
-  singleJobStateWithFallback(jobState, buildState, isMatrix) {
+  buildState(jobState, buildState, isMatrix) {
     if (isMatrix) {
       return buildState;
     } else {

--- a/app/templates/components/build-header.hbs
+++ b/app/templates/components/build-header.hbs
@@ -69,10 +69,17 @@
         <span class='inner-underline'>#{{item.number}} {{humanize-state item.state}}</span>
       {{/link-to}}
     {{else}}
-      {{#link-to "build" repo item}}
-        {{request-icon event=item.eventType state=item.state}}
-        <span class='inner-underline'>#{{item.number}} {{humanize-state item.state}}</span>
-      {{/link-to}}
+      {{#if item.isMatrix}}
+        {{#link-to "build" repo item}}
+          {{request-icon event=item.eventType state=item.state}}
+          <span class='inner-underline'>#{{item.number}} {{humanize-state item.state}}</span>
+        {{/link-to}}
+      {{else}}
+        {{#link-to "build" repo item}}
+          {{request-icon event=item.eventType state=item.jobs.firstObject.state}}
+          <span class='inner-underline'>#{{item.number}} {{humanize-state item.jobs.firstObject.state}}</span>
+        {{/link-to}}
+      {{/if}}
     {{/if}}
   </h3>
 

--- a/app/templates/components/build-header.hbs
+++ b/app/templates/components/build-header.hbs
@@ -70,8 +70,8 @@
       {{/link-to}}
     {{else}}
       {{#link-to "build" repo item}}
-        {{request-icon event=item.eventType state=singleJobStateWithFallback}}
-        <span class='inner-underline'>#{{item.number}} {{humanize-state singleJobStateWithFallback}}</span>
+        {{request-icon event=item.eventType state=buildState}}
+        <span class='inner-underline'>#{{item.number}} {{humanize-state buildState}}</span>
       {{/link-to}}
     {{/if}}
   </h3>

--- a/app/templates/components/build-header.hbs
+++ b/app/templates/components/build-header.hbs
@@ -76,8 +76,8 @@
         {{/link-to}}
       {{else}}
         {{#link-to "build" repo item}}
-          {{request-icon event=item.eventType state=item.jobs.firstObject.state}}
-          <span class='inner-underline'>#{{item.number}} {{humanize-state item.jobs.firstObject.state}}</span>
+          {{request-icon event=item.eventType state=singleJobStateWithFallback}}
+          <span class='inner-underline'>#{{item.number}} {{humanize-state singleJobStateWithFallback}}</span>
         {{/link-to}}
       {{/if}}
     {{/if}}

--- a/app/templates/components/build-header.hbs
+++ b/app/templates/components/build-header.hbs
@@ -69,17 +69,10 @@
         <span class='inner-underline'>#{{item.number}} {{humanize-state item.state}}</span>
       {{/link-to}}
     {{else}}
-      {{#if item.isMatrix}}
-        {{#link-to "build" repo item}}
-          {{request-icon event=item.eventType state=item.state}}
-          <span class='inner-underline'>#{{item.number}} {{humanize-state item.state}}</span>
-        {{/link-to}}
-      {{else}}
-        {{#link-to "build" repo item}}
-          {{request-icon event=item.eventType state=singleJobStateWithFallback}}
-          <span class='inner-underline'>#{{item.number}} {{humanize-state singleJobStateWithFallback}}</span>
-        {{/link-to}}
-      {{/if}}
+      {{#link-to "build" repo item}}
+        {{request-icon event=item.eventType state=singleJobStateWithFallback}}
+        <span class='inner-underline'>#{{item.number}} {{humanize-state singleJobStateWithFallback}}</span>
+      {{/link-to}}
     {{/if}}
   </h3>
 

--- a/tests/acceptance/builds/current-tab-test.js
+++ b/tests/acceptance/builds/current-tab-test.js
@@ -2,6 +2,7 @@ import { test } from 'qunit';
 import moduleForAcceptance from 'travis/tests/helpers/module-for-acceptance';
 import currentRepoTab from 'travis/tests/pages/repo-tabs/current';
 import jobTabs from 'travis/tests/pages/job-tabs';
+import jobPage from 'travis/tests/pages/job';
 
 moduleForAcceptance('Acceptance | builds/current tab', {
   beforeEach() {
@@ -22,13 +23,13 @@ test('renders most recent repository without builds', function (assert) {
   });
 });
 
-test('renders most recent repository and most recent build when builds present', function (assert) {
+test('renders most recent repository and most recent build when builds present, single-job build shows job status instead', function (assert) {
   let repository =  server.create('repository', { slug: 'travis-ci/travis-web' });
 
   const branch = server.create('branch', { name: 'acceptance-tests' });
   let commit = server.create('commit', { author_email: 'mrt@travis-ci.org', author_name: 'Mr T', committer_email: 'mrt@travis-ci.org', committer_name: 'Mr T', branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
-  let build = server.create('build', { number: '5', state: 'passed', repository, branch, commit });
-  let job = server.create('job', { number: '1234.1', state: 'passed', build, commit, repository, config: { language: 'Hello' } });
+  let build = server.create('build', { number: '5', state: 'started', repository, branch, commit });
+  let job = server.create('job', { number: '1234.1', state: 'received', build, commit, repository, config: { language: 'Hello' } });
 
   commit.update('build', build);
   commit.update('job', job);
@@ -39,6 +40,8 @@ test('renders most recent repository and most recent build when builds present',
   andThen(() => {
     assert.equal(document.title, 'travis-ci/travis-web - Travis CI');
     assert.ok(currentRepoTab.currentTabActive, 'Current tab is active by default when loading dashboard');
+
+    assert.equal(jobPage.state, '#5 booting', 'expected a single-job build’s state to be the job’s state');
   });
 
   andThen(() => {

--- a/tests/pages/repo-tabs/current.js
+++ b/tests/pages/repo-tabs/current.js
@@ -10,6 +10,6 @@ export default create({
   visit: visitable('travis-ci/travis-web'),
   currentTabActive: hasClass('active', '#tab_current'),
   showsNoBuildsMessaging: text('.missing-notice h2.page-title'),
-  showsCurrentBuild: hasClass('passed', 'section.build-header'),
+  showsCurrentBuild: hasClass('started', 'section.build-header'),
   noJobsErrorMessage: isVisible('.notice-banner--red')
 });


### PR DESCRIPTION
This is unsightly and perhaps can be improved but even now I’m a bit confused about how to handle asynchronous relationships in computed properties.