### PR TITLE
Remove unused Gravatar image link generator

### DIFF
--- a/app/services/external-links.js
+++ b/app/services/external-links.js
@@ -1,4 +1,3 @@
-/* global md5 */
 import Ember from 'ember';
 import config from 'travis/config/environment';
 
@@ -21,10 +20,6 @@ export default Ember.Service.extend({
 
   email(email) {
     return `mailto:${email}`;
-  },
-
-  gravatarImage(email, size) {
-    return `https://www.gravatar.com/avatar/${(md5(email.toLowerCase()))}?s=${size}&d=blank`;
   },
 
   travisWebBranch(branchName) {

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "travis",
   "dependencies": {
-    "JavaScript-MD5": "~2.3.0",
     "moment": "~2.13.0",
     "jquery-timeago": "~1.5.2",
     "pusher": "~2.2.3",

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -58,7 +58,6 @@ module.exports = function () {
 
   app.import('bower_components/pusher/dist/pusher.js');
   app.import('bower_components/jquery-timeago/jquery.timeago.js');
-  app.import('bower_components/JavaScript-MD5/js/md5.js');
   app.import('bower_components/moment/moment.js');
 
   app.import('bower_components/js-emoji/demo/emoji.css');

--- a/tests/unit/services/external-links-test.js
+++ b/tests/unit/services/external-links-test.js
@@ -39,13 +39,6 @@ test('email', function (assert) {
   assert.equal(service.email(email), 'mailto:builder@travis-ci.com');
 });
 
-test('gravatarImage', function (assert) {
-  let service = this.subject();
-  const email = 'builder@travis-ci.com';
-  const size = 'large';
-  assert.equal(service.gravatarImage(email, size), 'https://www.gravatar.com/avatar/7e04deb54e09fefd971875250cf6b415?s=large&d=blank');
-});
-
 test('travisWebBranch', function (assert) {
   const service = this.subject();
   const branchName = 'bd-no-justice-no-peace';


### PR DESCRIPTION
My original plan was to move this from a Bower to an npm
dependency, but it appears to be unused apart from the test.