### PR TITLE
remove query params that throw api errors

### DIFF
--- a/app/routes/dashboard/repositories.js
+++ b/app/routes/dashboard/repositories.js
@@ -17,9 +17,7 @@ export default TravisRoute.extend({
   model() {
     return Ember.RSVP.hash({
       repos: this.store.query('repo', {
-        active: true,
-        withLastBuild: true,
-        sort_by: 'last_build.finished_at:desc'
+        active: true
       }),
       accounts: this.store.query('account', {
         all: true


### PR DESCRIPTION
Apparently leftover params that were once planned in api but never made it in?
In any case, this will hopefully help clear up API logs