### PR TITLE
Fix SVG false positive visual diffs.

### DIFF
--- a/app/styles/app/layout.sass
+++ b/app/styles/app/layout.sass
@@ -100,10 +100,6 @@
     width: grid-calc(31, 36)
     margin-left: grid-calc(5, 36)
 
-body.testing
-  svg
-    shape-rendering: crispedges
-
 .feature-wrapper.dashboard
   #left
     display: none

--- a/tests/index.html
+++ b/tests/index.html
@@ -17,8 +17,11 @@
 
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}
+
+    <!-- Testing-only style that reduces false positives on SVG visual diffs in Percy. -->
+    <style>svg { shape-rendering: geometricPrecision; }</style>
   </head>
-  <body class='testing'>
+  <body>
     {{content-for "body"}}
     {{content-for "test-body"}}
 


### PR DESCRIPTION
@backspace — a followup to this PR from long ago: https://github.com/travis-ci/travis-web/pull/848

## The bug

SVGs have been seemingly flaky in Percy for a while, causing annoying false positive visual diffs.

![screen shot 2017-06-22 at 4 21 42 pm](https://user-images.githubusercontent.com/75300/27460148-eabae8d4-5766-11e7-893d-1a72565f38cc.png)

## The root cause
After digging into this a bit, the root cause is actually a bug introduced by https://github.com/travis-ci/travis-web/commit/d82b9cfffd9781cc8ea678262ab5ed0c1ddb7167#diff-7c16ab3f88a04758b1b87951c3d1385eR12

This line was added to the features route:

```javascript
Ember.$('body').attr('class', 'features');
```

That line will override _all_ classes on the `<body>` tag, causing the tag that originally looks like this:

```
<body id="home" class="testing">
```

To become:
```
<body id="home" class="features">
```

Because the `body` tag is _shared across test runs_ and only the `ember-test-container` changes, losing the `testing` class causes the SVG style to no longer be applied for any tests that follow. **The craziest part** of all this is that this will be affected by the order of the test runs —
 after a test happens to run that navigates to `routes/features.js`, the `testing` class will be removed from the body, causing different CSS to be applied in the DOM and sent to Percy for rendering. This side-effect on future tests is the reason this has seemed so flaky.

![screen shot 2017-06-22 at 3 52 37 pm](https://user-images.githubusercontent.com/75300/27460154-f3cdda8a-5766-11e7-94b6-c765910b7edb.png)
![screen shot 2017-06-22 at 3 52 32 pm](https://user-images.githubusercontent.com/75300/27460155-f3d0630e-5766-11e7-9620-cd59137891d2.png)

## The fix

Just remove the `body.testing` style and apply it directly in `tests/index.html` so it's applied always in tests regardless, and not in production CSS at all. Also, use `geometricPrecision` instead of `crispedges` which should still be deterministic but make SVGs look better and more like the real world.