### PR TITLE
Bump Ember-Data to 2.14.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ember-cli-uglify": "^1.2.0",
     "ember-computed-decorators": "0.3.0",
     "ember-concurrency": "0.8.5",
-    "ember-data": "2.12.2",
+    "ember-data": "2.14.2",
     "ember-data-filter": "1.13.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-exam": "0.7.0",


### PR DESCRIPTION
There was a confusing failing test in the `2.13` version that I had intended to debug, but this appears to pass 🤷‍♂️ .