### PR TITLE
Deduplicate repository layout

### DIFF
--- a/app/components/repository-layout.js
+++ b/app/components/repository-layout.js
@@ -1,0 +1,32 @@
+import Ember from 'ember';
+import computed from 'ember-computed-decorators';
+
+const { service } = Ember.inject;
+
+export default Ember.Component.extend({
+  statusImages: service(),
+
+  @computed('repo.slug', 'repo.defaultBranch.name')
+  statusImageUrl(slug, branchName) {
+    return this.get('statusImages').imageUrl(slug, branchName);
+  },
+
+  @computed('build.jobs.@each.{config}')
+  jobsLoaded(jobs) {
+    if (jobs) {
+      return jobs.isEvery('config');
+    }
+  },
+
+  @computed('build.jobs.[]')
+  noJobsError(jobs) {
+    return jobs.length < 1;
+  },
+
+  actions: {
+    statusImages() {
+      this.get('popup').open('status-images');
+      return false;
+    }
+  },
+});

--- a/app/components/repository-layout.js
+++ b/app/components/repository-layout.js
@@ -5,6 +5,7 @@ const { service } = Ember.inject;
 
 export default Ember.Component.extend({
   statusImages: service(),
+  popup: service(),
 
   @computed('repo.slug', 'repo.defaultBranch.name')
   statusImageUrl(slug, branchName) {

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -33,36 +33,9 @@ export default Ember.Controller.extend({
     return `landing/${version}-page`;
   },
 
-  @computed('repo.slug', 'repo.defaultBranch.name')
-  statusImageUrl(slug, branchName) {
-    return this.get('statusImages').imageUrl(slug, branchName);
-  },
-
   @alias('repos.repos.firstObject') repo: null,
 
   @alias('tabStates.mainTab') tab: null,
 
   @alias('repo.currentBuild') build: null,
-
-  @alias('repo.currentBuild.jobs.firstObject') job: null,
-
-  @computed('build.jobs.@each.{config}')
-  jobsLoaded(jobs) {
-    if (jobs) {
-      return jobs.isEvery('config');
-    }
-  },
-
-  @computed('build.jobs.[]')
-  noJobsError(jobs) {
-    return jobs.length < 1;
-  },
-
-  actions: {
-    statusImages() {
-      this.get('popup').open('status-images');
-      return false;
-    }
-  },
-
 });

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -38,4 +38,6 @@ export default Ember.Controller.extend({
   @alias('tabStates.mainTab') tab: null,
 
   @alias('repo.currentBuild') build: null,
+
+  @alias('build.jobs.firstObject') job: null,
 });

--- a/app/templates/components/repository-layout.hbs
+++ b/app/templates/components/repository-layout.hbs
@@ -1,0 +1,51 @@
+<article class="repo-header">
+  <header>
+    <h1 class="repo-title">{{#link-to "owner" repo.owner.login}}{{repo.owner.login}}{{/link-to}} / {{#link-to "repo" repo}}{{repo.name}}{{/link-to}}</h1>
+      <a href="{{urlGithub}}" title="{{repo.name}} on GitHub" class="repo-gh">
+        {{inline-svg 'icon-repooctocat'}}</a>
+      <div class="repo-badge">
+        <a href="#" id="status-image-popup" title="Latest push build on default branch: {{repo.defaultBranch.lastBuild.state}}" name="status-images" class="open-popup" {{action "statusImages"}}>
+          <img src={{statusImageUrl}} alt="build:{{repo.defaultBranch.lastBuild.state}}"/>
+        </a>
+      </div>
+  </header>
+  <main class="repo-main">
+  <div class="repo-navigation">
+    {{repo-show-tools repo=repo build=build job=job tab=tab}}
+    {{repo-show-tabs repo=repo tab=tab build=build job=job}}
+  </div>
+  <div class="travistab-body repo-body">
+    {{#build-wrapper build=build}}
+      {{#if loading}}
+        {{loading-indicator}}
+      {{else}}
+
+        {{#if build}}
+          {{build-header item=build commit=build.commit repo=repo}}
+
+          {{#if noJobsError}}
+            <p class="notice-banner--red">Sorry, we're having troubles fetching jobs. Please try again later.</p>
+          {{else}}
+            {{#if build.isMatrix}}
+              {{#if jobsLoaded}}
+                {{jobs-list jobs=build.requiredJobs repo=repo required="true"}}
+                {{jobs-list jobs=build.allowedFailureJobs repo=repo}}
+              {{else}}
+                {{loading-indicator center=true}}
+              {{/if}}
+            {{else}}
+              {{job-infrastructure-notification job=job}}
+              {{job-tabs job=job repo=repo}}
+              {{job-log job=job}}
+            {{/if}}
+          {{/if}}
+
+        {{else}}
+          {{no-builds}}
+        {{/if}}
+
+      {{/if}}
+    {{/build-wrapper}}
+  </div>
+  </main>
+</article>

--- a/app/templates/components/repository-layout.hbs
+++ b/app/templates/components/repository-layout.hbs
@@ -15,37 +15,41 @@
     {{repo-show-tabs repo=repo tab=tab build=build job=job}}
   </div>
   <div class="travistab-body repo-body">
-    {{#build-wrapper build=build}}
-      {{#if loading}}
-        {{loading-indicator}}
-      {{else}}
+    {{#if hasBlock}}
+      {{yield}}
+    {{else}}
+      {{#build-wrapper build=build}}
+        {{#if loading}}
+          {{loading-indicator}}
+        {{else}}
 
-        {{#if build}}
-          {{build-header item=build commit=build.commit repo=repo}}
+          {{#if build}}
+            {{build-header item=build commit=build.commit repo=repo}}
 
-          {{#if noJobsError}}
-            <p class="notice-banner--red">Sorry, we're having troubles fetching jobs. Please try again later.</p>
-          {{else}}
-            {{#if build.isMatrix}}
-              {{#if jobsLoaded}}
-                {{jobs-list jobs=build.requiredJobs repo=repo required="true"}}
-                {{jobs-list jobs=build.allowedFailureJobs repo=repo}}
-              {{else}}
-                {{loading-indicator center=true}}
-              {{/if}}
+            {{#if noJobsError}}
+              <p class="notice-banner--red">Sorry, we're having troubles fetching jobs. Please try again later.</p>
             {{else}}
-              {{job-infrastructure-notification job=job}}
-              {{job-tabs job=job repo=repo}}
-              {{job-log job=job}}
+              {{#if build.isMatrix}}
+                {{#if jobsLoaded}}
+                  {{jobs-list jobs=build.requiredJobs repo=repo required="true"}}
+                  {{jobs-list jobs=build.allowedFailureJobs repo=repo}}
+                {{else}}
+                  {{loading-indicator center=true}}
+                {{/if}}
+              {{else}}
+                {{job-infrastructure-notification job=job}}
+                {{job-tabs job=job repo=repo}}
+                {{job-log job=job}}
+              {{/if}}
             {{/if}}
+
+          {{else}}
+            {{no-builds}}
           {{/if}}
 
-        {{else}}
-          {{no-builds}}
         {{/if}}
-
-      {{/if}}
-    {{/build-wrapper}}
+      {{/build-wrapper}}
+    {{/if}}
   </div>
   </main>
 </article>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -12,57 +12,7 @@
             {{repos-empty}}
           {{else}}
             {{#if repo.isLoaded}}
-              <article class="repo-header">
-                <header>
-                  <h1 class="repo-title">{{#link-to "owner" repo.owner.login}}{{repo.owner.login}}{{/link-to}} / {{#link-to "repo" repo}}{{repo.name}}{{/link-to}}</h1>
-                    <a href="{{urlGithub}}" title="{{repo.name}} on GitHub" class="repo-gh">
-                      {{inline-svg 'icon-repooctocat'}}</a>
-                    <div class="repo-badge">
-                      <a href="#" id="status-image-popup" title="Latest push build on default branch: {{repo.defaultBranch.lastBuild.state}}" name="status-images" class="open-popup" {{action "statusImages"}}>
-                        <img src={{statusImageUrl}} alt="build:{{repo.defaultBranch.lastBuild.state}}"/>
-                      </a>
-                    </div>
-                </header>
-                <main class="repo-main">
-                <div class="repo-navigation">
-                  {{repo-show-tools repo=repo build=build job=job tab=tab}}
-                  {{repo-show-tabs repo=repo tab=tab build=build job=job}}
-                </div>
-                <div class="travistab-body repo-body">
-                  {{#build-wrapper build=build}}
-                    {{#if loading}}
-                      {{loading-indicator}}
-                    {{else}}
-
-                      {{#if build}}
-                        {{build-header item=build commit=build.commit repo=repo}}
-
-                        {{#if noJobsError}}
-                          <p class="notice-banner--red">Sorry, we're having troubles fetching jobs. Please try again later.</p>
-                        {{else}}
-                          {{#if build.isMatrix}}
-                            {{#if jobsLoaded}}
-                              {{jobs-list jobs=build.requiredJobs repo=repo required="true"}}
-                              {{jobs-list jobs=build.allowedFailureJobs repo=repo}}
-                            {{else}}
-                              {{loading-indicator center=true}}
-                            {{/if}}
-                          {{else}}
-                            {{job-infrastructure-notification job=job}}
-                            {{job-tabs job=job repo=repo}}
-                            {{job-log job=job}}
-                          {{/if}}
-                        {{/if}}
-
-                      {{else}}
-                        {{no-builds}}
-                      {{/if}}
-
-                    {{/if}}
-                  {{/build-wrapper}}
-                </div>
-                </main>
-              </article>
+              {{repository-layout repo=repo build=build job=job tab=tab}}
             {{else}}
               {{loading-indicator}}
             {{/if}}

--- a/app/templates/repo.hbs
+++ b/app/templates/repo.hbs
@@ -12,31 +12,9 @@
           {{repos-empty}}
         {{else}}
           {{#if repo.isLoaded}}
-            <article class="repo-header">
-              <header>
-                <h1 class="repo-title">{{#link-to "owner" repo.owner.login}}{{repo.owner.login}}{{/link-to}} / {{#link-to "repo" repo}}{{repo.name}}{{/link-to}}</h1>
-                  <a href="{{urlGithub}}" title="{{repo.name}} on GitHub" class="repo-gh">
-                    {{inline-svg 'icon-repooctocat'}}</a>
-                  <div class="repo-badge">
-                    <a href="#" id="status-image-popup" title="Latest push build on default branch: {{repo.defaultBranch.lastBuild.state}}" name="status-images" class="open-popup" {{action "statusImages"}}>
-                      <img src={{statusImageUrl}} alt="build:{{repo.defaultBranch.lastBuild.state}}"/>
-                    </a>
-                  </div>
-              </header>
-              <main class="repo-main">
-              <div class="repo-navigation">
-                {{repo-show-tools repo=repo build=build job=job tab=tab}}
-
-                {{repo-show-tabs repo=repo tab=tab build=build job=job}}
-              </div>
-              <div class="travistab-body repo-body">
-                {{outlet}}
-              </div>
-              </main>
-            </article>
-
-          {{else}}
-            {{loading-indicator}}
+            {{#repository-layout repo=repo build=build job=job tab=tab}}
+              {{outlet}}
+            {{/repository-layout}}
           {{/if}}
         {{/if}}
 


### PR DESCRIPTION
Part of moving the `index` page to rendering components forced me to duplicate the logic between the `repo` template and `index`. That was meant to be temporary, and this should fix it.

@drogus @lislis @backspace One thing I'm not really sure of here is naming. I'd like for to start having stronger naming conventions/better organization between components (given we have a number of them all under `app/components/`, but I'm not sure that `repository-layout` is in line with that or if that even conveys what I intended.

I was trying to capture the non-sidebar/main section of the page, and given this component wraps all build/job information at the repository level, I think this makes sense. But I'd be happy to hear other ideas if you have them 😄 