### PR TITLE
Use `router` service polyfill instead of private `-routing` service

### DIFF
--- a/app/components/branch-row.js
+++ b/app/components/branch-row.js
@@ -4,7 +4,7 @@ import config from 'travis/config/environment';
 const { service } = Ember.inject;
 
 export default Ember.Component.extend({
-  routing: service('-routing'),
+  router: service(),
   permissions: service(),
   externalLinks: service(),
 
@@ -69,7 +69,7 @@ export default Ember.Component.extend({
 
   actions: {
     viewAllBuilds() {
-      return this.get('routing').transitionTo('builds');
+      return this.get('router').transitionTo('builds');
     }
   }
 });

--- a/app/components/repos-list-item.js
+++ b/app/components/repos-list-item.js
@@ -5,7 +5,7 @@ import colorForState from 'travis/utils/color-for-state';
 const { service } = Ember.inject;
 
 export default Ember.Component.extend(Polling, {
-  routing: service('-routing'),
+  router: service(),
   tagName: 'li',
   pollModels: 'repo',
   classNames: ['repo'],

--- a/app/services/auth.js
+++ b/app/services/auth.js
@@ -6,7 +6,7 @@ import computed, { alias } from 'ember-computed-decorators';
 const { service } = Ember.inject;
 
 export default Ember.Service.extend({
-  routing: service('-routing'),
+  router: service(),
   flashes: service(),
   store: service(),
   storage: service(),
@@ -201,7 +201,7 @@ export default Ember.Service.extend({
   syncingDidChange: Ember.observer('isSyncing', 'currentUser', function () {
     const user = this.get('currentUser');
     if (user && user.get('isSyncing') && !user.get('syncedAt')) {
-      return this.get('routing').transitionTo('first_sync');
+      return this.get('router').transitionTo('first_sync');
     }
   }),
 

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "ember-qunit-nice-errors": "1.1.2",
     "ember-resolver": "4.1.0",
     "ember-route-action-helper": "^2.0.3",
+    "ember-router-service-polyfill": "^1.0.1",
     "ember-source": "2.13.3",
     "emberx-select": "~3.0.0",
     "glob": "^7.1.2",


### PR DESCRIPTION
This polyfill can likely be removed as of Ember 2.15. Adding this now as it moves us away from using private API sooner rather than later.