### PR TITLE
Fix Node version at 6.9.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "visibilityjs": "^1.2.4"
   },
   "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
+    "node": "6.9.5"
   },
   "private": true
 }


### PR DESCRIPTION
We are having failed Heroku deployments on Node 8, might as well stick
with a known working version for now.