### PR TITLE
Fix build state display

### DIFF
--- a/app/components/build-header.js
+++ b/app/components/build-header.js
@@ -66,7 +66,7 @@ export default Ember.Component.extend({
     return this.get('externalLinks').githubBranch(slug, branchName);
   },
 
-  @computed('item.jobs.firstObject.state', 'item.state', 'isMatrix')
+  @computed('item.jobs.firstObject.state', 'item.state', 'item.isMatrix')
   buildState(jobState, buildState, isMatrix) {
     if (isMatrix) {
       return buildState;


### PR DESCRIPTION
The referenced property in the `buildState` computed property was incorrect.

This should fix https://github.com/travis-pro/team-teal/issues/2043.