### PR TITLE
Randomize loading logo

### DIFF
--- a/app/components/loading-screen.js
+++ b/app/components/loading-screen.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+const { service } = Ember.inject;
+
+export default Ember.Component.extend({
+  randomLogo: service(),
+});

--- a/app/services/random-logo.js
+++ b/app/services/random-logo.js
@@ -1,0 +1,28 @@
+import Ember from 'ember';
+
+export default Ember.Service.extend({
+  logoVariants: [
+    'Tessa-1',
+    'Tessa-2',
+    'Tessa-3',
+    'Tessa-4',
+    'Tessa-pride-4',
+    'Tessa-pride',
+    'TravisCI-Mascot-1',
+    'TravisCI-Mascot-2',
+    'TravisCI-Mascot-3',
+    'TravisCI-Mascot-4',
+    'TravisCI-Mascot-4',
+    'TravisCI-Mascot-pride',
+  ],
+
+  init(...args) {
+    this._super(args);
+    this.set('logo', this.randomLogo());
+  },
+
+  randomLogo() {
+    const logos = this.get('logoVariants');
+    return logos[Math.floor(Math.random() * logos.length)];
+  },
+});

--- a/app/templates/application-loading.hbs
+++ b/app/templates/application-loading.hbs
@@ -93,8 +93,7 @@
 
   <div class="main">
     <div class="content-page">
-      <img src="/images/logos/TravisCI-Mascot-1.svg"  alt="Travis CI mascot" width="200" height="200">
-      {{loading-indicator center=true}}
+      {{loading-screen}}
     </div>
   </div>
 

--- a/app/templates/components/loading-screen.hbs
+++ b/app/templates/components/loading-screen.hbs
@@ -1,0 +1,2 @@
+<img src="/images/logos/{{randomLogo.logo}}.svg"  alt="Travis CI Logo" width="200" height="200">
+{{loading-indicator center=true}}

--- a/app/templates/dashboard/loading.hbs
+++ b/app/templates/dashboard/loading.hbs
@@ -1,4 +1,3 @@
 <div class="content-page">
-  <img src="/images/logos/TravisCI-Mascot-1.svg"  alt="Travis CI mascot" width="200" height="200">
-  {{loading-indicator center=true}}
+  {{loading-screen}}
 </div>

--- a/app/templates/loading.hbs
+++ b/app/templates/loading.hbs
@@ -93,8 +93,7 @@
 
   <div class="main">
     <div class="content-page">
-      <img src="/images/logos/TravisCI-Mascot-1.svg"  alt="Travis CI mascot" width="200" height="200">
-      {{loading-indicator center=true}}
+      {{loading-screen}}
     </div>
   </div>
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -12,7 +12,7 @@ module.exports = function () {
   } else {
     fingerprint = {
       // FIXME this is probably not desired
-      exclude: ['images/emoji', 'images/pro-landing/flag*', 'images/team'],
+      exclude: ['images/emoji', 'images/logos', 'images/pro-landing/flag*', 'images/team'],
       extensions: ['js', 'css', 'png', 'jpg', 'gif', 'map', 'svg']
     };
 


### PR DESCRIPTION
This shows a random logo (from all the SVG variants I noticed)
when the user first boots up the app.

Implementation-wise, it might be confusing at first as to why the
`random-logo` service was added instead of making this a part of the
`loading-screen` component. The reason is that we utilize several layers of loading
templates which -- were the randomization done at the component level --
would mean that the logo might jump between available options as we transition between loading screens. This would be jarring, so I opted for making the selection when the service
is first initialized and then referencing that state whenever the
component is used.

This should likely be behind some sort of feature flag before it goes
public.

See https://github.com/travis-pro/team-teal/issues/1729 for more details.