### PR TITLE
Revert chunked subscription to Pusher channels

### DIFF
--- a/app/utils/pusher.js
+++ b/app/utils/pusher.js
@@ -44,27 +44,14 @@ TravisPusher.prototype.init = function (config, ajaxService) {
 };
 
 TravisPusher.prototype.subscribeAll = function (channels) {
-  const results = [];
-  subscribeToChannelChunk(channels, 0, 1000, results, this);
-
+  var channel, i, len, results;
+  results = [];
+  for (i = 0, len = channels.length; i < len; i++) {
+    channel = channels[i];
+    results.push(this.subscribe(channel));
+  }
   return results;
 };
-
-function subscribeToChannelChunk(channels, chunk, chunkSize, results, target) {
-  const index = chunk * chunkSize;
-  const channelChunk = channels.slice(index, index + chunkSize);
-
-  for (let i = 0; i < channelChunk.length; i++) {
-    const channel = channelChunk[i];
-    results.push(target.subscribe(channel));
-  }
-
-  if (chunk < channels.length / chunkSize) {
-    Ember.run.later(function () {
-      subscribeToChannelChunk(channels, chunk + 1, chunkSize, results, target);
-    }, 1000);
-  }
-}
 
 TravisPusher.prototype.unsubscribeAll = function (channels) {
   var channel, i, len, results;


### PR DESCRIPTION
My unfamilarity with this code caused problems in the pro environment,
where subsequent chunk subscriptions failed because of incorrect
authorisation information. I’m going to fully revert for now.

The general idea of the problem is that the `bulk_ajax` method fetches
authorisation information for each channel in bulk, but since it happens
synchronously, it was only fetching it for the first chunk of channels.
I’d like to change it to fetch for each chunk.