### PR TITLE
Add background subscription to Pusher channels

### DIFF
--- a/app/utils/pusher.js
+++ b/app/utils/pusher.js
@@ -46,7 +46,7 @@ TravisPusher.prototype.init = function (config, ajaxService) {
 TravisPusher.prototype.subscribeAll = function (channels) {
   const results = [];
   this.unsubscribedChannelChunks = [];
-  subscribeToChannelChunk(channels, 0, 10, results, this);
+  subscribeToChannelChunk(channels, 0, 1000, results, this);
 
   return results;
 };

--- a/app/utils/pusher.js
+++ b/app/utils/pusher.js
@@ -221,7 +221,9 @@ if (ENV.featureFlags['pro-version'] || ENV.featureFlags['enterprise-version']) {
     name = this.channel.name;
     names = unsubscribedChannelChunk.channelNames;
     unsubscribedChannelChunk.callbacks.push(function (auths) {
+      //eslint-disable-next-line
       console.log('for these channel names', names);
+      //eslint-disable-next-line
       console.log('these auths came back:', auths);
       return _callback(false, {
         auth: auths[name]


### PR DESCRIPTION
This somewhat works, but I get subscription errors when testing
locally for 16 of the 167 channels it tries to subscribe to.
It seems to fail for the first channel of every chunk.

I’m putting this aside for now, too frustrated!