### PR TITLE
Update Trusty banner

### DIFF
--- a/app/components/job-infrastructure-notification.js
+++ b/app/components/job-infrastructure-notification.js
@@ -23,7 +23,7 @@ export default Ember.Component.extend({
   isTrustySudoFalse: Ember.computed.equal('queue', 'builds.ec2'),
 
   @computed('job.startedAt', 'job.config')
-  isTrustyStable(startedAt, config) {
+  isTrustyStable(startedAt, config = {}) {
     if (config.dist === 'trusty' && config.group === 'stable') {
       const jobRanAfterReleaseDate = Date.parse(startedAt) > Date.parse(LATEST_TRUSTY_RELEASE);
       if (jobRanAfterReleaseDate) {

--- a/app/components/job-infrastructure-notification.js
+++ b/app/components/job-infrastructure-notification.js
@@ -24,7 +24,7 @@ export default Ember.Component.extend({
 
   @computed('job.startedAt', 'queue', 'job.config')
   isTrustyStable(startedAt, queue, config) {
-    if (queue === 'builds.gce' && config.dist === 'trusty' && config.group === 'stable') {
+    if (config.dist === 'trusty' && config.group === 'stable') {
       const jobRanAfterReleaseDate = Date.parse(startedAt) > Date.parse(LATEST_TRUSTY_RELEASE);
       if (jobRanAfterReleaseDate) {
         return true;

--- a/app/components/job-infrastructure-notification.js
+++ b/app/components/job-infrastructure-notification.js
@@ -22,8 +22,8 @@ export default Ember.Component.extend({
 
   isTrustySudoFalse: Ember.computed.equal('queue', 'builds.ec2'),
 
-  @computed('job.startedAt', 'queue', 'job.config')
-  isTrustyStable(startedAt, queue, config) {
+  @computed('job.startedAt', 'job.config')
+  isTrustyStable(startedAt, config) {
     if (config.dist === 'trusty' && config.group === 'stable') {
       const jobRanAfterReleaseDate = Date.parse(startedAt) > Date.parse(LATEST_TRUSTY_RELEASE);
       if (jobRanAfterReleaseDate) {

--- a/app/templates/components/job-infrastructure-notification.hbs
+++ b/app/templates/components/job-infrastructure-notification.hbs
@@ -12,7 +12,7 @@
     {{/if}}
     {{#if isTrustyStable}}
       {{#notice-banner}}
-       This job {{conjugatedRun}} on our <b>Trusty</b> environment, which is gradually becoming our default Linux enviroment. Read all about this <a href="https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming?utm_source=web&utm_medium=banner&&utm_campaign=trusty-default">in our blog: Trusty as a default Linux is coming </a> and take note that you can add <code>dist: precise</code> in your .travis.yml file to continue using Precise.
+       This job {{conjugatedRun}} on our <b>Trusty</b> environment, which is gradually becoming our default Linux enviroment. Read all about this <a href="https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming?utm_source=web&utm_medium=banner&&utm_campaign=trusty-default">in our blog: Trusty as a default Linux is coming</a> and take note that you can add <code>dist: precise</code> in your .travis.yml file to continue using Precise.
       {{/notice-banner}}
     {{/if}}
   {{/if}}

--- a/app/templates/components/job-infrastructure-notification.hbs
+++ b/app/templates/components/job-infrastructure-notification.hbs
@@ -7,12 +7,12 @@
     {{/if}}
     {{#if isPreciseEOL}}
       {{#notice-banner}}
-        This job {{conjugatedRun}} on our Precise environment, which is in the process of being decommissioned.  Please read about the rollout of Trusty as default <a href="https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming">on the blog</a>, and take note that you can explicitly stay on Precise by specifying <code>dist: precise</code> in your .travis.yml.
+        This job {{conjugatedRun}} on our <b>Precise</b> environment, which is in the process of being decommissioned.  Please read about the rollout of Trusty as default <a href="https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming">on the blog</a>, and take note that you can explicitly stay on Precise by specifying <code>dist: precise</code> in your .travis.yml.
       {{/notice-banner}}
     {{/if}}
     {{#if isTrustyStable}}
       {{#notice-banner}}
-       This job {{conjugatedRun}} on our Trusty environment, which was updated on Wednesday, July 12th. Read all about it in the <a href="https://docs.travis-ci.com/user/build-environment-updates/2017-07-12">docs</a> and take note that you can add <code>group: deprecated-2017Q3</code> in your .travis.yml file to use the previous version.
+       This job {{conjugatedRun}} on our <b>Trusty</b> environment, which is gradually becoming our default Linux enviroment. Read all about this <a href="https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming?utm_source=web&utm_medium=banner&&utm_campaign=trusty-default">in our blog: Trusty as a default Linux is coming </a> and take note that you can add <code>dist: precise</code> in your .travis.yml file to continue using Precise.
       {{/notice-banner}}
     {{/if}}
   {{/if}}


### PR DESCRIPTION
For the incremental update of our default Linux environment from Precise to Trusty

https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming