### PR TITLE
Move to ember-decorators

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,11 +1,10 @@
 import config from 'travis/config/environment';
-import Ember from 'ember';
 import ActiveModelAdapter from 'active-model-adapter';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default ActiveModelAdapter.extend({
-  auth: service(),
+  @service auth: null,
+
   host: config.apiEndpoint,
   coalesceFindRequests: true,
 

--- a/app/adapters/beta-feature.js
+++ b/app/adapters/beta-feature.js
@@ -1,10 +1,8 @@
-import Ember from 'ember';
 import V3Adapter from 'travis/adapters/v3';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default V3Adapter.extend({
-  auth: service(),
+  @service auth: null,
 
   buildURL(modelName, id, snapshot, requestType) {
     let url = this._super(...arguments);

--- a/app/adapters/v3.js
+++ b/app/adapters/v3.js
@@ -1,11 +1,11 @@
 import Ember from 'ember';
 import config from 'travis/config/environment';
 import RESTAdapter from 'ember-data/adapters/rest';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default RESTAdapter.extend({
-  auth: service(),
+  @service auth: null,
+
   host: config.apiEndpoint,
 
   sortQueryParams: false,

--- a/app/components/add-cron-job.js
+++ b/app/components/add-cron-job.js
@@ -1,11 +1,11 @@
 import Ember from 'ember';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 import { task } from 'ember-concurrency';
 
 export default Ember.Component.extend({
+  @service store: null,
+
   classNames: ['form--cron'],
-  store: service(),
 
   reset() {
     this.setProperties({

--- a/app/components/add-env-var.js
+++ b/app/components/add-env-var.js
@@ -1,14 +1,14 @@
 import Ember from 'ember';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 import { task } from 'ember-concurrency';
 
 export default Ember.Component.extend({
+  @service store: null,
+  @service raven: null,
+  @service flashes: null,
+
   classNames: ['form--envvar'],
   classNameBindings: ['nameIsBlank:form-error'],
-  store: service(),
-  raven: service(),
-  flashes: service(),
 
   isValid() {
     if (Ember.isBlank(this.get('name'))) {

--- a/app/components/add-ssh-key.js
+++ b/app/components/add-ssh-key.js
@@ -1,12 +1,12 @@
 import Ember from 'ember';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 import { task } from 'ember-concurrency';
 
 export default Ember.Component.extend({
+  @service store: null,
+
   classNames: ['form--sshkey'],
   classNameBindings: ['valueError:form-error'],
-  store: service(),
   isSaving: false,
 
   didInsertElement() {

--- a/app/components/branch-row.js
+++ b/app/components/branch-row.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import config from 'travis/config/environment';
+import { computed } from 'ember-decorators/object';
 import { service } from 'ember-decorators/service';
 
 export default Ember.Component.extend({
@@ -14,13 +15,13 @@ export default Ember.Component.extend({
   isTriggering: false,
   hasTriggered: false,
 
-  urlGithubCommit: Ember.computed('branch.last_build', function () {
-    let slug = this.get('branch.repository.slug');
-    let commitSha = this.get('branch.last_build.commit.sha');
-    return this.get('externalLinks').githubCommit(slug, commitSha);
-  }),
+  @computed('branch.repository.slug', 'branch.last_build.commit.sha')
+  urlGithubCommit(slug, sha) {
+    return this.get('externalLinks').githubCommit(slug, sha);
+  },
 
-  getLast5Builds: Ember.computed(function () {
+  @computed()
+  getLast5Builds() {
     let apiEndpoint, branchName, lastBuilds, options, repoId;
     lastBuilds = Ember.ArrayProxy.create({
       content: [{}, {}, {}, {}, {}],
@@ -64,7 +65,7 @@ export default Ember.Component.extend({
       });
     }
     return lastBuilds;
-  }),
+  },
 
   actions: {
     viewAllBuilds() {

--- a/app/components/branch-row.js
+++ b/app/components/branch-row.js
@@ -1,12 +1,11 @@
 import Ember from 'ember';
 import config from 'travis/config/environment';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default Ember.Component.extend({
-  router: service(),
-  permissions: service(),
-  externalLinks: service(),
+  @service router: null,
+  @service permissions: null,
+  @service externalLinks: null,
 
   tagName: 'li',
   classNameBindings: ['branch.last_build.state'],

--- a/app/components/build-header.js
+++ b/app/components/build-header.js
@@ -23,13 +23,13 @@ export default Ember.Component.extend({
     }
   },
 
-  isJob: Ember.computed('item', function () {
-    if (this.get('item.build')) {
+  @computed('item.build')
+  isJob(build) {
+    if (build) {
       return true;
-    } else {
-      return false;
     }
-  }),
+    return false;
+  },
 
   @computed('isJob')
   build(isJob) {
@@ -40,20 +40,15 @@ export default Ember.Component.extend({
     }
   },
 
-  displayCompare: Ember.computed('item.eventType', function () {
-    let eventType = this.get('item.eventType');
-    if (eventType === 'api' || eventType === 'cron') {
-      return false;
-    } else {
-      return true;
-    }
-  }),
+  @computed('item.eventType')
+  displayCompare(eventType) {
+    return !['api', 'cron'].includes(eventType);
+  },
 
-  urlGithubCommit: Ember.computed('repo.slug', 'commit.sha', function () {
-    const slug = this.get('repo.slug');
-    const sha = this.get('commit.sha');
+  @computed('repo.slug', 'commit.sha')
+  urlGithubCommit(slug, sha) {
     return this.get('externalLinks').githubCommit(slug, sha);
-  }),
+  },
 
   @computed('item.startedAt', 'item.finishedAt')
   elapsedTime(startedAt, finishedAt) {

--- a/app/components/build-header.js
+++ b/app/components/build-header.js
@@ -1,11 +1,10 @@
 import Ember from 'ember';
 import { computed } from 'ember-decorators/object';
 import durationFrom from 'travis/utils/duration-from';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default Ember.Component.extend({
-  externalLinks: service(),
+  @service externalLinks: null,
 
   tagName: 'section',
   classNames: ['build-header'],

--- a/app/components/build-header.js
+++ b/app/components/build-header.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import computed from 'ember-computed-decorators';
+import { computed } from 'ember-decorators/object';
 import durationFrom from 'travis/utils/duration-from';
 
 const { service } = Ember.inject;

--- a/app/components/build-layout.js
+++ b/app/components/build-layout.js
@@ -1,24 +1,23 @@
 import Ember from 'ember';
+import { computed } from 'ember-decorators/object';
+import { alias } from 'ember-decorators/object/computed';
 
 export default Ember.Component.extend({
-  job: Ember.computed.alias('build.jobs.firstObject'),
+  @alias('build.jobs.firstObject') job: null,
 
-  noJobsError: Ember.computed('build.jobs', function () {
-    if (this.get('build.jobs.length') === 0) {
-      return true;
-    }
-  }),
+  @computed('build.jobs.[]')
+  noJobsError(jobs) {
+    return jobs.get('length') === 0;
+  },
 
-  loading: Ember.computed('build.isLoading', function () {
-    return this.get('build.isLoading');
-  }),
+  @alias('build.isLoading') loading: null,
 
-  jobsLoaded: Ember.computed('build.jobs.@each.config', function () {
-    let jobs = this.get('build.jobs');
+  @computed('build.jobs.@each.config')
+  jobsLoaded(jobs) {
     if (jobs) {
       return jobs.isEvery('config');
     }
-  }),
+  },
 
   buildStateDidChange: Ember.observer('build.state', function () {
     if (this.get('sendFaviconStateChanges')) {

--- a/app/components/build-tile.js
+++ b/app/components/build-tile.js
@@ -1,18 +1,17 @@
 import Ember from 'ember';
+import { computed } from 'ember-decorators/object';
 
 export default Ember.Component.extend({
   tagName: 'li',
   classNameBindings: ['build.state'],
   attributeBindings: ['title'],
 
-  title: Ember.computed('build', function () {
-    let num, state;
-    num = this.get('build.number');
-    state = this.get('build.state');
-    if (num) {
-      return `Build #${num} ${state}`;
+  @computed('build.{number,state}')
+  title(number, state) {
+    if (number) {
+      return `Build #${number} ${state}`;
     } else {
       return '';
     }
-  })
+  },
 });

--- a/app/components/build-wrapper.js
+++ b/app/components/build-wrapper.js
@@ -1,11 +1,13 @@
 import Ember from 'ember';
+import { computed } from 'ember-decorators/object';
 import colorForState from 'travis/utils/color-for-state';
 
 export default Ember.Component.extend({
   classNameBindings: ['color'],
   pollModels: 'build',
 
-  color: Ember.computed('build.state', function () {
-    return colorForState(this.get('build.state'));
-  })
+  @computed('build.state')
+  color(buildState) {
+    return colorForState(buildState);
+  },
 });

--- a/app/components/builds-item.js
+++ b/app/components/builds-item.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import computed from 'ember-computed-decorators';
+import { computed } from 'ember-decorators/object';
 
 const { service } = Ember.inject;
 

--- a/app/components/builds-item.js
+++ b/app/components/builds-item.js
@@ -1,10 +1,9 @@
 import Ember from 'ember';
 import { computed } from 'ember-decorators/object';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default Ember.Component.extend({
-  externalLinks: service(),
+  @service externalLinks: null,
 
   tagName: 'li',
   classNameBindings: ['build.state'],

--- a/app/components/caches-item.js
+++ b/app/components/caches-item.js
@@ -1,11 +1,11 @@
 import Ember from 'ember';
 import config from 'travis/config/environment';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 import { task } from 'ember-concurrency';
 
 export default Ember.Component.extend({
-  ajax: service(),
+  @service ajax: null,
+
   tagName: 'li',
   classNames: ['cache-item'],
   classNameBindings: ['cache.type'],

--- a/app/components/cron-job.js
+++ b/app/components/cron-job.js
@@ -1,13 +1,13 @@
 import Ember from 'ember';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 import { task } from 'ember-concurrency';
 
 export default Ember.Component.extend({
+  @service store: null,
+
   tagName: 'li',
   classNames: ['settings-cron'],
   actionType: 'Save',
-  store: service(),
   dontRunIfRecentBuildExists: Ember.computed('cron.dont_run_if_recent_build_exists', function () {
     if (this.get('cron.dont_run_if_recent_build_exists')) {
       return 'Do not run if there has been a build in the last 24h';

--- a/app/components/cron-job.js
+++ b/app/components/cron-job.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import { service } from 'ember-decorators/service';
+import { computed } from 'ember-decorators/object';
 import { task } from 'ember-concurrency';
 
 export default Ember.Component.extend({
@@ -8,13 +9,14 @@ export default Ember.Component.extend({
   tagName: 'li',
   classNames: ['settings-cron'],
   actionType: 'Save',
-  dontRunIfRecentBuildExists: Ember.computed('cron.dont_run_if_recent_build_exists', function () {
-    if (this.get('cron.dont_run_if_recent_build_exists')) {
+
+  @computed('cron.dont_run_if_recent_build_exists')
+  dontRunIfRecentBuildExists(dontRun) {
+    if (dontRun) {
       return 'Do not run if there has been a build in the last 24h';
-    } else {
-      return 'Always run';
     }
-  }),
+    return 'Always run';
+  },
 
   delete: task(function* () {
     yield this.get('cron').destroyRecord();

--- a/app/components/dashboard-row.js
+++ b/app/components/dashboard-row.js
@@ -1,13 +1,13 @@
 import Ember from 'ember';
-
-const { service } = Ember.inject;
-const { alias } = Ember.computed;
+import { service } from 'ember-decorators/service';
+import { computed } from 'ember-decorators/object';
+import { alias } from 'ember-decorators/object/computed';
 
 export default Ember.Component.extend({
-  permissions: service(),
-  externalLinks: service(),
-  ajax: service(),
-  flashes: service(),
+  @service('permissions') permissionsService: null,
+  @service externalLinks: null,
+  @service ajax: null,
+  @service flashes: null,
 
   tagName: 'li',
   classNameBindings: ['repo.active:is-active'],
@@ -16,17 +16,17 @@ export default Ember.Component.extend({
   isTriggering: false,
   dropupIsOpen: false,
 
-  currentBuild: alias('repo.currentBuild'),
+  @alias('repo.currentBuild') currentBuild: null,
 
-  urlGithubCommit: Ember.computed('repo.slug', 'currentBuild.commit.sha', function () {
-    const slug = this.get('repo.slug');
-    const sha = this.get('currentBuild.commit.sha');
+  @computed('repo.slug', 'currentBuild.commit.sha')
+  urlGithubCommit(slug, sha) {
     return this.get('externalLinks').githubCommit(slug, sha);
-  }),
+  },
 
-  displayMenuTofu: Ember.computed('permissions.all', 'repo', function () {
-    return this.get('permissions').hasPushPermission(this.get('repo'));
-  }),
+  @computed('permissions.all', 'repo')
+  displayMenuTofu(permissions, repo) {
+    return this.get('permissionsService').hasPushPermission(repo);
+  },
 
   openDropup() {
     this.toggleProperty('dropupIsOpen');
@@ -57,9 +57,11 @@ export default Ember.Component.extend({
     openDropup() {
       this.openDropup();
     },
+
     triggerBuild() {
       this.triggerBuild();
     },
+
     starRepo() {
       if (this.get('repo.starred')) {
         this.get('unstar').perform(this.get('repo'));

--- a/app/components/env-var.js
+++ b/app/components/env-var.js
@@ -1,16 +1,16 @@
 import Ember from 'ember';
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 import { task } from 'ember-concurrency';
 
 export default Ember.Component.extend({
+  @service flashes: null,
+
   tagName: 'li',
   classNames: ['settings-envvar'],
   classNameBindings: ['envVar.public:is-public', 'envVar.newlyCreated:newly-created'],
   validates: { name: ['presence'] },
   actionType: 'Save',
   showValueField: Ember.computed.alias('public'),
-
-  flashes: service(),
 
   value: Ember.computed('envVar.value', 'envVar.public', function () {
     if (this.get('envVar.public')) {

--- a/app/components/env-var.js
+++ b/app/components/env-var.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
 import { service } from 'ember-decorators/service';
+import { computed } from 'ember-decorators/object';
+import { alias } from 'ember-decorators/object/computed';
 import { task } from 'ember-concurrency';
 
 export default Ember.Component.extend({
@@ -10,15 +12,15 @@ export default Ember.Component.extend({
   classNameBindings: ['envVar.public:is-public', 'envVar.newlyCreated:newly-created'],
   validates: { name: ['presence'] },
   actionType: 'Save',
-  showValueField: Ember.computed.alias('public'),
+  @alias('public') showValueField: null,
 
-  value: Ember.computed('envVar.value', 'envVar.public', function () {
-    if (this.get('envVar.public')) {
-      return this.get('envVar.value');
-    } else {
-      return '••••••••••••••••';
+  @computed('envVar.{value,public}')
+  value(value, isPublic) {
+    if (isPublic) {
+      return value;
     }
-  }),
+    return '••••••••••••••••';
+  },
 
   delete: task(function* () {
     yield this.get('envVar').destroyRecord().catch(({ errors }) => {

--- a/app/components/feature-toggle.js
+++ b/app/components/feature-toggle.js
@@ -1,15 +1,14 @@
 import Ember from 'ember';
 import { task } from 'ember-concurrency';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default Ember.Component.extend({
+  @service features: null,
+  @service flashes: null,
+
   tagName: 'a',
   classNames: ['switch'],
   classNameBindings: ['feature.enabled:active', 'disabled:disabled', 'disabled:inline-block'],
-
-  features: service(),
-  flashes: service(),
 
   click() {
     this.get('toggleFeatureTask').perform(this.get('feature'));
@@ -22,13 +21,12 @@ export default Ember.Component.extend({
         this.applyFeatureState(feature);
       });
     } catch (e) {
-      // eslint-disable-next-line
-      this.get('flashes').error('There was an error while switching the feature. Please try again.');
+      const errMsg = 'There was an error while switching the feature. Please try again.';
+      this.get('flashes').error(errMsg);
     }
   }),
 
   applyFeatureState(feature) {
-    // let { dasherizedName, enabled } = feature.getProperties('name', 'enabled');
     let { name, enabled } = feature.getProperties('name', 'enabled');
     if (enabled) {
       this.get('features').enable(name);

--- a/app/components/flash-display.js
+++ b/app/components/flash-display.js
@@ -1,13 +1,14 @@
 import Ember from 'ember';
-
-const { alias } = Ember.computed;
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
+import { alias } from 'ember-decorators/object/computed';
 
 export default Ember.Component.extend({
-  flashes: service(),
+  @service flashes: null,
+
   classNames: ['flash'],
   tagName: 'ul',
-  messages: alias('flashes.messages'),
+
+  @alias('flashes.messages') messages: null,
 
   actions: {
     closeMessage(msg) {

--- a/app/components/flash-item.js
+++ b/app/components/flash-item.js
@@ -1,20 +1,24 @@
 import Ember from 'ember';
+import { computed } from 'ember-decorators/object';
+import { alias } from 'ember-decorators/object/computed';
+import { service } from 'ember-decorators/service';
 
 export default Ember.Component.extend({
   tagName: 'li',
   classNameBindings: ['type', 'topBarVisible:below-top-bar:fixed'],
 
-  flashes: Ember.inject.service(),
+  @service flashes: null,
 
-  type: Ember.computed('flash.type', function () {
-    return this.get('flash.type') || 'broadcast';
-  }),
+  @computed('flash.type')
+  type(type) {
+    return type || 'broadcast';
+  },
 
-  topBarVisible: Ember.computed.alias('flashes.topBarVisible'),
+  @alias('flashes.topBarVisible') topBarVisible: null,
 
   actions: {
     close() {
       return this.attrs.close(this.get('flash'));
     }
-  }
+  },
 });

--- a/app/components/job-infrastructure-notification.js
+++ b/app/components/job-infrastructure-notification.js
@@ -1,26 +1,23 @@
 /* global moment */
 import Ember from 'ember';
-import computed from 'ember-computed-decorators';
+import { computed } from 'ember-decorators/object';
+import { alias, equal } from 'ember-decorators/object/computed';
 
 const NOVEMBER_2016_RETIREMENT = '2016-11-28T12:00:00-08:00';
 const JANUARY_2017_RETIREMENT = '2017-01-20T12:00:00-08:00';
 const LATEST_TRUSTY_RELEASE = '2017-07-12T18:00:00-00:00';
 
 export default Ember.Component.extend({
-  queue: Ember.computed.alias('job.queue'),
-  jobConfig: Ember.computed.alias('job.config'),
+  @alias('job.queue') queue: null,
+  @alias('job.config') jobConfig: null,
 
-  conjugatedRun: Ember.computed('job.isFinished', function () {
-    if (this.get('job.isFinished')) {
-      return 'ran';
-    } else {
-      return 'is running';
-    }
-  }),
+  @computed('job.isFinished')
+  conjugatedRun(isFinished) {
+    return isFinished ? 'ran' : 'is running';
+  },
 
-  isLegacyInfrastructure: Ember.computed.equal('queue', 'builds.linux'),
-
-  isTrustySudoFalse: Ember.computed.equal('queue', 'builds.ec2'),
+  @equal('queue', 'builds.linux') isLegacyInfrastructure: null,
+  @equal('queue', 'builds.ec2') isTrustySudoFalse: null,
 
   @computed('job.startedAt', 'job.config')
   isTrustyStable(startedAt, config = {}) {
@@ -34,7 +31,7 @@ export default Ember.Component.extend({
     return false;
   },
 
-  isMacStadium6: Ember.computed.equal('queue', 'builds.macstadium6'),
+  @equal('queue', 'builds.macstadium6') isMacStadium6: null,
 
   @computed('queue', 'job.config')
   isPreciseEOL(queue, config) {
@@ -45,7 +42,7 @@ export default Ember.Component.extend({
     }
   },
 
-  macOSImage: Ember.computed.alias('jobConfig.osx_image'),
+  @alias('jobConfig.osx_image') macOSImage: null,
 
   deprecatedXcodeImages:
     ['beta-xcode6.1', 'beta-xcode6.2', 'beta-xcode6.3', 'xcode7', 'xcode7.1', 'xcode7.2'],

--- a/app/components/job-log.js
+++ b/app/components/job-log.js
@@ -1,7 +1,9 @@
 import Ember from 'ember';
+import { alias } from 'ember-decorators/object/computed';
 
 export default Ember.Component.extend({
-  log: Ember.computed.alias('job.log'),
+  @alias('job.log') log: null,
+
   classNames: ['job-log'],
 
   didReceiveAttrs() {

--- a/app/components/job-wrapper.js
+++ b/app/components/job-wrapper.js
@@ -1,20 +1,20 @@
 import Ember from 'ember';
 import colorForState from 'travis/utils/color-for-state';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
+import { computed } from 'ember-decorators/object';
 
 export default Ember.Component.extend({
-  externalLinks: service(),
+  @service externalLinks: null,
 
   pollModels: 'job.build',
 
-  color: Ember.computed('job.state', function () {
-    return colorForState(this.get('job.state'));
-  }),
+  @computed('job.state')
+  color(jobState) {
+    return colorForState(jobState);
+  },
 
-  urlGithubCommit: Ember.computed('repo.slug', 'commit.sha', function () {
-    const slug = this.get('repo.slug');
-    const sha = this.get('commit.sha');
+  @computed('repo.slug', 'commit.sha')
+  urlGithubCommit(slug, sha) {
     return this.get('externalLinks').githubCommit(slug, sha);
-  })
+  },
 });

--- a/app/components/jobs-item.js
+++ b/app/components/jobs-item.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import { computed } from 'ember-decorators/object';
 import jobConfigLanguage from 'travis/utils/job-config-language';
 
 export default Ember.Component.extend({
@@ -6,17 +7,17 @@ export default Ember.Component.extend({
   classNameBindings: ['job.state'],
   classNames: ['jobs-item'],
 
-  languages: Ember.computed('job.config', function () {
-    return jobConfigLanguage(this.get('job.config'));
-  }),
+  @computed('job.config')
+  languages(config) {
+    return jobConfigLanguage(config);
+  },
 
-  environment: Ember.computed('job.config.env', 'job.config.gemfile', function () {
-    let env = this.get('job.config.env');
-    let gemfile = this.get('job.config.gemfile');
+  @computed('job.config.{env,gemfile}')
+  environment(env, gemfile) {
     if (env) {
       return env;
     } else if (gemfile) {
       return `Gemfile: ${gemfile}`;
     }
-  })
+  },
 });

--- a/app/components/limit-concurrent-builds.js
+++ b/app/components/limit-concurrent-builds.js
@@ -1,17 +1,18 @@
 import Ember from 'ember';
+import { computed } from 'ember-decorators/object';
 import { task } from 'ember-concurrency';
 
 export default Ember.Component.extend({
   classNames: ['limit-concurrent-builds'],
 
-  description: Ember.computed('enabled', function () {
-    let description;
-    description = 'Limit concurrent jobs';
-    if (this.get('enabled')) {
+  @computed('enabled')
+  description(enabled) {
+    let description = 'Limit concurrent jobs';
+    if (enabled) {
       description += '  ';
     }
     return description;
-  }),
+  },
 
   limitChanged(value) {
     let limit, repo, savingFinished;

--- a/app/components/loading-screen.js
+++ b/app/components/loading-screen.js
@@ -1,7 +1,6 @@
 import Ember from 'ember';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default Ember.Component.extend({
-  randomLogo: service(),
+  @service randomLogo: null,
 });

--- a/app/components/not-active.js
+++ b/app/components/not-active.js
@@ -1,26 +1,24 @@
 import Ember from 'ember';
 import config from 'travis/config/environment';
-
-const { service } = Ember.inject;
-const { alias } = Ember.computed;
-
+import { service } from 'ember-decorators/service';
+import { computed } from 'ember-decorators/object';
+import { alias } from 'ember-decorators/object/computed';
 import { task } from 'ember-concurrency';
 
 export default Ember.Component.extend({
-  auth: service(),
-  flashes: service(),
-  permissions: service(),
+  @service auth: null,
+  @service flashes: null,
+  @service permissions: null,
 
-  user: alias('auth.currentUser'),
+  @alias('auth.currentUser') user: null,
 
-  canActivate: Ember.computed('repo.permissions.admin', function () {
-    let repo = this.get('repo');
+  @computed('repo', 'repo.permissions.admin')
+  canActivate(repo, adminPermissions) {
     if (repo) {
-      return repo.get('permissions.admin');
-    } else {
-      return false;
+      return adminPermissions;
     }
-  }),
+    return false;
+  },
 
   activate: task(function* () {
     const apiEndpoint = config.apiEndpoint;

--- a/app/components/org-item.js
+++ b/app/components/org-item.js
@@ -1,30 +1,35 @@
 import Ember from 'ember';
-
-const { alias } = Ember.computed;
+import { computed } from 'ember-decorators/object';
+import { alias } from 'ember-decorators/object/computed';
 
 export default Ember.Component.extend({
   classNames: ['media', 'account'],
   tagName: 'li',
   classNameBindings: ['type', 'selected'],
-  type: alias('account.type'),
-  selected: alias('account.selected'),
+
   tokenIsVisible: false,
 
-  name: Ember.computed('account', function () {
-    return this.get('account.name') || this.get('account.login');
-  }),
+  @alias('account.type') type: null,
+  @alias('account.selected') selected: null,
 
-  avatarUrl: Ember.computed('account', function () {
-    return this.get('account.avatarUrl') || false;
-  }),
+  @computed('account.{name,login}')
+  name(name, login) {
+    return name || login;
+  },
 
-  isUser: Ember.computed('account', function () {
-    return this.get('account.type') === 'user';
-  }),
+  @computed('account.avatarUrl')
+  avatarUrl(url) {
+    return url || false;
+  },
+
+  @computed('account.type')
+  isUser(type) {
+    return type === 'user';
+  },
 
   actions: {
     tokenVisibility() {
       this.toggleProperty('tokenIsVisible');
     }
-  }
+  },
 });

--- a/app/components/owner-repo-tile.js
+++ b/app/components/owner-repo-tile.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import computed from 'ember-computed-decorators';
+import { computed } from 'ember-decorators/object';
 
 export default Ember.Component.extend({
   tagName: 'li',

--- a/app/components/pagination-navigation.js
+++ b/app/components/pagination-navigation.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import { computed } from 'ember-decorators/object';
 import { alias } from 'ember-decorators/object/computed';
 
 export default Ember.Component.extend({
@@ -6,16 +7,21 @@ export default Ember.Component.extend({
   classNames: ['pagination-navigation'],
   @alias('collection.pagination') pagination: null,
 
-  outerWindow: Ember.computed('outer', function () {
-    return this.get('outer') || 1;
-  }),
-  innerWindow: Ember.computed('inner', function () {
-    return this.get('inner') || 2;
-  }),
+  @computed('outer')
+  outerWindow(outer) {
+    return outer || 1;
+  },
 
-  pages: Ember.computed('pagination.numberOfPages', function () {
-    let numberOfPages = this.get('pagination.numberOfPages');
-    let thresholdDisplayAll = ((this.get('outerWindow') + 1) * 2) + (this.get('innerWindow') + 1);
+  @computed('inner')
+  innerWindow(inner) {
+    return inner || 2;
+  },
+
+  @computed('pagination.{numberOfPages,perPage,currentPage,offset}',
+            'innerWindow',
+            'outerWindow')
+  pages(numberOfPages, perPage, currentPage, offset, innerWindow, outerWindow) {
+    let thresholdDisplayAll = ((outerWindow + 1) * 2) + (innerWindow + 1);
     let pageArray = [];
 
     // display all pages if there is only a few
@@ -23,15 +29,11 @@ export default Ember.Component.extend({
       for (let i = 0; i < numberOfPages; i++) {
         pageArray.push({
           num: i + 1,
-          offset: this.get('pagination.perPage') * i
+          offset: perPage * i
         });
       }
     // else stack together pagination
     } else {
-      let currentPage = this.get('pagination.currentPage');
-      let currentOffset = this.get('pagination.offset');
-      let innerWindow = this.get('innerWindow');
-      let outerWindow = this.get('outerWindow');
       let innerHalf = Math.ceil(innerWindow / 2);
       let lowerInnerBoundary = currentPage - innerHalf;
       if (lowerInnerBoundary < 0) {
@@ -50,7 +52,7 @@ export default Ember.Component.extend({
         if (i !== currentPage) {
           pageArray.push({
             num: 1 + i,
-            offset: this.get('pagination.perPage') * i
+            offset: perPage * i
           });
         }
       }
@@ -65,7 +67,7 @@ export default Ember.Component.extend({
         if (i > lowerOuterBoundary) {
           pageArray.push({
             num: i,
-            offset: (this.get('pagination.perPage') * (i - 1))
+            offset: perPage * (i - 1)
           });
         }
       }
@@ -75,7 +77,7 @@ export default Ember.Component.extend({
         // current page
         pageArray.push({
           num: currentPage,
-          offset: currentOffset
+          offset,
         });
       }
 
@@ -84,7 +86,7 @@ export default Ember.Component.extend({
         if (i < upperOuterBoundary) {
           pageArray.push({
             num: i,
-            offset: (this.get('pagination.perPage') * (i - 1))
+            offset: perPage * (i - 1)
           });
         }
       }
@@ -99,7 +101,7 @@ export default Ember.Component.extend({
         if (!(i < currentPage)) {
           pageArray.push({
             num: i,
-            offset: (this.get('pagination.perPage') * (i - 1))
+            offset: perPage * (i - 1)
           });
         }
       }
@@ -110,5 +112,5 @@ export default Ember.Component.extend({
       });
     }
     return pageArray;
-  })
+  },
 });

--- a/app/components/pagination-navigation.js
+++ b/app/components/pagination-navigation.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { alias } from 'ember-computed-decorators';
+import { alias } from 'ember-decorators/object/computed';
 
 export default Ember.Component.extend({
   tagName: 'nav',

--- a/app/components/popup-click-handler.js
+++ b/app/components/popup-click-handler.js
@@ -1,9 +1,9 @@
 import Ember from 'ember';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default Ember.Component.extend({
-  popup: service(),
+  @service popup: null,
+
   classNames: ['application'],
 
   click(event) {

--- a/app/components/queued-jobs.js
+++ b/app/components/queued-jobs.js
@@ -1,12 +1,11 @@
 import Ember from 'ember';
 import config from 'travis/config/environment';
 import Visibility from 'npm:visibilityjs';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default Ember.Component.extend({
-  store: service(),
-  updateTimesService: service('updateTimes'),
+  @service store: null,
+  @service('updateTimes') updateTimesService: null,
 
   init() {
     this._super(...arguments);

--- a/app/components/remove-log-popup.js
+++ b/app/components/remove-log-popup.js
@@ -1,9 +1,8 @@
 import Ember from 'ember';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default Ember.Component.extend({
-  flashes: service(),
+  @service flashes: null,
 
   actions: {
     close() {

--- a/app/components/repo-actions.js
+++ b/app/components/repo-actions.js
@@ -1,21 +1,18 @@
 import Ember from 'ember';
+import { service } from 'ember-decorators/service';
 import { computed } from 'ember-decorators/object';
-
+import { alias } from 'ember-decorators/object/computed';
 import eventually from 'travis/utils/eventually';
-
 import { task, taskGroup } from 'ember-concurrency';
 
-const { service } = Ember.inject;
-const { alias } = Ember.computed;
-
 export default Ember.Component.extend({
+  @service flashes: null,
+  @service auth: null,
+
   classNames: ['repo-main-tools'],
   classNameBindings: ['labelless'],
 
-  flashes: service(),
-  auth: service(),
-
-  user: alias('auth.currentUser'),
+  @alias('auth.currentUser') user: null,
 
   @computed('type', 'job', 'build')
   item(type, job, build) {

--- a/app/components/repo-actions.js
+++ b/app/components/repo-actions.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import { service } from 'ember-decorators/service';
 import { computed } from 'ember-decorators/object';
-import { alias } from 'ember-decorators/object/computed';
+import { alias, and } from 'ember-decorators/object/computed';
 import eventually from 'travis/utils/eventually';
 import { task, taskGroup } from 'ember-concurrency';
 
@@ -53,9 +53,9 @@ export default Ember.Component.extend({
     }
   },
 
-  canCancel: Ember.computed.and('userHasPullPermissionForRepo', 'item.canCancel'),
-  canRestart: Ember.computed.and('userHasPullPermissionForRepo', 'item.canRestart'),
-  canDebug: Ember.computed.and('userHasPushPermissionForRepo', 'item.canDebug'),
+  @and('userHasPullPermissionForRepo', 'item.canCancel') canCancel: null,
+  @and('userHasPullPermissionForRepo', 'item.canRestart') canRestart: null,
+  @and('userHasPushPermissionForRepo', 'item.canDebug') canDebug: null,
 
   cancel: task(function* () {
     let type = this.get('type');

--- a/app/components/repo-actions.js
+++ b/app/components/repo-actions.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import computed from 'ember-computed-decorators';
+import { computed } from 'ember-decorators/object';
 
 import eventually from 'travis/utils/eventually';
 

--- a/app/components/repo-show-tabs.js
+++ b/app/components/repo-show-tabs.js
@@ -1,45 +1,50 @@
 import Ember from 'ember';
 import config from 'travis/config/environment';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
+import { computed } from 'ember-decorators/object';
+import { alias } from 'ember-decorators/object/computed';
 
 export default Ember.Component.extend({
-  tabStates: service(),
+  @service tabStates: null,
 
   tagName: 'nav',
   classNames: ['travistab-nav'],
 
   config,
 
-  tab: Ember.computed.alias('tabStates.mainTab'),
+  @alias('tabStates.mainTab') tab: null,
 
-  classCurrent: Ember.computed('tab', function () {
-    if (this.get('tab') === 'current') {
+  @computed('tab')
+  classCurrent(tab) {
+    if (tab === 'current') {
       return 'active';
     }
-  }),
+  },
 
-  classBuilds: Ember.computed('tab', function () {
-    if (this.get('tab') === 'builds') {
+  @computed('tab')
+  classBuilds(tab) {
+    if (tab === 'builds') {
       return 'active';
     }
-  }),
+  },
 
-  classPullRequests: Ember.computed('tab', function () {
-    if (this.get('tab') === 'pull_requests') {
+  @computed('tab')
+  classPullRequests(tab) {
+    if (tab === 'pull_requests') {
       return 'active';
     }
-  }),
+  },
 
-  classBranches: Ember.computed('tab', function () {
-    if (this.get('tab') === 'branches') {
+  @computed('tab')
+  classBranches(tab) {
+    if (tab === 'branches') {
       return 'active';
     }
-  }),
+  },
 
-  classBuild: Ember.computed('tab', function () {
-    let classes, tab;
-    tab = this.get('tab');
+  @computed('tab')
+  classBuild(tab) {
+    let classes;
     classes = [];
     if (tab === 'build') {
       classes.push('active');
@@ -48,35 +53,40 @@ export default Ember.Component.extend({
       classes.push('display-inline');
     }
     return classes.join(' ');
-  }),
+  },
 
-  classJob: Ember.computed('tab', function () {
-    if (this.get('tab') === 'job') {
+  @computed('tab')
+  classJob(tab) {
+    if (tab === 'job') {
       return 'active';
     }
-  }),
+  },
 
-  classRequests: Ember.computed('tab', function () {
-    if (this.get('tab') === 'requests') {
+  @computed('tab')
+  classRequests(tab) {
+    if (tab === 'requests') {
       return 'active';
     }
-  }),
+  },
 
-  classCaches: Ember.computed('tab', function () {
-    if (this.get('tab') === 'caches') {
+  @computed('tab')
+  classCaches(tab) {
+    if (tab === 'caches') {
       return 'active';
     }
-  }),
+  },
 
-  classSettings: Ember.computed('tab', function () {
-    if (this.get('tab') === 'settings') {
+  @computed('tab')
+  classSettings(tab) {
+    if (tab === 'settings') {
       return 'active';
     }
-  }),
+  },
 
-  classRequest: Ember.computed('tab', function () {
-    if (this.get('tab') === 'request') {
+  @computed('tab')
+  classRequest(tab) {
+    if (tab === 'request') {
       return 'active';
     }
-  })
+  },
 });

--- a/app/components/repo-show-tools.js
+++ b/app/components/repo-show-tools.js
@@ -1,20 +1,20 @@
 import Ember from 'ember';
 import config from 'travis/config/environment';
-
-const { service } = Ember.inject;
-const { alias } = Ember.computed;
+import { service } from 'ember-decorators/service';
+import { computed } from 'ember-decorators/object';
+import { alias } from 'ember-decorators/object/computed';
 
 export default Ember.Component.extend({
-  auth: service(),
-  popup: service(),
-  permissions: service(),
+  @service auth: null,
+  @service popup: null,
+  @service permissions: null,
 
   tagName: 'nav',
   classNames: ['option-button'],
   classNameBindings: ['isOpen:is-open'],
   isOpen: false,
 
-  currentUser: alias('auth.currentUser'),
+  @alias('auth.currentUser') currentUser: null,
 
   click() {
     return this.toggleProperty('isOpen');
@@ -24,15 +24,18 @@ export default Ember.Component.extend({
     this.set('isOpen', false);
   },
 
-  displaySettingsLink: Ember.computed('permissions.all', 'repo', function () {
-    return this.get('permissions').hasPushPermission(this.get('repo'));
-  }),
+  @computed('permissions.all', 'repo')
+  displaySettingsLink(permissions, repo) {
+    return this.get('permissions').hasPushPermission(repo);
+  },
 
-  displayCachesLink: Ember.computed('permissions.all', 'repo', function () {
-    return this.get('permissions').hasPushPermission(this.get('repo')) && config.endpoints.caches;
-  }),
+  @computed('permissions.all', 'repo')
+  displayCachesLink(permissions, repo) {
+    return this.get('permissions').hasPushPermission(repo) && config.endpoints.caches;
+  },
 
-  displayStatusImages: Ember.computed('permissions.all', 'repo', function () {
-    return this.get('permissions').hasPermission(this.get('repo'));
-  })
+  @computed('permissions.all', 'repo')
+  displayStatusImages(permissions, repo) {
+    return this.get('permissions').hasPermission(repo);
+  },
 });

--- a/app/components/repos-list-item.js
+++ b/app/components/repos-list-item.js
@@ -1,18 +1,17 @@
 import Ember from 'ember';
 import Polling from 'travis/mixins/polling';
 import colorForState from 'travis/utils/color-for-state';
-
-const { service } = Ember.inject;
+import { computed } from 'ember-decorators/object';
 
 export default Ember.Component.extend(Polling, {
-  router: service(),
   tagName: 'li',
   pollModels: 'repo',
   classNames: ['repo'],
 
-  color: Ember.computed('repo.currentBuild.state', function () {
-    return colorForState(this.get('repo.currentBuild.state'));
-  }),
+  @computed('repo.currentBuild.state')
+  color(buildState) {
+    return colorForState(buildState);
+  },
 
   scrollTop() {
     if (window.scrollY > 0) {

--- a/app/components/repos-list-tabs.js
+++ b/app/components/repos-list-tabs.js
@@ -1,37 +1,40 @@
 import Ember from 'ember';
-
-const { service } = Ember.inject;
-const { alias } = Ember.computed;
+import { service } from 'ember-decorators/service';
+import { computed } from 'ember-decorators/object';
+import { alias } from 'ember-decorators/object/computed';
 
 export default Ember.Component.extend({
-  auth: service(),
+  @service auth: null,
+  @service tabStates: null,
+
   tagName: 'nav',
   classNames: ['travistab-nav', 'travistab-nav--underline', 'travistab-nav--sidebar'],
-  tabStates: service(),
 
-  tab: alias('tabStates.sidebarTab'),
+  @alias('tabStates.sidebarTab') tab: null,
 
-  currentUser: alias('auth.currentUser'),
+  @alias('auth.currentUser') currentUser: null,
 
-  classRunning: Ember.computed('tab', function () {
-    return this.get('tab') === 'running' ? 'active' : '';
-  }),
+  @computed('tab')
+  classRunning(tab) {
+    return tab === 'running' ? 'active' : '';
+  },
 
-  classOwned: Ember.computed('tab', 'currentUser', function () {
-    let classes;
-    classes = [];
-    if (this.get('tab') === 'owned') {
+  @computed('tab', 'currentUser')
+  classOwned(tab, currentUser) {
+    let classes = [];
+    if (tab === 'owned') {
       classes.push('active');
     }
-    if (this.get('currentUser')) {
+    if (currentUser) {
       classes.push('display-inline');
     }
     return classes.join(' ');
-  }),
+  },
 
-  classNew: Ember.computed('currentUser', function () {
-    if (this.get('currentUser')) {
+  @computed('currentUser')
+  classNew(currentUser) {
+    if (currentUser) {
       return 'display-inline';
     }
-  })
+  },
 });

--- a/app/components/repos-list.js
+++ b/app/components/repos-list.js
@@ -1,10 +1,9 @@
 import Ember from 'ember';
-import computed from 'ember-computed-decorators';
-
-const { service } = Ember.inject;
+import { computed } from 'ember-decorators/object';
+import { service } from 'ember-decorators/service';
 
 export default Ember.Component.extend({
-  tabStates: service(),
+  @service tabStates: null,
 
   @computed('viewingOwned')
   noReposMessage(tab) {

--- a/app/components/repository-layout.js
+++ b/app/components/repository-layout.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import computed from 'ember-computed-decorators';
+import { computed } from 'ember-decorators/object';
 
 const { service } = Ember.inject;
 

--- a/app/components/repository-layout.js
+++ b/app/components/repository-layout.js
@@ -1,12 +1,11 @@
 import Ember from 'ember';
 import { computed } from 'ember-decorators/object';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default Ember.Component.extend({
-  statusImages: service(),
-  externalLinks: service(),
-  popup: service(),
+  @service statusImages: null,
+  @service externalLinks: null,
+  @service popup: null,
 
   @computed('repo.slug', 'repo.defaultBranch.name')
   statusImageUrl(slug, branchName) {

--- a/app/components/repository-sidebar.js
+++ b/app/components/repository-sidebar.js
@@ -1,19 +1,19 @@
 import Ember from 'ember';
 import Visibility from 'npm:visibilityjs';
 import { task } from 'ember-concurrency';
-import computed, { alias } from 'ember-computed-decorators';
-
-const { service } = Ember.inject;
+import { computed } from 'ember-decorators/object';
+import { alias } from 'ember-decorators/object/computed';
+import { service } from 'ember-decorators/service';
 
 export default Ember.Component.extend({
-  tabStates: service(),
-  jobState: service(),
-  ajax: service(),
-  updateTimesService: service('updateTimes'),
-  repositories: service(),
-  store: service(),
-  auth: service(),
-  router: service(),
+  @service tabStates: null,
+  @service jobState: null,
+  @service ajax: null,
+  @service('updateTimes') updateTimesService: null,
+  @service repositories: null,
+  @service store: null,
+  @service auth: null,
+  @service router: null,
 
   init(...args) {
     this._super(args);
@@ -68,10 +68,10 @@ export default Ember.Component.extend({
     return runningAmount + queuedAmount;
   },
 
-  @computed('features.proVersion', 'jobState.runningJobs')
-  runningJobs(proVersion) {
+  @computed('features.proVersion', 'jobState.runningJobs.[]')
+  runningJobs(proVersion, runningJobs) {
     if (!proVersion) { return []; }
-    return this.get('jobState.runningJobs');
+    return runningJobs;
   },
 
   @computed('features.proVersion')

--- a/app/components/request-icon.js
+++ b/app/components/request-icon.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import { computed } from 'ember-decorators/object';
 
 const eventToIcon = {
   push: 'push',
@@ -22,15 +23,14 @@ export default Ember.Component.extend({
   classNameBindings: ['event', 'state', 'title'],
   attributeBindings: ['title'],
 
-  icon: Ember.computed('event', function () {
-    const event = this.get('event');
+  @computed('event')
+  icon(event) {
     const iconName = eventToIcon[event] || eventToIcon.default;
-
     return `icon-${iconName}`;
-  }),
+  },
 
-  title: Ember.computed('event', function () {
-    const event = this.get('event');
+  @computed('event')
+  title(event) {
     return eventToTitle[event] || eventToTitle.default;
-  })
+  },
 });

--- a/app/components/requests-item.js
+++ b/app/components/requests-item.js
@@ -1,51 +1,38 @@
 import Ember from 'ember';
+import { computed } from 'ember-decorators/object';
 
 export default Ember.Component.extend({
   classNames: ['request-item'],
   classNameBindings: ['requestClass'],
   tagName: 'li',
 
-  isGHPages: Ember.computed('request.message', function () {
-    let message = this.get('request.message');
-    if (message === 'github pages branch') {
-      return true;
-    } else {
-      return false;
-    }
-  }),
+  @computed('request.message')
+  isGHPages(message) {
+    return message === 'github pages branch';
+  },
 
-  requestClass: Ember.computed('content.isAccepted', function () {
-    if (this.get('request.isAccepted')) {
-      return 'accepted';
-    } else {
-      return 'rejected';
-    }
-  }),
+  @computed('request.isAccepted')
+  requestClass(isAccepted) {
+    return isAccepted ? 'accepted' : 'rejected';
+  },
 
-  type: Ember.computed('request.isPullRequest', function () {
-    if (this.get('request.isPullRequest')) {
-      return 'pull_request';
-    } else {
-      return 'push';
-    }
-  }),
+  @computed('request.isPullRequest')
+  type(isPullRequest) {
+    return isPullRequest ? 'pull_request' : 'push';
+  },
 
-  status: Ember.computed('request.isAccepted', function () {
-    if (this.get('request.isAccepted')) {
-      return 'Accepted';
-    } else {
-      return 'Rejected';
-    }
-  }),
+  @computed('request.isAccepted')
+  status(isAccepted) {
+    return isAccepted ? 'Accepted' : 'Rejected';
+  },
 
-  message: Ember.computed('features.proVersion', 'request.message', function () {
-    let message = this.get('request.message');
-    if (this.get('features.proVersion') && message === 'private repository') {
+  @computed('features.proVersion', 'request.message')
+  message(proVersion, message) {
+    if (proVersion && message === 'private repository') {
       return '';
     } else if (!message) {
       return 'Build created successfully ';
-    } else {
-      return message;
     }
-  })
+    return message;
+  },
 });

--- a/app/components/running-jobs.js
+++ b/app/components/running-jobs.js
@@ -2,12 +2,11 @@ import Ember from 'ember';
 import Polling from 'travis/mixins/polling';
 import config from 'travis/config/environment';
 import Visibility from 'npm:visibilityjs';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default Ember.Component.extend(Polling, {
-  store: service(),
-  updateTimesService: service('updateTimes'),
+  @service store: null,
+  @service('updateTimes') updateTimesService: null,
 
   pollHook() {
     return this.get('store').find('job', {});

--- a/app/components/settings-switch.js
+++ b/app/components/settings-switch.js
@@ -1,10 +1,10 @@
 import Ember from 'ember';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 import { task } from 'ember-concurrency';
 
 export default Ember.Component.extend({
-  flashes: service(),
+  @service flashes: null,
+
   tagName: 'a',
   classNames: ['switch'],
   classNameBindings: ['active', 'key'],

--- a/app/components/show-more-button.js
+++ b/app/components/show-more-button.js
@@ -1,23 +1,24 @@
 import Ember from 'ember';
-
-const { alias } = Ember.computed;
+import { computed } from 'ember-decorators/object';
+import { alias } from 'ember-decorators/object/computed';
 
 export default Ember.Component.extend({
   tagName: 'button',
   classNames: ['showmore-button', 'button'],
   classNameBindings: ['isLoading'],
   attributeBindings: ['disabled'],
-  disabled: alias('isLoading'),
 
-  buttonLabel: Ember.computed('isLoading', function () {
-    if (this.get('isLoading')) {
+  @alias('isLoading') disabled: null,
+
+  @computed('isLoading')
+  buttonLabel(loading) {
+    if (loading) {
       return 'Loading';
-    } else {
-      return 'Show more';
     }
-  }),
+    return 'Show more';
+  },
 
   click() {
     return this.attrs.showMore();
-  }
+  },
 });

--- a/app/components/status-icon.js
+++ b/app/components/status-icon.js
@@ -1,4 +1,6 @@
 import Ember from 'ember';
+import { computed } from 'ember-decorators/object';
+import { equal, empty } from 'ember-decorators/object/computed';
 
 export default Ember.Component.extend({
   tagName: 'span',
@@ -6,41 +8,30 @@ export default Ember.Component.extend({
   classNameBindings: ['status'],
   attributeBindings: ['label:aria-label', 'label:title'],
 
-  label: Ember.computed('status', function () {
-    return `Job ${this.get('status')}`;
-  }),
+  @computed('status')
+  label(status) {
+    return `Job ${status}`;
+  },
 
-  hasPassed: Ember.computed('status', function () {
-    return this.get('status') === 'passed' || this.get('status') === 'accepted';
-  }),
+  @computed('status')
+  hasPassed(status) {
+    return ['passed', 'accepted'].includes(status);
+  },
 
-  hasFailed: Ember.computed('status', function () {
-    return this.get('status') === 'failed' || this.get('status') === 'rejected';
-  }),
+  @computed('status')
+  hasFailed(status) {
+    return ['failed', 'rejected'].includes(status);
+  },
 
-  hasErrored: Ember.computed('status', function () {
-    return this.get('status') === 'errored';
-  }),
+  @equal('status', 'errored') hasErrored: null,
 
-  wasCanceled: Ember.computed('status', function () {
-    return this.get('status') === 'canceled';
-  }),
+  @equal('status', 'canceled') wasCanceled: null,
 
-  isRunning: Ember.computed('status', function () {
-    let status = this.get('status');
+  @computed('status')
+  isRunning(status) {
     let runningStates = ['started', 'queued', 'booting', 'received', 'created'];
     return runningStates.includes(status);
-  }),
+  },
 
-  isEmpty: Ember.computed('status', function () {
-    if (!this.get('status')) {
-      return true;
-    } else {
-      if (this.get('status') === '') {
-        return true;
-      } else {
-        return false;
-      }
-    }
-  })
+  @empty('status') isEmpty: null,
 });

--- a/app/components/status-images.js
+++ b/app/components/status-images.js
@@ -1,26 +1,24 @@
 import Ember from 'ember';
 import Config from 'travis/config/environment';
-
-const { service } = Ember.inject;
-const { alias } = Ember.computed;
+import { service } from 'ember-decorators/service';
+import { computed } from 'ember-decorators/object';
+import { alias } from 'ember-decorators/object/computed';
 
 export default Ember.Component.extend({
-  popup: service(),
-  auth: service(),
-  externalLinks: service(),
-  statusImages: service(),
+  @service popup: null,
+  @service auth: null,
+  @service externalLinks: null,
+  @service statusImages: null,
 
-  popupName: alias('popup.popupName'),
+  @alias('popup.popupName') popupName: null,
 
   id: 'status-images',
   attributeBindings: ['id'],
   classNames: ['popup', 'status-images'],
   formats: ['Image URL', 'Markdown', 'Textile', 'Rdoc', 'AsciiDoc', 'RST', 'Pod', 'CCTray'],
 
-  branches: Ember.computed('popupName', 'repo', function () {
-    let repoId = this.get('repo.id'),
-      popupName = this.get('popupName');
-
+  @computed('popupName', 'repo.id')
+  branches(popupName, repoId) {
     if (popupName === 'status-images') {
       let array = Ember.ArrayProxy.create({ content: [] }),
         apiEndpoint = Config.apiEndpoint,
@@ -53,7 +51,7 @@ export default Ember.Component.extend({
       // if status images popup is not open, don't fetch any branches
       return [];
     }
-  }),
+  },
 
   actions: {
     close() {
@@ -61,12 +59,13 @@ export default Ember.Component.extend({
     }
   },
 
-  statusString: Ember.computed('format', 'repo.slug', 'branch', function () {
-    const format = this.get('format') || this.get('formats.firstObject');
-    const branch = this.get('branch') || 'master';
+  @computed('format', 'repo.slug', 'branch')
+  statusString(format, slug, branch) {
+    const imageFormat = format || this.get('formats.firstObject');
+    const gitBranch = branch || 'master';
 
-    return this.formatStatusImage(format, this.get('repo.slug'), branch);
-  }),
+    return this.formatStatusImage(imageFormat, slug, gitBranch);
+  },
 
   formatStatusImage(format, slug, branch) {
     switch (format) {
@@ -87,5 +86,5 @@ export default Ember.Component.extend({
       case 'CCTray':
         return this.get('statusImages').ccXml(slug, branch);
     }
-  }
+  },
 });

--- a/app/components/sync-button.js
+++ b/app/components/sync-button.js
@@ -1,12 +1,13 @@
 import Ember from 'ember';
-
-const { service } = Ember.inject;
-const { alias } = Ember.computed;
+import { service } from 'ember-decorators/service';
+import { alias } from 'ember-decorators/object/computed';
 
 export default Ember.Component.extend({
-  auth: service(),
-  user: alias('auth.currentUser'),
+  @service auth: null,
+
+  @alias('auth.currentUser') user: null,
   classNames: ['sync-button'],
+
   actions: {
     sync() {
       return this.get('user').sync();

--- a/app/components/team-member.js
+++ b/app/components/team-member.js
@@ -1,4 +1,6 @@
 import Ember from 'ember';
+import { computed } from 'ember-decorators/object';
+import { or } from 'ember-decorators/object/computed';
 
 const countrySentenceOverrides = {
   newzealand: 'New Zealand',
@@ -22,13 +24,15 @@ export default Ember.Component.extend({
   tagName: 'li',
   classNames: ['team-member'],
 
-  countrySentence: Ember.computed('member.country', function () {
-    return countryToSentence(this.get('member.country'));
-  }),
+  @computed('member.country')
+  countrySentence(country) {
+    return countryToSentence(country);
+  },
 
-  nationalitySentence: Ember.computed('member.nationality', function () {
-    return countryToSentence(this.get('member.nationality'));
-  }),
+  @computed('member.nationality')
+  nationalitySentence(nationality) {
+    return countryToSentence(nationality);
+  },
 
-  countryOrAlias: Ember.computed.or('member.countryAlias', 'member.country')
+  @or('member.countryAlias', 'member.country') countryOrAlias: null,
 });

--- a/app/components/top-bar.js
+++ b/app/components/top-bar.js
@@ -1,6 +1,7 @@
 /* global HS, Waypoint */
 import Ember from 'ember';
-import computed, { alias } from 'ember-computed-decorators';
+import { computed } from 'ember-decorators/object';
+import { alias } from 'ember-decorators/object/computed';
 
 const { service } = Ember.inject;
 

--- a/app/components/top-bar.js
+++ b/app/components/top-bar.js
@@ -2,19 +2,18 @@
 import Ember from 'ember';
 import { computed } from 'ember-decorators/object';
 import { alias } from 'ember-decorators/object/computed';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default Ember.Component.extend({
+  @service auth: null,
+  @service store: null,
+  @service externalLinks: null,
+  @service features: null,
+  @service flashes: null,
+  @service('broadcasts') broadcastsService: null,
+
   tagName: 'header',
   classNames: ['top'],
-  auth: service(),
-  store: service(),
-  externalLinks: service(),
-  features: service(),
-  flashes: service(),
-  broadcastsService: service('broadcasts'),
-
   landingPage: false,
 
   @alias('auth.currentUser') user: null,

--- a/app/components/travis-status.js
+++ b/app/components/travis-status.js
@@ -1,10 +1,14 @@
 import Ember from 'ember';
 import config from 'travis/config/environment';
+import { computed } from 'ember-decorators/object';
 
 export default Ember.Component.extend({
   status: null,
 
-  statusPageStatusUrl: Ember.computed(() => config.statusPageStatusUrl),
+  @computed()
+  statusPageStatusUrl() {
+    return config.statusPageStatusUrl;
+  },
 
   didInsertElement() {
     let url = this.get('statusPageStatusUrl');

--- a/app/components/travis-switch.js
+++ b/app/components/travis-switch.js
@@ -1,17 +1,15 @@
 import Ember from 'ember';
+import { or } from 'ember-decorators/object/computed';
 
 export default Ember.Component.extend({
   tagName: 'a',
   classNames: ['travis-switch', 'switch'],
   classNameBindings: ['_active:active'],
 
-  _active: Ember.computed('target.active', 'active', function () {
-    return this.get('target.active') || this.get('active');
-  }),
+  @or('target.active', 'active') _active: null,
 
   click() {
-    let target;
-    target = this.get('target');
+    let target = this.get('target');
     if (this.get('toggleAutomatically') !== 'false') {
       if (target) {
         this.set('target.active', !this.get('target.active'));

--- a/app/components/user-avatar.js
+++ b/app/components/user-avatar.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import computed from 'ember-computed-decorators';
+import { computed } from 'ember-decorators/object';
 
 export default Ember.Component.extend({
   tagName: 'span',

--- a/app/controllers/account.js
+++ b/app/controllers/account.js
@@ -1,13 +1,15 @@
 /* global Travis */
 import Ember from 'ember';
-
-const { service } = Ember.inject;
-const { alias } = Ember.computed;
+import { service } from 'ember-decorators/service';
+import { computed, action } from 'ember-decorators/object';
+import { alias } from 'ember-decorators/object/computed';
 
 export default Ember.Controller.extend({
-  auth: service(),
+  @service auth: null,
+
   allHooks: [],
-  user: alias('auth.currentUser'),
+
+  @alias('auth.currentUser') user: null,
 
   init() {
     this._super(...arguments);
@@ -17,14 +19,15 @@ export default Ember.Controller.extend({
     }));
   },
 
-  actions: {
-    sync() {
-      return this.get('user').sync();
-    },
 
-    toggle(hook) {
-      return hook.toggle();
-    }
+  @action
+  sync() {
+    return this.get('user').sync();
+  },
+
+  @action
+  toggle(hook) {
+    return hook.toggle();
   },
 
   reloadHooks() {
@@ -45,49 +48,39 @@ export default Ember.Controller.extend({
     }
   },
 
-  accountName: Ember.computed('model.name', 'model.login', function () {
-    return this.get('model.name') || this.get('model.login');
-  }),
+  @computed('model.{name,login}')
+  accountName(name, login) {
+    return name || login;
+  },
 
-  hooks: Ember.computed('allHooks.length', 'allHooks', function () {
-    let hooks = this.get('allHooks');
+  @computed('allHooks.[]')
+  hooks(hooks) {
     if (!hooks) {
       this.reloadHooks();
     }
-    return this.get('allHooks').filter(function (hook) {
-      return hook.get('admin');
-    }).sortBy('name');
-  }),
+    return hooks.filter(hook => hook.get('admin')).sortBy('name');
+  },
 
-  hooksWithoutAdmin: Ember.computed('allHooks.length', 'allHooks', function () {
-    let hooks = this.get('allHooks');
+  @computed('allHooks.[]')
+  hooksWithoutAdmin(hooks) {
     if (!hooks) {
       this.reloadHooks();
     }
-    return this.get('allHooks').filter(function (hook) {
-      return !hook.get('admin');
-    }).sortBy('name');
-  }),
+    return hooks.filter(hook => !hook.get('admin')).sortBy('name');
+  },
 
-  showPrivateReposHint: Ember.computed(function () {
-    return this.config.show_repos_hint === 'private';
-  }),
-
-  showPublicReposHint: Ember.computed(function () {
-    return this.config.show_repos_hint === 'public';
-  }),
-
-  billingUrl: Ember.computed('model.name', 'model.login', function () {
-    var id;
-    id = this.get('model.type') === 'user' ? 'user' : this.get('model.login');
+  @computed('model.{type,login}')
+  billingUrl(type, name, login) {
+    const id = type === 'user' ? 'user' : login;
     return this.config.billingEndpoint + '/subscriptions/' + id;
-  }),
+  },
 
-  subscribeButtonInfo: Ember.computed('model.login', 'model.type', function () {
+  @computed('billingUrl', 'model.{subscribed,education}')
+  subscribeButtonInfo(billingUrl, subscribed, education) {
     return {
-      billingUrl: this.get('billingUrl'),
-      subscribed: this.get('model.subscribed'),
-      education: this.get('model.education')
+      billingUrl,
+      subscribed,
+      education,
     };
-  })
+  },
 });

--- a/app/controllers/accounts.js
+++ b/app/controllers/accounts.js
@@ -1,3 +1,0 @@
-import Ember from 'ember';
-
-export default Ember.Controller.extend();

--- a/app/controllers/branches.js
+++ b/app/controllers/branches.js
@@ -1,30 +1,35 @@
 import Ember from 'ember';
-
-const { controller } = Ember.inject;
+import { controller } from 'ember-decorators/controller';
+import { computed } from 'ember-decorators/object';
+import { alias, notEmpty, filter } from 'ember-decorators/object/computed';
 
 export default Ember.Controller.extend({
-  repoController: controller('repo'),
+  @controller('repo') repoController: null,
 
-  tab: Ember.computed.alias('repoController.tab'),
+  @alias('repoController.tab') tab: null,
 
-  defaultBranch: Ember.computed('model', function () {
-    return this.get('model').filterBy('default_branch')[0];
-  }),
+  @computed('model')
+  defaultBranch(model) {
+    return model.filterBy('default_branch')[0];
+  },
 
-  branchesExist: Ember.computed.notEmpty('model'),
-  nonDefaultBranches: Ember.computed.filter('model', function (branch) {
+  @notEmpty('model') branchesExist: null,
+
+  @filter('model', function (branch, index, array) {
     return !branch.default_branch;
-  }),
+  })  nonDefaultBranches: null,
 
-  activeBranches: Ember.computed('model', function () {
-    const activeBranches = this.get('nonDefaultBranches').filterBy('exists_on_github');
+  @computed('nonDefaultBranches')
+  activeBranches(nonDefaultBranches) {
+    const activeBranches = nonDefaultBranches.filterBy('exists_on_github');
     return this._sortBranchesByFinished(activeBranches);
-  }),
+  },
 
-  inactiveBranches: Ember.computed('model', function () {
-    const inactiveBranches = this.get('nonDefaultBranches').filterBy('exists_on_github', false);
+  @computed('nonDefaultBranches')
+  inactiveBranches(nonDefaultBranches) {
+    const inactiveBranches = nonDefaultBranches.filterBy('exists_on_github', false);
     return this._sortBranchesByFinished(inactiveBranches);
-  }),
+  },
 
   _sortBranchesByFinished(branches) {
     const unfinished = branches.filter(branch => {

--- a/app/controllers/build.js
+++ b/app/controllers/build.js
@@ -4,19 +4,21 @@ import GithubUrlProperties from 'travis/mixins/github-url-properties';
 import Visibility from 'npm:visibilityjs';
 import config from 'travis/config/environment';
 
-const { service, controller } = Ember.inject;
-const { alias } = Ember.computed;
+import { controller } from 'ember-decorators/controller';
+import { service } from 'ember-decorators/service';
+import { alias } from 'ember-decorators/object/computed';
 
 export default Ember.Controller.extend(GithubUrlProperties, Polling, {
-  auth: service(),
-  repoController: controller('repo'),
+  @service auth: null,
+  @service('updateTimes') updateTimesService: null,
 
-  repo: alias('repoController.repo'),
-  currentUser: alias('auth.currentUser'),
-  tab: alias('repoController.tab'),
+  @controller('repo') repoController: null,
+
+  @alias('repoController.repo') repo: null,
+  @alias('auth.currentUser') currentUser: null,
+  @alias('repoController.tab') tab: null,
+
   sendFaviconStateChanges: true,
-
-  updateTimesService: service('updateTimes'),
 
   updateTimes() {
     this.get('updateTimesService').push(this.get('build.stages'));

--- a/app/controllers/builds.js
+++ b/app/controllers/builds.js
@@ -1,21 +1,24 @@
 import Ember from 'ember';
 import LoadMoreBuildsMixin from 'travis/mixins/builds/load-more';
-
-const { service, controller } = Ember.inject;
-const { alias } = Ember.computed;
+import { service } from 'ember-decorators/service';
+import { controller } from 'ember-decorators/controller';
+import { computed } from 'ember-decorators/object';
+import { alias } from 'ember-decorators/object/computed';
 
 const mixins = [LoadMoreBuildsMixin];
 
 export default Ember.Controller.extend(...mixins, {
-  tabStates: service(),
+  @service tabStates: null,
 
   buildsSorting: ['number:desc'],
   builds: Ember.computed.sort('model', 'buildsSorting'),
-  repoController: controller('repo'),
-  repo: alias('repoController.repo'),
-  tab: alias('tabStates.mainTab'),
 
-  displayShowMoreButton: Ember.computed('tab', 'builds.lastObject.number', function () {
-    return this.get('tab') !== 'branches' && parseInt(this.get('builds.lastObject.number')) > 1;
-  }),
+  @controller('repo') repoController: null,
+  @alias('repoController.repo') repo: null,
+  @alias('repoController.tab') tab: null,
+
+  @computed('tab', 'builds.lastObject.number')
+  displayShowMoreButton(tab, lastBuildNumber) {
+    return tab !== 'branches' && parseInt(lastBuildNumber) > 1;
+  },
 });

--- a/app/controllers/caches.js
+++ b/app/controllers/caches.js
@@ -1,16 +1,19 @@
 import Ember from 'ember';
 import config from 'travis/config/environment';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
+import { computed } from 'ember-decorators/object';
+import { alias } from 'ember-decorators/object/computed';
 import { task } from 'ember-concurrency';
 
 export default Ember.Controller.extend({
-  ajax: service(),
-  repo: Ember.computed.alias('model.repo'),
+  @service ajax: null,
 
-  cachesExist: Ember.computed('model.pushes.length', 'model.pullRequests.length', function () {
-    return this.get('model.pushes.length') || this.get('model.pullRequests.length');
-  }),
+  @alias('model.repo') repo: null,
+
+  @computed('model.pushes.[]', 'model.pullRequests.[]')
+  cachesExist(pushes, pullRequests) {
+    return pushes.length || pullRequests.length;
+  },
 
   deleteRepoCache: task(function * () {
     if (config.skipConfirmations || confirm('Are you sure?')) {

--- a/app/controllers/caches.js
+++ b/app/controllers/caches.js
@@ -12,7 +12,9 @@ export default Ember.Controller.extend({
 
   @computed('model.pushes.[]', 'model.pullRequests.[]')
   cachesExist(pushes, pullRequests) {
-    return pushes.length || pullRequests.length;
+    if (pushes || pullRequests) {
+      return pushes.length || pullRequests.length;
+    }
   },
 
   deleteRepoCache: task(function * () {

--- a/app/controllers/dashboard/repositories.js
+++ b/app/controllers/dashboard/repositories.js
@@ -1,20 +1,24 @@
 import Ember from 'ember';
 import { task, taskGroup } from 'ember-concurrency';
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
+import { computed } from 'ember-decorators/object';
 
 export default Ember.Controller.extend({
   queryParams: ['account', 'offset'],
   offset: 0,
-  flashes: service(),
-  ajax: service(),
+
+  @service flashes: null,
+  @service ajax: null,
 
   starring: taskGroup().drop(),
-  tasks: Ember.computed(function () {
+
+  @computed()
+  tasks() {
     return [
       this.get('star'),
       this.get('unstar')
     ];
-  }),
+  },
 
   star: task(function * (repo) {
     repo.set('starred', true);
@@ -105,17 +109,15 @@ export default Ember.Controller.extend({
       return repos;
     }),
 
-  selectedOrg: Ember.computed('account', function () {
-    let accounts = this.get('model.accounts');
-    let filter =  this.get('account');
-
+  @computed('model.accounts', 'account')
+  selectedOrg(accounts, account) {
     let filteredAccount = accounts.filter(function (item) {
-      if (item.get('login') === filter) {
+      if (item.get('login') === account) {
         return item;
       }
     });
     return filteredAccount[0];
-  }),
+  },
 
   actions: {
     selectOrg(org) {

--- a/app/controllers/features.js
+++ b/app/controllers/features.js
@@ -1,8 +1,8 @@
 import Ember from 'ember';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
+import { alias } from 'ember-decorators/object/computed';
 
 export default Ember.Controller.extend({
-  featureFlags: service(),
-  featuresLoading: Ember.computed.alias('featureFlags.fetchTask.isRunning')
+  @service featureFlags: null,
+  @alias('featureFlags.fetchTask.isRunning') featuresLoading: null,
 });

--- a/app/controllers/first-sync.js
+++ b/app/controllers/first-sync.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
+import { alias } from 'ember-decorators/object/computed';
 
 export default Ember.Controller.extend({
-  user: Ember.computed.alias('auth.currentUser'),
-  isSyncing: Ember.computed.alias('user.isSyncing')
+  @alias('auth.currentUser') user: null,
+  @alias('user.isSyncing') isSyncing: null,
 });

--- a/app/controllers/flash.js
+++ b/app/controllers/flash.js
@@ -1,9 +1,9 @@
 import Ember from 'ember';
 
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default Ember.Controller.extend({
-  flashes: service(),
+  @service flashes: null,
 
   loadFlashes() {
     return this.get('flashes').loadFlashes(...arguments);

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
-import computed, { alias } from 'ember-computed-decorators';
+import { computed } from 'ember-decorators/object';
+import { alias } from 'ember-decorators/object/computed';
 import Visibility from 'npm:visibilityjs';
 import config from 'travis/config/environment';
 

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -3,16 +3,15 @@ import { computed } from 'ember-decorators/object';
 import { alias } from 'ember-decorators/object/computed';
 import Visibility from 'npm:visibilityjs';
 import config from 'travis/config/environment';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default Ember.Controller.extend({
-  auth: service(),
-  tabStates: service(),
-  updateTimesService: service('updateTimes'),
-  statusImages: service(),
-  popup: service(),
-  repositories: service(),
+  @service auth: null,
+  @service tabStates: null,
+  @service('updateTimes') updateTimesService: null,
+  @service statusImages: null,
+  @service popup: null,
+  @service repositories: null,
 
   init() {
     this._super(...arguments);

--- a/app/controllers/job.js
+++ b/app/controllers/job.js
@@ -1,24 +1,25 @@
 import Ember from 'ember';
-
-const { service, controller } = Ember.inject;
-const { alias } = Ember.computed;
+import { service } from 'ember-decorators/service';
+import { controller } from 'ember-decorators/controller';
+import { computed, observes } from 'ember-decorators/object';
+import { alias } from 'ember-decorators/object/computed';
 
 export default Ember.Controller.extend({
-  auth: service(),
-  externalLinks: service(),
+  @service auth: null,
+  @service externalLinks: null,
 
-  repoController: controller('repo'),
-  repo: alias('repoController.repo'),
-  currentUser: alias('auth.currentUser'),
-  tab: alias('repoController.tab'),
+  @controller('repo') repoController: null,
+  @alias('repoController.repo') repo: null,
+  @alias('auth.currentUser') currentUser: null,
+  @alias('repoController.tab') tab: null,
 
-  urlGithubCommit: Ember.computed('repo.slug', 'commit.sha', function () {
-    const slug = this.get('repo.slug');
-    const sha = this.get('commit.sha');
+  @computed('repo.slug', 'commit.sha')
+  urlGithubCommit(slug, sha) {
     return this.get('externalLinks').githubCommit(slug, sha);
-  }),
+  },
 
-  jobStateDidChange: Ember.observer('job.state', function () {
-    return this.send('faviconStateDidChange', this.get('job.state'));
-  })
+  @observes('job.state')
+  jobStateDidChange(state) {
+    return this.send('faviconStateDidChange', state);
+  },
 });

--- a/app/controllers/main/error.js
+++ b/app/controllers/main/error.js
@@ -1,3 +1,0 @@
-import Ember from 'ember';
-
-export default Ember.Controller.extend();

--- a/app/controllers/owner.js
+++ b/app/controllers/owner.js
@@ -1,22 +1,23 @@
 import Ember from 'ember';
+import { computed } from 'ember-decorators/object';
 
 export default Ember.Controller.extend({
   isLoading: false,
 
-  githubProfile: Ember.computed('model', function () {
-    return this.get('config').sourceEndpoint + '/' + (this.get('model.login'));
-  }),
+  @computed('config.sourceEndpoint', 'model.login')
+  githubProfile(endpoint, login) {
+    return `${endpoint}/${login}`;
+  },
 
-  owner: Ember.computed('model', function () {
-    var data;
-    data = this.get('model');
+  @computed('model')
+  owner(model) {
     return {
-      login: data.login,
-      name: data.name,
-      avatar: data.avatar_url,
-      isSyncing: data.is_syncing,
-      avatarUrl: data.avatar_url,
-      syncedAt: data.synced_at
+      login: model.login,
+      name: model.name,
+      avatar: model.avatar_url,
+      isSyncing: model.is_syncing,
+      avatarUrl: model.avatar_url,
+      syncedAt: model.synced_at
     };
-  })
+  },
 });

--- a/app/controllers/owner/repositories.js
+++ b/app/controllers/owner/repositories.js
@@ -1,10 +1,12 @@
 import Ember from 'ember';
+import { computed } from 'ember-decorators/object';
 
 export default Ember.Controller.extend({
   isLoading: false,
-  repos: Ember.computed('model', function () {
-    var data, repos;
-    data = this.get('model');
+
+  @computed('model')
+  repos(data) {
+    var repos;
     repos = [];
     if (data.repositories) {
       repos = data.repositories.filter(function (item) {
@@ -14,5 +16,5 @@ export default Ember.Controller.extend({
       }).sortBy('default_branch.last_build.finished_at').reverse();
     }
     return repos;
-  })
+  },
 });

--- a/app/controllers/owner/running.js
+++ b/app/controllers/owner/running.js
@@ -1,10 +1,12 @@
 import Ember from 'ember';
+import { computed } from 'ember-decorators/object';
 
 export default Ember.Controller.extend({
   isLoading: false,
-  running: Ember.computed('model', function () {
-    var data, repos;
-    data = this.get('model');
+
+  @computed('model')
+  running(data) {
+    var repos;
     repos = data.repositories.filter(function (item) {
       if (item.currentBuild !== null) {
         if (item.currentBuild.state === 'started') {
@@ -13,5 +15,5 @@ export default Ember.Controller.extend({
       }
     });
     return repos;
-  })
+  },
 });

--- a/app/controllers/plans.js
+++ b/app/controllers/plans.js
@@ -1,14 +1,14 @@
 /* global _gaq */
 import Ember from 'ember';
 import config from 'travis/config/environment';
+import { action } from 'ember-decorators/object';
 
 export default Ember.Controller.extend({
-  actions: {
-    gaCta(location) {
-      if (config.gaCode) {
-        _gaq.push(['_trackPageview', '/virtual/signup?' + location]);
-      }
-      this.auth.signIn();
+  @action
+  gaCta(location) {
+    if (config.gaCode) {
+      _gaq.push(['_trackPageview', '/virtual/signup?' + location]);
     }
-  }
+    this.auth.signIn();
+  },
 });

--- a/app/controllers/pull-requests.js
+++ b/app/controllers/pull-requests.js
@@ -1,23 +1,24 @@
 import Ember from 'ember';
 import LoadMoreBuildsMixin from 'travis/mixins/builds/load-more';
-
-const { service, controller } = Ember.inject;
-const { alias } = Ember.computed;
+import { controller } from 'ember-decorators/controller';
+import { computed } from 'ember-decorators/object';
+import { alias } from 'ember-decorators/object/computed';
 
 const mixins = [LoadMoreBuildsMixin];
 
 export default Ember.Controller.extend(...mixins, {
-  tabStates: service(),
+  @controller('repo') repoController: null,
 
   buildsSorting: ['number:desc'],
   builds: Ember.computed.sort('model', 'buildsSorting'),
-  repoController: controller('repo'),
-  repo: alias('repoController.repo'),
-  tab: alias('tabStates.mainTab'),
-  isLoaded: alias('model.isLoaded'),
-  isLoading: alias('model.isLoading'),
 
-  displayShowMoreButton: Ember.computed('tab', 'builds.lastObject.number', function () {
-    return this.get('tab') !== 'branches' && parseInt(this.get('builds.lastObject.number')) > 1;
-  }),
+  @alias('repoController.repo') repo: null,
+  @alias('repoController.tab') tab: null,
+  @alias('model.isLoaded') isLoaded: null,
+  @alias('model.isLoading') isLoading: null,
+
+  @computed('tab', 'builds.lastObject.number')
+  displayShowMoreButton(tab, lastBuildNumber) {
+    return tab !== 'branches' && parseInt(lastBuildNumber) > 1;
+  },
 });

--- a/app/controllers/repo.js
+++ b/app/controllers/repo.js
@@ -15,9 +15,8 @@ export default Ember.Controller.extend({
   @controller('job') jobController: null,
   @controller('build') buildController: null,
   @controller('builds') buildsController: null,
-  @controller('repos') reposController: null,
 
-  @alias('reposController.repos') repos: null,
+  @alias('repositories.accessible') repos: null,
   @alias('auth.currentUser') currentUser: null,
   @alias('buildController.build') build: null,
   @alias('buildsController.content') builds: null,

--- a/app/controllers/repo.js
+++ b/app/controllers/repo.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import eventually from 'travis/utils/eventually';
 import Visibility from 'npm:visibilityjs';
 import { service } from 'ember-decorators/service';
-import { controller } from 'ember-decorators/service';
+import { controller } from 'ember-decorators/controller';
 import { computed } from 'ember-decorators/object';
 import { alias } from 'ember-decorators/object/computed';
 

--- a/app/controllers/repo.js
+++ b/app/controllers/repo.js
@@ -1,27 +1,38 @@
 import Ember from 'ember';
 import eventually from 'travis/utils/eventually';
 import Visibility from 'npm:visibilityjs';
-
-const { service, controller } = Ember.inject;
-const { alias } = Ember.computed;
+import { service } from 'ember-decorators/service';
+import { controller } from 'ember-decorators/service';
+import { computed } from 'ember-decorators/object';
+import { alias } from 'ember-decorators/object/computed';
 
 export default Ember.Controller.extend({
-  updateTimesService: service('updateTimes'),
-  repositories: service(),
-  popup: service(),
-  tabStates: service(),
+  @service repositories: null,
+  @service tabStates: null,
+  @service('updateTimes') updateTimesService: null,
+  @service popup: null,
 
-  jobController: controller('job'),
-  buildController: controller('build'),
-  buildsController: controller('builds'),
-  repos: alias('repositories.accessible'),
-  currentUser: alias('auth.currentUser'),
+  @controller('job') jobController: null,
+  @controller('build') buildController: null,
+  @controller('builds') buildsController: null,
+  @controller('repos') reposController: null,
+
+  @alias('reposController.repos') repos: null,
+  @alias('auth.currentUser') currentUser: null,
+  @alias('buildController.build') build: null,
+  @alias('buildsController.content') builds: null,
+  @alias('jobController.job') job: null,
 
   classNames: ['repo'],
 
-  build: Ember.computed.alias('buildController.build'),
-  builds: Ember.computed.alias('buildsController.content'),
-  job: Ember.computed.alias('jobController.job'),
+  reset() {
+    this.set('repo', null);
+  },
+
+  @computed('repos.isLoaded', 'repos.[]')
+  isEmpty(loaded, repos) {
+    return loaded && Ember.isEmpty(repos);
+  },
 
   init() {
     this._super(...arguments);

--- a/app/controllers/requests.js
+++ b/app/controllers/requests.js
@@ -1,13 +1,12 @@
 import Ember from 'ember';
-
-const { controller } = Ember.inject;
+import { controller } from 'ember-decorators/controller';
+import { computed } from 'ember-decorators/object';
 
 export default Ember.Controller.extend({
-  repoController: controller('repo'),
+  @controller('repo') repoController: null,
 
-  lintUrl: Ember.computed('repoController.repo.slug', function () {
-    var slug;
-    slug = this.get('repoController.repo.slug');
-    return 'https://lint.travis-ci.org/' + slug;
-  })
+  @computed('repoController.repo.slug')
+  lintUrl(slug) {
+    return `https://lint.travis-ci.org/${slug}`;
+  },
 });

--- a/app/controllers/search.js
+++ b/app/controllers/search.js
@@ -1,7 +1,6 @@
 import Ember from 'ember';
 import { alias } from 'ember-decorators/object/computed';
 import { service } from 'ember-decorators/service';
-import { controller } from 'ember-decorators/controller';
 
 export default Ember.Controller.extend({
   @service auth: null,
@@ -9,9 +8,7 @@ export default Ember.Controller.extend({
   @service statusImages: null,
   @service repositories: null,
 
-  @controller repos: null,
-
-  @alias('repos.repos.firstObject') repo: null,
+  @alias('repositories.searchResults.firstObject') repo: null,
 
   @alias('tabStates.mainTab') tab: null,
 

--- a/app/controllers/search.js
+++ b/app/controllers/search.js
@@ -1,15 +1,17 @@
 import Ember from 'ember';
-import { alias } from 'ember-computed-decorators';
-
-const { service } = Ember.inject;
+import { alias } from 'ember-decorators/object/computed';
+import { service } from 'ember-decorators/service';
+import { controller } from 'ember-decorators/controller';
 
 export default Ember.Controller.extend({
-  auth: service(),
-  tabStates: service(),
-  statusImages: service(),
-  repositories: service(),
+  @service auth: null,
+  @service tabStates: null,
+  @service statusImages: null,
+  @service repositories: null,
 
-  @alias('repositories.searchResults.firstObject') repo: null,
+  @controller repos: null,
+
+  @alias('repos.repos.firstObject') repo: null,
 
   @alias('tabStates.mainTab') tab: null,
 

--- a/app/controllers/settings.js
+++ b/app/controllers/settings.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
-import computed, { alias, sort, filterBy } from 'ember-computed-decorators';
+import { computed } from 'ember-decorators/object';
+import { alias, sort, filterBy } from 'ember-decorators/object/computed';
 
 export default Ember.Controller.extend({
   envVarSorting: ['name'],

--- a/app/helpers/github-commit-link.js
+++ b/app/helpers/github-commit-link.js
@@ -1,10 +1,9 @@
 import formatCommit from 'travis/utils/format-commit';
 import Ember from 'ember';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default Ember.Helper.extend({
-  externalLinks: service(),
+  @service externalLinks: null,
 
   compute([slug, commitSha]) {
     if (!commitSha) {

--- a/app/mixins/builds/load-more.js
+++ b/app/mixins/builds/load-more.js
@@ -5,8 +5,6 @@ const { service } = Ember.inject;
 export default Ember.Mixin.create({
   tabStates: service(),
 
-  tab: Ember.computed.alias('tabStates.mainTab'),
-
   showMore() {
     const id = this.get('repo.id'),
       buildsLength = this.get('builds.length');
@@ -30,9 +28,9 @@ export default Ember.Mixin.create({
       }
     }
 
-    const tabName = this.get('tab');
+    const tabName = this.get('tabStates.mainTab');
     const singularTab = tabName.substr(0, tabName.length - 1);
-    const type = this.get('tab') === 'builds' ? 'push' : singularTab;
+    const type = tabName === 'builds' ? 'push' : singularTab;
     this.loadMoreBuilds(id, buildsLength, type);
   },
 

--- a/app/mixins/builds/load-more.js
+++ b/app/mixins/builds/load-more.js
@@ -1,9 +1,8 @@
 import Ember from 'ember';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default Ember.Mixin.create({
-  tabStates: service(),
+  @service tabStates: null,
 
   showMore() {
     const id = this.get('repo.id'),

--- a/app/mixins/duration-attributes.js
+++ b/app/mixins/duration-attributes.js
@@ -1,19 +1,22 @@
 import Ember from 'ember';
 import attr from 'ember-data/attr';
+import { computed } from 'ember-decorators/object';
 
 export default Ember.Mixin.create({
   _startedAt: attr(),
   _finishedAt: attr(),
 
-  startedAt: Ember.computed('_startedAt', 'notStarted', function () {
-    if (!this.get('notStarted')) {
-      return this.get('_startedAt');
+  @computed('_startedAt', 'notStarted')
+  startedAt(startedAt, notStarted) {
+    if (!notStarted) {
+      return startedAt;
     }
-  }),
+  },
 
-  finishedAt: Ember.computed('_finishedAt', 'notStarted', function () {
-    if (!this.get('notStarted')) {
-      return this.get('_finishedAt');
+  @computed('_finishedAt', 'notStarted')
+  finishedAt(finishedAt, notStarted) {
+    if (!notStarted) {
+      return finishedAt;
     }
-  })
+  },
 });

--- a/app/mixins/duration-calculations.js
+++ b/app/mixins/duration-calculations.js
@@ -1,28 +1,21 @@
 import Ember from 'ember';
 import durationFrom from 'travis/utils/duration-from';
+import { computed } from 'ember-decorators/object';
 
 export default Ember.Mixin.create({
-  duration: Ember.computed(
-    '_duration',
-    'finishedAt',
-    'startedAt',
-    'notStarted',
-    '_finishedAt',
-    '_startedAt',
-    function () {
-      let duration = this.get('_duration');
-      if (this.get('notStarted')) {
-        return null;
-      } else if (duration) {
-        return duration;
-      } else {
-        return durationFrom(this.get('startedAt'), this.get('finishedAt'));
-      }
+  @computed('_duration', 'finishedAt', 'startedAt', 'notStarted')
+  duration(duration, finishedAt, startedAt, notStarted) {
+    if (notStarted) {
+      return null;
+    } else if (duration) {
+      return duration;
+    } else {
+      return durationFrom(startedAt, finishedAt);
     }
-  ),
+  },
 
   updateTimes() {
     this.notifyPropertyChange('duration');
     return this.notifyPropertyChange('finishedAt');
-  }
+  },
 });

--- a/app/mixins/github-url-properties.js
+++ b/app/mixins/github-url-properties.js
@@ -1,19 +1,17 @@
 import Ember from 'ember';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
+import { computed } from 'ember-decorators/object';
 
 export default Ember.Mixin.create({
-  externalLinks: service(),
+  @service externalLinks: null,
 
-  urlGithubCommit: Ember.computed('repo.slug', 'commit.sha', function () {
-    const slug = this.get('repo.slug');
-    const sha = this.get('commit.sha');
+  @computed('repo.slug', 'commit.sha')
+  urlGithubCommit(slug, sha) {
     return this.get('externalLinks').githubCommit(slug, sha);
-  }),
+  },
 
-  urlGithubPullRequest: Ember.computed('repo.slug', 'build.pullRequestNumber', function () {
-    const slug = this.get('repo.slug');
-    const pullRequestNumber = this.get('build.pullRequestNumber');
+  @computed('repo.slug', 'build.pullRequestNumber')
+  urlGithubPullRequest(slug, pullRequestNumber) {
     return this.get('externalLinks').githubPullRequest(slug, pullRequestNumber);
-  })
+  },
 });

--- a/app/mixins/polling.js
+++ b/app/mixins/polling.js
@@ -1,9 +1,8 @@
 import Ember from 'ember';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default Ember.Mixin.create({
-  polling: service(),
+  @service polling: null,
 
   init() {
     this.set('currentPollModels', {});

--- a/app/models/account.js
+++ b/app/models/account.js
@@ -1,8 +1,8 @@
 import Ember from 'ember';
 import attr from 'ember-data/attr';
 import Model from 'ember-data/model';
-
-const { alias } = Ember.computed;
+import { computed } from 'ember-decorators/object';
+import { alias } from 'ember-decorators/object/computed';
 
 export default Model.extend({
   name: attr(),
@@ -11,12 +11,14 @@ export default Model.extend({
   reposCount: attr('number'),
   subscribed: attr('boolean'),
   education: attr('boolean'),
-  login: alias('id'),
-  displayName: Ember.computed('login', 'name', function () {
-    if (Ember.isBlank(this.get('name'))) {
-      return this.get('login');
-    } else {
-      return this.get('name');
+
+  @alias('id') login: null,
+
+  @computed('login', 'name')
+  displayName(login, name) {
+    if (Ember.isBlank(name)) {
+      return login;
     }
-  })
+    return name;
+  },
 });

--- a/app/models/branch.js
+++ b/app/models/branch.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 import { hasMany, belongsTo } from 'ember-data/relationships';
+import { computed } from 'ember-decorators/object';
 
 export default Model.extend({
   name: attr('string'),
@@ -12,10 +12,11 @@ export default Model.extend({
   builds: hasMany('builds', { inverse: 'branch' }),
   repo: belongsTo('repo', { inverse: 'defaultBranch' }),
 
-  repoId: Ember.computed('id', function () {
-    const match = this.get('id').match(/\/repo\/(\d+)\//);
+  @computed('id')
+  repoId(id) {
+    const match = id.match(/\/repo\/(\d+)\//);
     if (match) {
       return match[1];
     }
-  })
+  },
 });

--- a/app/models/build.js
+++ b/app/models/build.js
@@ -7,11 +7,10 @@ import Model from 'ember-data/model';
 import DurationCalculations from 'travis/mixins/duration-calculations';
 import attr from 'ember-data/attr';
 import { hasMany, belongsTo } from 'ember-data/relationships';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default Model.extend(DurationCalculations, {
-  ajax: service(),
+  @service ajax: null,
 
   branch: belongsTo('branch', { async: false, inverse: 'builds' }),
   branchName: Ember.computed.alias('branch.name'),

--- a/app/models/build.js
+++ b/app/models/build.js
@@ -8,12 +8,14 @@ import DurationCalculations from 'travis/mixins/duration-calculations';
 import attr from 'ember-data/attr';
 import { hasMany, belongsTo } from 'ember-data/relationships';
 import { service } from 'ember-decorators/service';
+import { computed } from 'ember-decorators/object';
+import { alias } from 'ember-decorators/object/computed';
 
 export default Model.extend(DurationCalculations, {
   @service ajax: null,
 
-  branch: belongsTo('branch', { async: false, inverse: 'builds' }),
-  branchName: Ember.computed.alias('branch.name'),
+  @alias('branch.name') branchName: null,
+
   state: attr(),
   number: attr('number'),
   message: attr('string'),
@@ -23,89 +25,92 @@ export default Model.extend(DurationCalculations, {
   pullRequestNumber: attr('number'),
   pullRequestTitle: attr('string'),
   eventType: attr('string'),
-  repo: belongsTo('repo', { async: true }),
-  repoCurrentBuild: belongsTo('repo', { async: true, inverse: 'currentBuild' }),
-  commit: belongsTo('commit', { async: false }),
-  jobs: hasMany('job', { async: true }),
-  stages: hasMany('stage', { async: true }),
   _config: attr(),
 
-  config: Ember.computed('_config', function () {
-    let config = this.get('_config');
+  repo: belongsTo('repo', { async: true }),
+  branch: belongsTo('branch', { async: false, inverse: 'builds' }),
+  repoCurrentBuild: belongsTo('repo', { async: true, inverse: 'currentBuild' }),
+  commit: belongsTo('commit', { async: false }),
+
+  jobs: hasMany('job', { async: true }),
+  stages: hasMany('stage', { async: true }),
+
+  @computed('_config', 'currentState.stateName')
+  config(config, stateName) {
     if (config) {
       return pickBy(config);
-    } else if (this.get('currentState.stateName') !== 'root.loading') {
+    } else if (stateName !== 'root.loading') {
       if (this.get('isFetchingConfig')) {
         return;
       }
       this.set('isFetchingConfig', true);
       return this.reload();
     }
-  }),
+  },
 
-  isPullRequest: Ember.computed('eventType', function () {
-    return this.get('eventType') === 'pull_request';
-  }),
+  @computed('eventType')
+  isPullRequest(eventType) {
+    return eventType === 'pull_request';
+  },
 
-  isMatrix: Ember.computed('jobs.length', function () {
-    return this.get('jobs.length') > 1;
-  }),
+  @computed('jobs.[]')
+  isMatrix(jobs) {
+    return jobs.get('length') > 1;
+  },
 
-  isFinished: Ember.computed('state', function () {
-    let state = this.get('state');
+  @computed('state')
+  isFinished(state) {
     let finishedStates = ['passed', 'failed', 'errored', 'canceled'];
     return finishedStates.includes(state);
-  }),
+  },
 
-  notStarted: Ember.computed('state', function () {
-    let state = this.get('state');
+  @computed('state')
+  notStarted(state) {
     let waitingStates = ['queued', 'created', 'received'];
     return waitingStates.includes(state);
-  }),
+  },
 
-  requiredJobs: Ember.computed('jobs.@each.allowFailure', function () {
-    return this.get('jobs').filter(function (data) {
-      return !data.get('allowFailure');
-    });
-  }),
+  @computed('jobs.@each.allowFailure')
+  requiredJobs(jobs) {
+    return jobs.filter(job => !job.get('allowFailure'));
+  },
 
-  allowedFailureJobs: Ember.computed('jobs.@each.allowFailure', function () {
-    return this.get('jobs').filter(function (data) {
-      return data.get('allowFailure');
-    });
-  }),
+  @computed('jobs.@each.allowFailure')
+  allowedFailureJobs(jobs) {
+    return jobs.filter(job => job.get('allowFailure'));
+  },
 
-  rawConfigKeys: Ember.computed('config', 'jobs.@each.config', function () {
-    var keys;
-    keys = [];
-    this.get('jobs').forEach(function (job) {
-      return safelistedConfigKeys(job.get('config')).forEach(function (key) {
+  @computed('jobs.@each.config')
+  rawConfigKeys(jobs) {
+    let keys = [];
+    jobs.forEach((job) => {
+      return safelistedConfigKeys(job.get('config')).forEach((key) => {
         if (!keys.includes(key)) {
           return keys.pushObject(key);
         }
       });
     });
     return keys;
-  }),
+  },
 
-  configKeys: Ember.computed('rawConfigKeys.length', function () {
-    var headers, keys;
-    keys = this.get('rawConfigKeys');
-    headers = ['Job', 'Duration', 'Finished'];
-    return headers.concat(keys).map(function (key) {
+  @computed('rawConfigKeys.[]')
+  configKeys(keys) {
+    const headers = ['Job', 'Duration', 'Finished'];
+    return headers.concat(keys).map((key) => {
       if (configKeysMap.hasOwnProperty(key)) {
         return configKeysMap[key];
       } else {
         return key;
       }
     });
-  }),
+  },
 
-  canCancel: Ember.computed('jobs.@each.canCancel', 'jobs.[]', function () {
-    return this.get('jobs').filterBy('canCancel', true).length;
-  }),
+  @computed('jobs.@each.canCancel')
+  canCancel(jobs) {
+    return !Ember.isEmpty(jobs.filterBy('canCancel'));
+  },
 
-  canRestart: Ember.computed.alias('isFinished'),
+  @alias('isFinished') canRestart: null,
 
   cancel() {
     return this.get('ajax').postV3('/build/' + (this.get('id')) + '/cancel');
@@ -115,19 +120,20 @@ export default Model.extend(DurationCalculations, {
     return this.get('ajax').postV3(`/build/${this.get('id')}/restart`);
   },
 
-  canDebug: Ember.computed('jobs.length', function () {
-    return this.get('jobs.length') === 1;
-  }),
+  @computed('jobs.[]')
+  canDebug(jobs) {
+    return jobs.get('length') === 1;
+  },
 
   debug() {
     return Ember.RSVP.all(this.get('jobs').map(job => job.debug()));
   },
 
-  formattedFinishedAt: Ember.computed('finishedAt', function () {
-    let finishedAt = this.get('finishedAt');
+  @computed('finishedAt')
+  formattedFinishedAt(finishedAt) {
     if (finishedAt) {
       var m = moment(finishedAt);
       return m.isValid() ? m.format('lll') : 'not finished yet';
     }
-  })
+  },
 });

--- a/app/models/commit.js
+++ b/app/models/commit.js
@@ -2,11 +2,10 @@ import Ember from 'ember';
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 import { belongsTo } from 'ember-data/relationships';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default Model.extend({
-  externalLinks: service(),
+  @service externalLinks: null,
 
   sha: attr(),
   branch: attr(),

--- a/app/models/commit.js
+++ b/app/models/commit.js
@@ -1,8 +1,8 @@
-import Ember from 'ember';
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 import { belongsTo } from 'ember-data/relationships';
 import { service } from 'ember-decorators/service';
+import { computed } from 'ember-decorators/object';
 
 export default Model.extend({
   @service externalLinks: null,
@@ -21,31 +21,24 @@ export default Model.extend({
 
   build: belongsTo('build'),
 
-  subject: Ember.computed('message', function () {
-    if (this.get('message')) {
-      return this.get('message').split('\n', 1)[0];
+  @computed('message')
+  subject(message) {
+    if (message) {
+      return message.split('\n', 1)[0];
     }
-  }),
+  },
 
-  body: Ember.computed('message', function () {
-    let message = this.get('message');
+  @computed('message')
+  body(message) {
     if (message && message.indexOf('\n') > 0) {
       return message.substr(message.indexOf('\n') + 1).trim();
     } else {
       return '';
     }
-  }),
+  },
 
-  authorIsCommitter: Ember.computed(
-    'authorName',
-    'authorEmail',
-    'committerName',
-    'committerEmail',
-    function () {
-      let namesMatch = this.get('authorName') === this.get('committerName');
-      let emailsMatch = this.get('authorEmail') === this.get('committerEmail');
-      return namesMatch && emailsMatch;
-    }
-  )
-
+  @computed('authorName', 'authorEmail', 'committerName', 'committerEmail')
+  authorIsCommitter(authorName, authorEmail, committerName, committerEmail) {
+    return authorName === committerName && authorEmail === committerEmail;
+  },
 });

--- a/app/models/hook.js
+++ b/app/models/hook.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import Model from 'ember-data/model';
 import config from 'travis/config/environment';
+import { computed } from 'ember-decorators/object';
 import attr from 'ember-data/attr';
 
 export default Model.extend({
@@ -11,21 +12,25 @@ export default Model.extend({
   admin: attr('boolean'),
   'private': attr('boolean'),
 
-  account: Ember.computed('slug', function () {
-    return this.get('slug').split('/')[0];
-  }),
+  @computed('slug')
+  account(slug) {
+    return slug.split('/')[0];
+  },
 
-  slug: Ember.computed('ownerName', 'name', function () {
-    return (this.get('ownerName')) + '/' + (this.get('name'));
-  }),
+  @computed('ownerName', 'name')
+  slug(ownerName, name) {
+    return `${ownerName}/${name}`;
+  },
 
-  urlGithub: Ember.computed(function () {
-    return config.sourceEndpoint + '/' + (this.get('slug'));
-  }),
+  @computed('slug')
+  urlGithub(slug) {
+    return `${config.sourceEndpoint}/${slug}`;
+  },
 
-  urlGithubAdmin: Ember.computed(function () {
-    return config.sourceEndpoint + '/' + (this.get('slug')) + '/settings/hooks#travis_minibucket';
-  }),
+  @computed('slug')
+  urlGithubAdmin(slug) {
+    return `${config.sourceEndpoint}/${slug}/settings/hooks#travis_minibucket`;
+  },
 
   toggle() {
     if (this.get('isSaving')) {
@@ -58,5 +63,5 @@ export default Model.extend({
         }
       }
     });
-  }
+  },
 });

--- a/app/models/job.js
+++ b/app/models/job.js
@@ -8,7 +8,7 @@ import DurationCalculations from 'travis/mixins/duration-calculations';
 import DurationAttributes from 'travis/mixins/duration-attributes';
 import attr from 'ember-data/attr';
 import { belongsTo } from 'ember-data/relationships';
-import computed from 'ember-computed-decorators';
+import { computed } from 'ember-decorators/object';
 
 const { service } = Ember.inject;
 

--- a/app/models/job.js
+++ b/app/models/job.js
@@ -9,11 +9,11 @@ import DurationAttributes from 'travis/mixins/duration-attributes';
 import attr from 'ember-data/attr';
 import { belongsTo } from 'ember-data/relationships';
 import { computed } from 'ember-decorators/object';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default Model.extend(DurationCalculations, DurationAttributes, {
-  ajax: service(),
+  @service ajax: null,
+
   logId: attr(),
   queue: attr(),
   state: attr(),

--- a/app/models/job.js
+++ b/app/models/job.js
@@ -47,8 +47,9 @@ export default Model.extend(DurationCalculations, DurationAttributes, {
     });
   },
 
-  config: Ember.computed('_config', function () {
-    let config = this.get('_config');
+  // TODO: DO NOT SET OTHER PROPERTIES WITHIN A COMPUTED PROPERTY!
+  @computed('_config')
+  config(config) {
     if (config) {
       return pickBy(config);
     } else {
@@ -66,7 +67,7 @@ export default Model.extend(DurationCalculations, DurationAttributes, {
 
       fetchConfig();
     }
-  }),
+  },
 
   getCurrentState() {
     return this.get('currentState.stateName');

--- a/app/models/log.js
+++ b/app/models/log.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import config from 'travis/config/environment';
+import { service } from 'ember-decorators/service';
 
 var Request = Ember.Object.extend({
   HEADERS: {
@@ -51,10 +52,8 @@ var Request = Ember.Object.extend({
   }
 });
 
-const { service } = Ember.inject;
-
 var LogModel = Ember.Object.extend({
-  features: service(),
+  @service features: null,
 
   version: 0,
   isLoaded: false,

--- a/app/models/log.js
+++ b/app/models/log.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 import config from 'travis/config/environment';
 import { service } from 'ember-decorators/service';
+import { computed } from 'ember-decorators/object';
+import { gt } from 'ember-decorators/object/computed';
 
 var Request = Ember.Object.extend({
   HEADERS: {
@@ -58,7 +60,7 @@ var LogModel = Ember.Object.extend({
   version: 0,
   isLoaded: false,
   length: 0,
-  hasContent: Ember.computed.gt('parts.length', 0),
+  @gt('parts.length', 0) hasContent: null,
 
   fetchMissingParts(partNumbers, after) {
     var data;
@@ -97,11 +99,12 @@ var LogModel = Ember.Object.extend({
     });
   },
 
-  parts: Ember.computed(function () {
+  @computed()
+  parts() {
     return Ember.ArrayProxy.create({
       content: []
     });
-  }),
+  },
 
   clearParts() {
     var parts;

--- a/app/models/repo.js
+++ b/app/models/repo.js
@@ -3,12 +3,12 @@ import Model from 'ember-data/model';
 import Ember from 'ember';
 import attr from 'ember-data/attr';
 import { belongsTo } from 'ember-data/relationships';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 const Repo = Model.extend({
+  @service ajax: null,
+
   permissions: attr(),
-  ajax: service(),
   slug: attr(),
   description: attr(),
   'private': attr('boolean'),

--- a/app/models/request.js
+++ b/app/models/request.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 import { belongsTo } from 'ember-data/relationships';
+import { computed } from 'ember-decorators/object';
 
 export default Model.extend({
   created_at: attr(),
@@ -19,14 +19,16 @@ export default Model.extend({
   commit: belongsTo('commit', { async: true }),
   build: belongsTo('build', { async: true }),
 
-  isAccepted: Ember.computed('result', function () {
+  @computed('result', 'build.id')
+  isAccepted(result, buildId) {
     // For some reason some of the requests have a null result beside the fact that
     // the build was created. We need to look into it, but for now we can just assume
     // that if build was created, the request was accepted
-    return this.get('result') === 'accepted' || this.get('build.id');
-  }),
+    return result === 'accepted' || buildId;
+  },
 
-  isPullRequest: Ember.computed('event_type', function () {
-    return this.get('event_type') === 'pull_request';
-  })
+  @computed('event_type')
+  isPullRequest(eventType) {
+    return eventType === 'pull_request';
+  },
 });

--- a/app/models/stage.js
+++ b/app/models/stage.js
@@ -1,23 +1,20 @@
 import Model from 'ember-data/model';
-import Ember from 'ember';
-
 import attr from 'ember-data/attr';
 import { belongsTo } from 'ember-data/relationships';
-
+import { computed } from 'ember-decorators/object';
 import DurationCalculations from 'travis/mixins/duration-calculations';
 import DurationAttributes from 'travis/mixins/duration-attributes';
 
 export default Model.extend(DurationCalculations, DurationAttributes, {
-  build: belongsTo({ async: true }),
-
   number: attr(),
   name: attr(),
-
   state: attr(),
 
-  notStarted: Ember.computed('state', function () {
-    let state = this.get('state');
+  build: belongsTo({ async: true }),
+
+  @computed('state')
+  notStarted(state) {
     let waitingStates = ['queued', 'created', 'received'];
     return waitingStates.includes(state);
-  })
+  },
 });

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -3,14 +3,12 @@ import Ember from 'ember';
 import Model from 'ember-data/model';
 import config from 'travis/config/environment';
 import attr from 'ember-data/attr';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default Model.extend({
-  ajax: service(),
-
+  @service ajax: null,
   // TODO: this totally not should be needed here
-  sessionStorage: service(),
+  @service sessionStorage: null,
 
   name: attr(),
   email: attr(),

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -4,6 +4,7 @@ import Model from 'ember-data/model';
 import config from 'travis/config/environment';
 import attr from 'ember-data/attr';
 import { service } from 'ember-decorators/service';
+import { computed } from 'ember-decorators/object';
 
 export default Model.extend({
   @service ajax: null,
@@ -20,9 +21,10 @@ export default Model.extend({
   repoCount: attr('number'),
   avatarUrl: attr(),
 
-  fullName: Ember.computed('name', 'login', function () {
-    return this.get('name') || this.get('login');
-  }),
+  @computed('name', 'login')
+  fullName(name, login) {
+    return name || login;
+  },
 
   isSyncingDidChange: Ember.observer('isSyncing', function () {
     return Ember.run.next(this, function () {
@@ -32,63 +34,66 @@ export default Model.extend({
     });
   }),
 
-  urlGithub: Ember.computed(function () {
-    return config.sourceEndpoint + '/' + (this.get('login'));
-  }),
+  @computed('login')
+  urlGithub(login) {
+    return `${config.sourceEndpoint}/${login}`;
+  },
 
-  _rawPermissions: Ember.computed(function () {
+  @computed()
+  _rawPermissions() {
     return this.get('ajax').get('/users/permissions');
-  }),
+  },
 
-  permissions: Ember.computed(function () {
-    var permissions;
-    permissions = Ember.ArrayProxy.create({
+  @computed('_rawPermissions')
+  permissions(_rawPermissions) {
+    let permissions = Ember.ArrayProxy.create({
       content: []
     });
-    this.get('_rawPermissions').then((data) => {
+    _rawPermissions.then((data) => {
       return permissions.set('content', data.permissions);
     });
     return permissions;
-  }),
+  },
 
-  adminPermissions: Ember.computed(function () {
-    var permissions;
-    permissions = Ember.ArrayProxy.create({
+  @computed('_rawPermissions')
+  adminPermissions(_rawPermissions) {
+    let permissions = Ember.ArrayProxy.create({
       content: []
     });
-    this.get('_rawPermissions').then((data) => {
+    _rawPermissions.then((data) => {
       return permissions.set('content', data.admin);
     });
     return permissions;
-  }),
+  },
 
-  pullPermissions: Ember.computed(function () {
-    var permissions;
-    permissions = Ember.ArrayProxy.create({
+  @computed('_rawPermissions')
+  pullPermissions(_rawPermissions) {
+    const permissions = Ember.ArrayProxy.create({
       content: []
     });
-    this.get('_rawPermissions').then((data) => {
+    _rawPermissions.then((data) => {
       return permissions.set('content', data.pull);
     });
     return permissions;
-  }),
+  },
 
-  pushPermissions: Ember.computed(function () {
-    var permissions;
-    permissions = Ember.ArrayProxy.create({
+  @computed('_rawPermissions')
+  pushPermissions(_rawPermissions) {
+    const permissions = Ember.ArrayProxy.create({
       content: []
     });
-    this.get('_rawPermissions').then((data) => {
+    _rawPermissions.then((data) => {
       return permissions.set('content', data.push);
     });
     return permissions;
-  }),
+  },
 
-  pushPermissionsPromise: Ember.computed(function () {
-    return this.get('_rawPermissions').then((data) => {
+  @computed('_rawPermissions')
+  pushPermissionsPromise(_rawPermissions) {
+    return _rawPermissions.then((data) => {
       return data.pull;
     });
-  }),
+  },
 
   hasAccessToRepo(repo) {
     let id = repo.get ? repo.get('id') : repo;
@@ -114,9 +119,7 @@ export default Model.extend({
     }
   },
 
-  type: Ember.computed(function () {
-    return 'user';
-  }),
+  type: 'user',
 
   sync() {
     var self;

--- a/app/routes/accounts/index.js
+++ b/app/routes/accounts/index.js
@@ -1,10 +1,8 @@
-import Ember from 'ember';
 import TravisRoute from 'travis/routes/basic';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default TravisRoute.extend({
-  auth: service(),
+  @service auth: null,
 
   redirect: function () {
     // TODO: setting accounts model in ProfileRoute is wrong, but

--- a/app/routes/auth.js
+++ b/app/routes/auth.js
@@ -1,10 +1,9 @@
 import Ember from 'ember';
 import TravisRoute from 'travis/routes/basic';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default TravisRoute.extend({
-  auth: service(),
+  @service auth: null,
 
   needsAuth: false,
 
@@ -36,5 +35,5 @@ export default TravisRoute.extend({
         return this.transitionTo('index');
       }
     }
-  }
+  },
 });

--- a/app/routes/basic.js
+++ b/app/routes/basic.js
@@ -1,10 +1,10 @@
 import Ember from 'ember';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
+import { alias } from 'ember-decorators/object/computed';
 
 export default Ember.Route.extend({
-  auth: service(),
-  featureFlags: service(),
+  @service auth: null,
+  @service featureFlags: null,
 
   activate() {
     if (this.routeName !== 'error') {
@@ -44,5 +44,5 @@ export default Ember.Route.extend({
   },
 
   // on pro, we need to auth on every route
-  needsAuth: Ember.computed.alias('features.proVersion'),
+  @alias('features.proVersion') needsAuth: null,
 });

--- a/app/routes/branches.js
+++ b/app/routes/branches.js
@@ -1,12 +1,11 @@
 import Ember from 'ember';
 import TravisRoute from 'travis/routes/basic';
 import config from 'travis/config/environment';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default TravisRoute.extend({
-  repositories: service(),
-  tabStates: service(),
+  @service repositories: null,
+  @service tabStates: null,
 
   model(/* params*/) {
     var allTheBranches, apiEndpoint, options, repoId;

--- a/app/routes/build.js
+++ b/app/routes/build.js
@@ -1,10 +1,8 @@
-import Ember from 'ember';
 import TravisRoute from 'travis/routes/basic';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default TravisRoute.extend({
-  tabStates: service(),
+  @service tabStates: null,
 
   titleToken(model) {
     return 'Build #' + (model.get('number'));

--- a/app/routes/builds.js
+++ b/app/routes/builds.js
@@ -1,11 +1,8 @@
-import Ember from 'ember';
 import TravisRoute from 'travis/routes/basic';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default TravisRoute.extend({
-  repositories: service(),
-  tabStates: service(),
+  @service tabStates: null,
 
   activate(...args) {
     this._super(args);

--- a/app/routes/caches.js
+++ b/app/routes/caches.js
@@ -45,10 +45,9 @@ export default TravisRoute.extend({
       }
       return {
         repo,
-        pushes: pushes,
-        pullRequests: pullRequests
+        pushes,
+        pullRequests,
       };
     });
-  }
-
+  },
 });

--- a/app/routes/caches.js
+++ b/app/routes/caches.js
@@ -1,10 +1,9 @@
-import Ember from 'ember';
 import TravisRoute from 'travis/routes/basic';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default TravisRoute.extend({
-  ajax: service(),
+  @service ajax: service(),
+
   needsAuth: true,
 
   setupController(/* controller*/) {

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,11 +1,10 @@
 import Ember from 'ember';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default Ember.Route.extend({
-  auth: service(),
-  tabStates: service(),
-  repositories: service(),
+  @service auth: null,
+  @service tabStates: null,
+  @service repositories: null,
 
   redirect() {
     if (this.get('auth.signedIn')) {

--- a/app/routes/pull-requests.js
+++ b/app/routes/pull-requests.js
@@ -1,11 +1,8 @@
-import Ember from 'ember';
 import TravisRoute from 'travis/routes/basic';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default TravisRoute.extend({
-  repositories: service(),
-  tabStates: service(),
+  @service tabStates: null,
 
   activate(...args) {
     this._super(args);

--- a/app/routes/repo.js
+++ b/app/routes/repo.js
@@ -2,13 +2,12 @@ import TravisRoute from 'travis/routes/basic';
 import Repo from 'travis/models/repo';
 import ScrollResetMixin from 'travis/mixins/scroll-reset';
 import Ember from 'ember';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default TravisRoute.extend(ScrollResetMixin, {
-  store: service(),
-  tabStates: service(),
-  repositories: service(),
+  @service store: null,
+  @service tabStates: null,
+  @service repositories: null,
 
   activate(...args) {
     this._super(args);

--- a/app/routes/repo/index.js
+++ b/app/routes/repo/index.js
@@ -1,10 +1,8 @@
-import Ember from 'ember';
 import TravisRoute from 'travis/routes/basic';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default TravisRoute.extend({
-  tabStates: service(),
+  @service tabStates: null,
 
   setupController(controller, model) {
     this._super(...arguments);

--- a/app/routes/search.js
+++ b/app/routes/search.js
@@ -1,11 +1,10 @@
 import Ember from 'ember';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default Ember.Route.extend({
-  tabStates: service(),
-  auth: service(),
-  repositories: service(),
+  @service tabStates: null,
+  @service auth: null,
+  @service repositories: null,
 
   redirect() {
     if (!this.get('auth.signedIn')) {

--- a/app/routes/settings.js
+++ b/app/routes/settings.js
@@ -1,11 +1,11 @@
+import Ember from 'ember';
 import TravisRoute from 'travis/routes/basic';
 import config from 'travis/config/environment';
-import Ember from 'ember';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default TravisRoute.extend({
-  ajax: service(),
+  @service ajax: null,
+
   needsAuth: true,
 
   setupController: function (controller, model) {

--- a/app/services/ajax.js
+++ b/app/services/ajax.js
@@ -1,21 +1,19 @@
 /* global jQuery */
 import Ember from 'ember';
 import config from 'travis/config/environment';
-let defaultOptions;
+import { service } from 'ember-decorators/service';
 
 jQuery.support.cors = true;
 
-defaultOptions = {
+let defaultOptions = {
   accepts: {
     json: 'application/json; version=2'
   }
 };
 
-const { service } = Ember.inject;
-
 export default Ember.Service.extend({
-  auth: service(),
-  features: service(),
+  @service auth: null,
+  @service features: null,
 
   get(url, callback, errorCallback) {
     return this.ajax(url, 'get', {

--- a/app/services/auth.js
+++ b/app/services/auth.js
@@ -3,16 +3,16 @@ import config from 'travis/config/environment';
 import Ember from 'ember';
 import { computed } from 'ember-decorators/object';
 import { alias } from 'ember-decorators/object/computed';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default Ember.Service.extend({
-  router: service(),
-  flashes: service(),
-  store: service(),
-  storage: service(),
-  sessionStorage: service(),
-  ajax: service(),
+  @service router: null,
+  @service flashes: null,
+  @service store: null,
+  @service storage: null,
+  @service sessionStorage: null,
+  @service ajax: null,
+
   state: 'signed-out',
   receivingEnd: `${location.protocol}//${location.host}`,
 

--- a/app/services/broadcasts.js
+++ b/app/services/broadcasts.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import config from 'travis/config/environment';
-import computed from 'ember-computed-decorators';
+import { computed } from 'ember-decorators/object';
 
 const { service } = Ember.inject;
 

--- a/app/services/broadcasts.js
+++ b/app/services/broadcasts.js
@@ -1,12 +1,11 @@
 import Ember from 'ember';
 import config from 'travis/config/environment';
 import { computed } from 'ember-decorators/object';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default Ember.Service.extend({
-  auth: service(),
-  storage: service(),
+  @service auth: null,
+  @service storage: null,
 
   @computed('auth.signedIn')
   broadcasts(signedIn) {

--- a/app/services/feature-flags.js
+++ b/app/services/feature-flags.js
@@ -1,11 +1,10 @@
 import Ember from 'ember';
 import { task } from 'ember-concurrency';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default Ember.Service.extend({
-  store: service(),
-  features: service(),
+  @service store: null,
+  @service features: null,
 
   serverFlags: [],
 

--- a/app/services/flashes.js
+++ b/app/services/flashes.js
@@ -1,8 +1,8 @@
 import Ember from 'ember';
 import LimitedArray from 'travis/utils/limited-array';
-
-const { service } = Ember.inject;
-const { alias } = Ember.computed;
+import { computed } from 'ember-decorators/object';
+import { alias } from 'ember-decorators/computed';
+import { service } from 'ember-decorators/service';
 
 const messageTypeToIcon = {
   notice: 'icon-flag',
@@ -23,9 +23,10 @@ const messageTypeToCloseButton = {
 };
 
 export default Ember.Service.extend({
-  auth: service(),
-  store: service(),
-  currentUser: alias('auth.currentUser'),
+  @service auth: null,
+  @service store: null,
+
+  @alias('auth.currentUser') currentUser: null,
 
   // This changes when scrolling to adjust flash messages to fixed
   topBarVisible: true,
@@ -43,16 +44,14 @@ export default Ember.Service.extend({
     }));
   },
 
-  messages: Ember.computed('flashes.[]', 'flashes.length', function () {
-    let flashes, model;
-
-    flashes = this.get('flashes');
-    model = [];
-    if (flashes) {
+  @computed('flashes.[]')
+  messages(flashes) {
+    let model = [];
+    if (flashes.length) {
       model.pushObjects(flashes.toArray().reverse());
     }
     return model.uniq();
-  }),
+  },
 
   // TODO: when we rewrite all of the place where we use `loadFlashes` we could
   // rewrite this class and make the implementation better, because right now

--- a/app/services/flashes.js
+++ b/app/services/flashes.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import LimitedArray from 'travis/utils/limited-array';
 import { computed } from 'ember-decorators/object';
-import { alias } from 'ember-decorators/computed';
+import { alias } from 'ember-decorators/object/computed';
 import { service } from 'ember-decorators/service';
 
 const messageTypeToIcon = {

--- a/app/services/job-state.js
+++ b/app/services/job-state.js
@@ -1,10 +1,9 @@
 import Ember from 'ember';
 import { task } from 'ember-concurrency';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default Ember.Service.extend({
-  store: service(),
+  @service store: null,
 
   runningJobs: [],
 

--- a/app/services/permissions.js
+++ b/app/services/permissions.js
@@ -1,26 +1,27 @@
 import Ember from 'ember';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
+import { computed } from 'ember-decorators/object';
+import { alias } from 'ember-decorators/object/computed';
 
 export default Ember.Service.extend({
-  auth: service(),
+  @service auth: null,
 
   init() {
     this.get('all');
     return this._super(...arguments);
   },
 
-  currentUser: Ember.computed.alias('auth.currentUser'),
+  @alias('auth.currentUser') currentUser: null,
 
   // This is computed property that can be used to allow any properties that
   // use permissions service to add dependencies easier. So instead of depending
   // on each of these things separately, we can depend on all
-  all: Ember.computed('currentUser.permissions', 'currentUser.permissions.[]',
-         'currentUser.pushPermissions', 'currentUser.pushPermissions.[]',
-         // eslint-disable-next-line
-         'currentUser.adminPermissions', 'currentUser.adminPermissions.[]', function () {
-           return null;
-         }),
+  @computed('currentUser.permissions.[]',
+            'currentUser.pushPermissions.[]',
+            'currentUser.adminPermissions.[]')
+  all() {
+    return null;
+  },
 
   hasPermission(repo) {
     return this.checkPermission(repo, 'permissions');

--- a/app/services/repositories.js
+++ b/app/services/repositories.js
@@ -2,16 +2,15 @@ import Ember from 'ember';
 import config from 'travis/config/environment';
 import Repo from 'travis/models/repo';
 import { task, timeout } from 'ember-concurrency';
-import computed from 'ember-computed-decorators';
-
-const { service } = Ember.inject;
+import { computed } from 'ember-decorators/object';
+import { service } from 'ember-decorators/service';
 
 export default Ember.Service.extend({
-  auth: service(),
-  store: service(),
-  tabStates: service(),
-  ajax: service(),
-  router: service(),
+  @service auth: null,
+  @service store: null,
+  @service tabStates: null,
+  @service ajax: null,
+  @service router: null,
 
   @computed('requestOwnedRepositories', 'performSearchRequest', 'showSearchResults')
   tasks(accessible, performSearch, showSearch) {

--- a/app/services/starred-repos.js
+++ b/app/services/starred-repos.js
@@ -1,7 +1,6 @@
 import Ember from 'ember';
-import computed from 'ember-computed-decorators';
-
-let { service } = Ember.inject;
+import { computed } from 'ember-decorators/object';
+import { service } from 'ember-decorators/service';
 
 let StarredReposWrapper = Ember.ArrayProxy.extend({
   init() {
@@ -16,7 +15,7 @@ let StarredReposWrapper = Ember.ArrayProxy.extend({
 });
 
 export default Ember.Service.extend({
-  store: service(),
+  @service store: null,
 
   fetch() {
     let starredRepos = this.get('starredRepos');

--- a/app/services/status-images.js
+++ b/app/services/status-images.js
@@ -1,11 +1,10 @@
 import Ember from 'ember';
 import config from 'travis/config/environment';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default Ember.Service.extend({
-  auth: service(),
-  features: service(),
+  @service auth: null,
+  @service features: null,
 
   imageUrl(slug, branch) {
     let prefix = `${location.protocol}//${location.host}`;

--- a/app/services/store.js
+++ b/app/services/store.js
@@ -2,11 +2,11 @@
 import DS from 'ember-data';
 import Ember from 'ember';
 import PaginatedCollectionPromise from 'travis/utils/paginated-collection-promise';
-
-const { service } = Ember.inject;
+import { service } from 'ember-decorators/service';
 
 export default DS.Store.extend({
-  auth: service(),
+  @service auth: null,
+
   defaultAdapter: 'application',
   adapter: 'application',
 

--- a/app/templates/components/repository-sidebar.hbs
+++ b/app/templates/components/repository-sidebar.hbs
@@ -16,7 +16,7 @@
   showMyRepositories=(action "showMyRepositories")
   showRunningJobs=(action "showRunningJobs")}}
 
-{{#if shouldShowRunningJobs}}
+{{#if showRunningJobs}}
   <div class="travistab-body sidebar-list">
     <div>
       {{running-jobs jobs=runningJobs}}

--- a/app/templates/components/repository-sidebar.hbs
+++ b/app/templates/components/repository-sidebar.hbs
@@ -16,7 +16,7 @@
   showMyRepositories=(action "showMyRepositories")
   showRunningJobs=(action "showRunningJobs")}}
 
-{{#if showRunningJobs}}
+{{#if shouldShowRunningJobs}}
   <div class="travistab-body sidebar-list">
     <div>
       {{running-jobs jobs=runningJobs}}

--- a/app/utils/expandable-record-array.js
+++ b/app/utils/expandable-record-array.js
@@ -1,10 +1,12 @@
 import Ember from 'ember';
+import { computed } from 'ember-decorators/object';
 
 export default Ember.ArrayProxy.extend({
   isLoaded: false,
   isLoading: false,
 
-  promise: Ember.computed(function () {
+  @computed()
+  promise() {
     var self;
     self = this;
     return new Ember.RSVP.Promise(function (resolve) {
@@ -20,7 +22,7 @@ export default Ember.ArrayProxy.extend({
         return self.addObserver('isLoaded', observer);
       }
     });
-  }),
+  },
 
   load(array) {
     this.set('isLoading', true);

--- a/app/utils/limited-array.js
+++ b/app/utils/limited-array.js
@@ -1,32 +1,31 @@
 import Ember from 'ember';
 import limit from 'travis/utils/computed-limit';
-
-const { alias } = Ember.computed;
+import { computed } from 'ember-decorators/object';
+import { alias } from 'ember-decorators/object/computed';
 
 export default Ember.ArrayProxy.extend({
   limit: 10,
-  isLoaded: alias('content.isLoaded'),
+
   arrangedContent: limit('content', 'limit'),
 
-  totalLength: Ember.computed('content.length', function () {
-    return this.get('content.length');
-  }),
+  @alias('content.isLoaded') isLoaded: null,
 
-  leftLength: Ember.computed('totalLength', 'limit', function () {
-    var left, limit, totalLength;
-    totalLength = this.get('totalLength');
-    limit = this.get('limit');
-    left = totalLength - limit;
+  @alias('content.length') totalLength: null,
+
+  @computed('totalLength', 'limit')
+  leftLength(total, limit) {
+    const left = total - limit;
     if (left < 0) {
       return 0;
     } else {
       return left;
     }
-  }),
+  },
 
-  isMore: Ember.computed('leftLength', function () {
-    return this.get('leftLength') > 0;
-  }),
+  @computed('leftLength')
+  isMore(leftLength) {
+    return leftLength > 0;
+  },
 
   showAll() {
     return this.set('limit', Infinity);

--- a/app/utils/paginated-collection-promise.js
+++ b/app/utils/paginated-collection-promise.js
@@ -1,9 +1,10 @@
 import Ember from 'ember';
 import PaginatedCollection from 'travis/utils/paginated-collection';
+import { computed } from 'ember-decorators/object';
 
 export default PaginatedCollection.extend(Ember.PromiseProxyMixin, {
-  promise: Ember.computed('content', function () {
-    let content = this.get('content');
+  @computed('content')
+  promise(content) {
     let promise = new Ember.RSVP.Promise(function (resolve, reject) {
       content.then(function (value) {
         resolve(PaginatedCollection.create({ content: value }));
@@ -12,5 +13,5 @@ export default PaginatedCollection.extend(Ember.PromiseProxyMixin, {
       });
     });
     return promise;
-  })
+  },
 });


### PR DESCRIPTION
`ember-computed-decorators` has been renamed to [ember-decorators](https://github.com/rwjblue/ember-decorators) to more aptly represent how the project has grown. The project recently hit its 1.0, so it makes sense to cut over.

I've been meaning to move more and more of the codebase over previously, but this finally provides a good opportunity to convert things, including some extras that didn't exist in the previous version: ember data decorators, action decorators, etc.

This PR will tackle getting the bulk converted, but will probably be followed by additional changes to take advantage of more things in the package that we hadn't used before.