### PR TITLE
Fix download link for raw logs (with token)

### DIFF
--- a/app/components/log-content.js
+++ b/app/components/log-content.js
@@ -200,7 +200,7 @@ export default Ember.Component.extend({
     });
   },
 
-  @computed('log.{id,token}', 'features.proVersion')
+  @computed('log.job.id', 'job.log.token', 'features.proVersion')
   plainTextLogUrl(id, token, proVersion) {
     if (id) {
       let url = this.get('externalLinks').plainTextLog(id);


### PR DESCRIPTION
The computed property signature is very odd and could probably be
simplified, but this fixes the issue.