### PR TITLE
Add customisable flash message preamble

### DIFF
--- a/app/services/flashes.js
+++ b/app/services/flashes.js
@@ -69,18 +69,14 @@ export default Ember.Service.extend({
 
       let messageText, preamble;
 
-      if (msg[type].message) {
-        messageText = msg[type].message;
-        preamble = msg[type].preamble;
-      } else {
-        messageText = msg;
-        preamble = messageTypeToPreamble[type];
-      }
+      messageText = msg[type].message;
+      preamble = msg[type].preamble || messageTypeToPreamble[type];
+
       msg = {
         type,
         message: messageText,
         icon: messageTypeToIcon[type],
-        preamble: preamble,
+        preamble,
         closeButton: messageTypeToCloseButton[type]
       };
       this.get('flashes').unshiftObject(msg);

--- a/app/services/flashes.js
+++ b/app/services/flashes.js
@@ -66,11 +66,21 @@ export default Ember.Service.extend({
     for (i = 0, len = msgs.length; i < len; i++) {
       msg = msgs[i];
       type = Object.keys(msg)[0];
+
+      let messageText, preamble;
+
+      if (msg[type].message) {
+        messageText = msg[type].message;
+        preamble = msg[type].preamble;
+      } else {
+        messageText = msg;
+        preamble = messageTypeToPreamble[type];
+      }
       msg = {
         type,
-        message: msg[type],
+        message: messageText,
         icon: messageTypeToIcon[type],
-        preamble: messageTypeToPreamble[type],
+        preamble: preamble,
         closeButton: messageTypeToCloseButton[type]
       };
       this.get('flashes').unshiftObject(msg);
@@ -100,23 +110,23 @@ export default Ember.Service.extend({
     this.setup();
   },
 
-  display(type, message) {
+  display(type, message, preamble) {
     if (!['error', 'notice', 'success'].includes(type)) {
       // eslint-disable-next-line
       console.warn("WARNING: <service:flashes> display(type, message) function can only handle 'error', 'notice' and 'success' types");
     }
-    this.loadFlashes([{ [type]: message }]);
+    this.loadFlashes([{ [type]: { message, preamble } }]);
   },
 
-  success(message) {
-    this.display('success', message);
+  success(message, preamble = messageTypeToPreamble['success']) {
+    this.display('success', message, preamble);
   },
 
-  error(message) {
-    this.display('error', message);
+  error(message, preamble = messageTypeToPreamble['error']) {
+    this.display('error', message, preamble);
   },
 
-  notice(message) {
-    this.display('notice', message);
+  notice(message, preamble = messageTypeToPreamble['notice']) {
+    this.display('notice', message, preamble);
   }
 });

--- a/tests/acceptance/auth/automatic-sign-out-test.js
+++ b/tests/acceptance/auth/automatic-sign-out-test.js
@@ -17,7 +17,7 @@ skip('when token is invalid user should be signed out', function (assert) {
   visit('/');
 
   andThen(function () {
-    assert.equal(topPage.flashMessage, "You've been signed out, because your access token has expired.");
+    assert.equal(topPage.flashMessage.text, "You've been signed out, because your access token has expired.");
   });
   percySnapshot(assert);
 });

--- a/tests/acceptance/builds/cancel-test.js
+++ b/tests/acceptance/builds/cancel-test.js
@@ -27,6 +27,6 @@ test('cancelling build', function (assert) {
     .cancelBuild();
 
   andThen(function () {
-    assert.equal(topPage.flashMessage, 'Build has been successfully cancelled.', 'cancelled build notification should be displayed');
+    assert.equal(topPage.flashMessage.text, 'Build has been successfully cancelled.', 'cancelled build notification should be displayed');
   });
 });

--- a/tests/acceptance/builds/debug-test.js
+++ b/tests/acceptance/builds/debug-test.js
@@ -34,7 +34,7 @@ test('debugging single-job build', function (assert) {
 
   andThen(function () {
     assert.deepEqual(requestBodies.pop(), { quiet: true });
-    assert.equal(topPage.flashMessage, 'The build was successfully restarted in debug mode but make sure to watch the log for a host to connect to.');
+    assert.equal(topPage.flashMessage.text, 'The build was successfully restarted in debug mode but make sure to watch the log for a host to connect to.');
   });
 });
 

--- a/tests/acceptance/builds/pull-requests-test.js
+++ b/tests/acceptance/builds/pull-requests-test.js
@@ -86,6 +86,6 @@ test('view and cancel pull requests', function (assert) {
   page.builds(0).cancelButton.click();
 
   andThen(() => {
-    assert.equal(topPage.flashMessage, 'Build has been successfully cancelled.');
+    assert.equal(topPage.flashMessage.text, 'Build has been successfully cancelled.');
   });
 });

--- a/tests/acceptance/builds/restart-test.js
+++ b/tests/acceptance/builds/restart-test.js
@@ -24,7 +24,7 @@ test('restarting build', function (assert) {
     .restartBuild();
 
   andThen(function () {
-    assert.equal(topPage.flashMessage, 'The build was successfully restarted.', 'restarted notification should display proper build restarted text');
+    assert.equal(topPage.flashMessage.text, 'The build was successfully restarted.', 'restarted notification should display proper build restarted text');
     assert.equal(buildPage.singleJobLogText, 'Hello log', 'shows log text of single build job');
   });
 });

--- a/tests/acceptance/home/flashes-test.js
+++ b/tests/acceptance/home/flashes-test.js
@@ -1,0 +1,14 @@
+import { test } from 'qunit';
+import moduleForAcceptance from 'travis/tests/helpers/module-for-acceptance';
+import topPage from 'travis/tests/pages/top';
+
+moduleForAcceptance('Acceptance | home/flashes');
+
+test('the flashes service displays flash messages', function (assert) {
+  visit('/');
+  this.application.__container__.lookup('service:flashes').success('TOTAL SUCCESS');
+
+  andThen(() => {
+    assert.equal(topPage.flashMessage, 'TOTAL SUCCESS');
+  });
+});

--- a/tests/acceptance/home/flashes-test.js
+++ b/tests/acceptance/home/flashes-test.js
@@ -9,6 +9,6 @@ test('the flashes service displays flash messages', function (assert) {
   this.application.__container__.lookup('service:flashes').success('TOTAL SUCCESS');
 
   andThen(() => {
-    assert.equal(topPage.flashMessage, 'TOTAL SUCCESS');
+    assert.equal(topPage.flashMessage.text, 'TOTAL SUCCESS');
   });
 });

--- a/tests/acceptance/home/flashes-test.js
+++ b/tests/acceptance/home/flashes-test.js
@@ -13,3 +13,14 @@ test('the flashes service displays flash messages', function (assert) {
     assert.ok(topPage.flashMessage.isSuccess, 'expected the flash message to have class `success`');
   });
 });
+
+test('the flashes service permits overriding the preamble', function (assert) {
+  visit('/');
+  this.application.__container__.lookup('service:flashes').notice('A notice!', 'Custom preamble');
+
+  andThen(() => {
+    assert.equal(topPage.flashMessage.text, 'A notice!');
+    assert.equal(topPage.flashMessage.preamble, 'Custom preamble');
+    assert.ok(topPage.flashMessage.isNotice, 'expected the flash message to have class `notice`');
+  });
+});

--- a/tests/acceptance/home/flashes-test.js
+++ b/tests/acceptance/home/flashes-test.js
@@ -10,5 +10,6 @@ test('the flashes service displays flash messages', function (assert) {
 
   andThen(() => {
     assert.equal(topPage.flashMessage.text, 'TOTAL SUCCESS');
+    assert.ok(topPage.flashMessage.isSuccess, 'expected the flash message to have class `success`');
   });
 });

--- a/tests/acceptance/home/flashes-test.js
+++ b/tests/acceptance/home/flashes-test.js
@@ -24,3 +24,21 @@ test('the flashes service permits overriding the preamble', function (assert) {
     assert.ok(topPage.flashMessage.isNotice, 'expected the flash message to have class `notice`');
   });
 });
+
+test('the flashes service has a loadFlashes interface', function (assert) {
+  // See here for an example of where this is used:
+  // https://github.com/travis-ci/travis-api/blob/c4ae7cd2d7e403d4bf1649c3c7d1d5a68d871095/lib/travis/api/app/endpoint/jobs.rb#L33-L35
+
+  visit('/');
+  this.application.__container__.lookup('service:flashes').loadFlashes([{
+    error: {
+      message: 'An error message.'
+    }
+  }]);
+
+  andThen(() => {
+    assert.equal(topPage.flashMessage.text, 'An error message.');
+    assert.equal(topPage.flashMessage.preamble, 'Oh no!');
+    assert.ok(topPage.flashMessage.isError, 'expected the flash message to have class `error`');
+  });
+});

--- a/tests/acceptance/job/cancel-test.js
+++ b/tests/acceptance/job/cancel-test.js
@@ -29,6 +29,6 @@ test('restarting job', function (assert) {
     .cancelJob();
 
   andThen(function () {
-    assert.equal(topPage.flashMessage, 'Job has been successfully cancelled.', 'cancelled job notification should be displayed');
+    assert.equal(topPage.flashMessage.text, 'Job has been successfully cancelled.', 'cancelled job notification should be displayed');
   });
 });

--- a/tests/acceptance/job/debug-test.js
+++ b/tests/acceptance/job/debug-test.js
@@ -39,7 +39,7 @@ test('debugging job', function (assert) {
 
   andThen(function () {
     assert.deepEqual(requestBodies.pop(), { quiet: true });
-    assert.equal(topPage.flashMessage, 'The job was successfully restarted in debug mode but make sure to watch the log for a host to connect to.');
+    assert.equal(topPage.flashMessage.text, 'The job was successfully restarted in debug mode but make sure to watch the log for a host to connect to.');
   });
   percySnapshot(assert);
 });

--- a/tests/acceptance/job/restart-test.js
+++ b/tests/acceptance/job/restart-test.js
@@ -29,6 +29,6 @@ test('restarting job', function (assert) {
     .restartJob();
 
   andThen(function () {
-    assert.equal(topPage.flashMessage, 'The job was successfully restarted.', 'restarted notification should display proper job restarted text');
+    assert.equal(topPage.flashMessage.text, 'The job was successfully restarted.', 'restarted notification should display proper job restarted text');
   });
 });

--- a/tests/acceptance/repo/build-list-routes-test.js
+++ b/tests/acceptance/repo/build-list-routes-test.js
@@ -270,7 +270,7 @@ test('view and cancel pull requests', function (assert) {
   page.builds(0).cancelButton.click();
 
   andThen(() => {
-    assert.equal(topPage.flashMessage, 'Build has been successfully cancelled.');
+    assert.equal(topPage.flashMessage.text, 'Build has been successfully cancelled.');
   });
 });
 

--- a/tests/acceptance/repo/settings-test.js
+++ b/tests/acceptance/repo/settings-test.js
@@ -236,7 +236,7 @@ test('delete and create environment variables', function (assert) {
   settingsPage.environmentVariableForm.add();
 
   andThen(() => {
-    assert.equal(topPage.flashMessage, 'There was an error saving this environment variable.');
+    assert.equal(topPage.flashMessage.text, 'There was an error saving this environment variable.');
 
     // This will cause deletions to fail
     server.delete('/settings/env_vars/:id', () => {}, 500);
@@ -246,7 +246,7 @@ test('delete and create environment variables', function (assert) {
 
   andThen(() => {
     assert.equal(settingsPage.environmentVariables().count, 2, 'expected the environment variable to remain');
-    assert.equal(topPage.flashMessage, 'There was an error deleting this environment variable.');
+    assert.equal(topPage.flashMessage.text, 'There was an error deleting this environment variable.');
 
     server.delete('/settings/env_vars/:id', () => {}, 404);
   });
@@ -255,7 +255,7 @@ test('delete and create environment variables', function (assert) {
 
   andThen(() => {
     assert.equal(settingsPage.environmentVariables().count, 2, 'expected the environment variable to remain');
-    assert.equal(topPage.flashMessage, 'This environment variable has already been deleted. Try refreshing.');
+    assert.equal(topPage.flashMessage.text, 'This environment variable has already been deleted. Try refreshing.');
   });
 });
 

--- a/tests/pages/top.js
+++ b/tests/pages/top.js
@@ -46,5 +46,9 @@ export default PageObject.create({
     }
   }),
 
-  flashMessage: text('p.flash-message .message', { resetScope: true })
+  flashMessage: {
+    scope: 'ul.flash li:eq(0)',
+    resetScope: true,
+    text: text('p.flash-message .message')
+  }
 });

--- a/tests/pages/top.js
+++ b/tests/pages/top.js
@@ -49,6 +49,7 @@ export default PageObject.create({
   flashMessage: {
     scope: 'ul.flash li:eq(0)',
     resetScope: true,
-    text: text('p.flash-message .message')
+    text: text('p.flash-message .message'),
+    isSuccess: hasClass('success')
   }
 });

--- a/tests/pages/top.js
+++ b/tests/pages/top.js
@@ -54,6 +54,7 @@ export default PageObject.create({
     preamble: text('p.flash-message .preamble'),
 
     isSuccess: hasClass('success'),
-    isNotice: hasClass('notice')
+    isNotice: hasClass('notice'),
+    isError: hasClass('error')
   }
 });

--- a/tests/pages/top.js
+++ b/tests/pages/top.js
@@ -49,7 +49,11 @@ export default PageObject.create({
   flashMessage: {
     scope: 'ul.flash li:eq(0)',
     resetScope: true,
+
     text: text('p.flash-message .message'),
-    isSuccess: hasClass('success')
+    preamble: text('p.flash-message .preamble'),
+
+    isSuccess: hasClass('success'),
+    isNotice: hasClass('notice')
   }
 });


### PR DESCRIPTION
This lets the default preamble be overwritten. It also adds acceptance tests around flash messages.