### PR TITLE
Speed up test suite

### DIFF
--- a/app/services/store.js
+++ b/app/services/store.js
@@ -2,6 +2,7 @@
 import DS from 'ember-data';
 import Ember from 'ember';
 import PaginatedCollectionPromise from 'travis/utils/paginated-collection-promise';
+import config from 'travis/config/environment';
 import { service } from 'ember-decorators/service';
 
 export default DS.Store.extend({
@@ -82,7 +83,7 @@ export default DS.Store.extend({
 
       Ember.run.later(() => {
         this.findRecord('branch', `/repo/${data.repository_id}/branch/${branchName}`);
-      }, 2000);
+      }, config.intervals.branchCreatedSyncDelay);
 
       delete data.branch;
     }

--- a/config/environment.js
+++ b/config/environment.js
@@ -35,6 +35,7 @@ module.exports = function (environment) {
     endpoints: {},
     intervals: {
       updateTimes: 1000,
+      branchCreatedSyncDelay: 2000,
       repositorySearchDebounceRate: 500,
     },
     githubOrgsOauthAccessSettingsUrl: 'https://github.com/settings/connections/applications/f244293c729d5066cf27',
@@ -109,6 +110,7 @@ module.exports = function (environment) {
     ENV.locationType = 'none';
 
     ENV.intervals.searchDebounceRate = 0;
+    ENV.intervals.branchCreatedSyncDelay = 0;
 
     ENV.APP.rootElement = '#ember-testing';
 

--- a/tests/integration/components/add-env-var-test.js
+++ b/tests/integration/components/add-env-var-test.js
@@ -47,7 +47,7 @@ test('it adds an env var on submit', function (assert) {
   assert.ok(!envVar.get('public'), 'env var should be private');
 
   var done = assert.async();
-  setTimeout(function () { done(); }, 500);
+  done();
 });
 
 test('it shows an error if no name is present', function (assert) {
@@ -103,5 +103,5 @@ test('it adds a public env var on submit', function (assert) {
   assert.ok(envVar.get('public'), 'env var should be public');
 
   var done = assert.async();
-  setTimeout(function () { done(); }, 500);
+  done();
 });

--- a/tests/integration/components/add-ssh-key-test.js
+++ b/tests/integration/components/add-ssh-key-test.js
@@ -50,7 +50,7 @@ test('it adds an ssh key on submit', function (assert) {
   percySnapshot(assert);
 
   var done = assert.async();
-  setTimeout(function () { done(); }, 500);
+  done();
 });
 
 

--- a/tests/integration/components/ssh-key-test.js
+++ b/tests/integration/components/ssh-key-test.js
@@ -63,9 +63,8 @@ test('it deletes a custom key if permissions are right', function (assert) {
   assert.ok(key.get('isDeleted'), 'key should be deleted');
   percySnapshot(assert);
 
-  // we don't deal with saving records for now, so at least wait till it's done
   var done = assert.async();
-  setTimeout(function () { done(); }, 500);
+  done();
 });
 
 test('it does not delete the custom key if permissions are insufficient', function (assert) {


### PR DESCRIPTION
I've removed some of our timeouts completely and replaced another one that was causing an acceptance test to hang with a config value that we can set to `0` in tests.

Based on my local testing, this seems to speed things up by a little over 10%.

Before:
<img width="637" alt="screen shot 2017-08-08 at 3 15 31 pm" src="https://user-images.githubusercontent.com/366944/29107894-b73ac1b4-7cdc-11e7-8a20-1eacb2252b57.png">

After:
<img width="625" alt="screen shot 2017-08-08 at 3 15 29 pm" src="https://user-images.githubusercontent.com/366944/29107900-be8d9d88-7cdc-11e7-9f54-e672e3564551.png">
