### PR TITLE
Change test randomisation to not run with Percy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install:
 before_script:
   - if [ "$EMBER_VERSION" = 'default' ] && [ $TRAVIS_PULL_REQUEST = 'false' ]; then echo "Enabling Percy on push with default Ember" && export PERCY_ENABLE=1; fi
   - echo $PERCY_ENABLE
-  - if [ "$PERCY_ENABLE" ]; then export $RANDOMISE=--random; fi
+  - if [ "$PERCY_ENABLE" ]; then export RANDOMISE=--random; fi
   - echo $RANDOMISE
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install:
 before_script:
   - if [ "$EMBER_VERSION" = 'default' ] && [ $TRAVIS_PULL_REQUEST = 'false' ]; then echo "Enabling Percy on push with default Ember" && export PERCY_ENABLE=1; fi
   - echo $PERCY_ENABLE
-  - if [ "$PERCY_ENABLE" ]; then export RANDOMISE=--random; fi
+  - if [ "$PERCY_ENABLE" -ne 1 ]; then export RANDOMISE=--random; fi
   - echo $RANDOMISE
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,11 @@ install:
 before_script:
   - if [ "$EMBER_VERSION" = 'default' ] && [ $TRAVIS_PULL_REQUEST = 'false' ]; then echo "Enabling Percy on push with default Ember" && export PERCY_ENABLE=1; fi
   - echo $PERCY_ENABLE
+  - if [ "$PERCY_ENABLE" ]; then export $RANDOMISE=--random; fi
+  - echo $RANDOMISE
 
 script:
-  - ember try:one $EMBER_VERSION --skip-cleanup=true --- ember exam --reporter dot --random
+  - ember try:one $EMBER_VERSION --skip-cleanup=true --- ember exam --reporter dot $RANDOMISE
 
 before_deploy:
   - ASSETS_HOST=https://s3.amazonaws.com/travis-error-pages ember build --env production


### PR DESCRIPTION
I did manage to fix a lot of the spurious visual diffs by [eliminating some test bleed-through](https://github.com/travis-ci/travis-web/pull/1140/files) (and we got some [welcome help for others](https://github.com/travis-ci/travis-web/pull/1147)), but we still have one or two on each build since then. I don’t have time at the moment to look deeply enough to remove the rest of the bleed-though, so instead I’m suggesting that we stop randomising tests when we’ll be producing diffs with Percy.

I don’t love it, but the noise from the false diffs is grating and I don’t know if/when I’ll be able to address the cause.