### PR TITLE
Restore live favicon-as-status

### DIFF
--- a/app/components/build-layout.js
+++ b/app/components/build-layout.js
@@ -19,12 +19,6 @@ export default Ember.Component.extend({
     }
   },
 
-  buildStateDidChange: Ember.observer('build.state', function () {
-    if (this.get('sendFaviconStateChanges')) {
-      return this.send('faviconStateDidChange', this.get('build.state'));
-    }
-  }),
-
   buildStagesSort: ['number'],
   sortedBuildStages: Ember.computed.sort('build.stages', 'buildStagesSort')
 });

--- a/app/controllers/build.js
+++ b/app/controllers/build.js
@@ -9,7 +9,6 @@ import { service } from 'ember-decorators/service';
 import { alias } from 'ember-decorators/object/computed';
 import { observes } from 'ember-decorators/object';
 
-
 export default Ember.Controller.extend(GithubUrlProperties, Polling, {
   @service auth: null,
   @service('updateTimes') updateTimesService: null,

--- a/app/controllers/build.js
+++ b/app/controllers/build.js
@@ -7,6 +7,8 @@ import config from 'travis/config/environment';
 import { controller } from 'ember-decorators/controller';
 import { service } from 'ember-decorators/service';
 import { alias } from 'ember-decorators/object/computed';
+import { observes } from 'ember-decorators/object';
+
 
 export default Ember.Controller.extend(GithubUrlProperties, Polling, {
   @service auth: null,
@@ -30,4 +32,11 @@ export default Ember.Controller.extend(GithubUrlProperties, Polling, {
       return Visibility.every(config.intervals.updateTimes, this.updateTimes.bind(this));
     }
   },
+
+  @observes('build.state')
+  buildStateDidChange() {
+    if (this.get('sendFaviconStateChanges')) {
+      this.send('faviconStateDidChange', this.get('build.state'));
+    }
+  }
 });

--- a/app/controllers/job.js
+++ b/app/controllers/job.js
@@ -19,7 +19,7 @@ export default Ember.Controller.extend({
   },
 
   @observes('job.state')
-  jobStateDidChange(state) {
-    return this.send('faviconStateDidChange', state);
+  jobStateDidChange() {
+    return this.send('faviconStateDidChange', this.get('job.state'));
   },
 });

--- a/tests/acceptance/builds/cancel-test.js
+++ b/tests/acceptance/builds/cancel-test.js
@@ -3,6 +3,9 @@ import moduleForAcceptance from 'travis/tests/helpers/module-for-acceptance';
 import buildPage from 'travis/tests/pages/build';
 import topPage from 'travis/tests/pages/top';
 
+import Ember from 'ember';
+import getFaviconUri from 'travis/utils/favicon-data-uris';
+
 moduleForAcceptance('Acceptance | builds/cancel', {
   beforeEach() {
     const currentUser = server.create('user');
@@ -28,5 +31,6 @@ test('cancelling build', function (assert) {
 
   andThen(function () {
     assert.equal(topPage.flashMessage.text, 'Build has been successfully cancelled.', 'cancelled build notification should be displayed');
+    assert.equal(Ember.$('head link[rel=icon]').attr('href'), getFaviconUri('yellow'), 'expected the favicon data URI to match the one for running');
   });
 });

--- a/tests/acceptance/job/basic-layout-test.js
+++ b/tests/acceptance/job/basic-layout-test.js
@@ -2,12 +2,15 @@ import { test } from 'qunit';
 import moduleForAcceptance from 'travis/tests/helpers/module-for-acceptance';
 import jobPage from 'travis/tests/pages/job';
 
+import Ember from 'ember';
+import getFaviconUri from 'travis/utils/favicon-data-uris';
+
 import config from 'travis/config/environment';
 
 moduleForAcceptance('Acceptance | job/basic layout');
 
 test('visiting job-view', function (assert) {
-  assert.expect(7);
+  assert.expect(8);
 
   let repo = server.create('repository', { slug: 'travis-ci/travis-web' }),
     branch = server.create('branch', { name: 'acceptance-tests' });
@@ -27,6 +30,8 @@ test('visiting job-view', function (assert) {
 
   andThen(() => {
     assert.equal(document.title, 'Job #1234.1 - travis-ci/travis-web - Travis CI');
+
+    assert.equal(Ember.$('head link[rel=icon]').attr('href'), getFaviconUri('green'), 'expected the favicon data URI to match the one for passing');
 
     assert.equal(jobPage.branch, 'acceptance-tests');
     assert.equal(jobPage.message, 'acceptance-tests This is a message');


### PR DESCRIPTION
This broke with some refactoring. As of this commit, the job state is indicated for a favicon and backed up with a test, but I haven’t gotten it working for builds yet.