### PR TITLE
Sort starred repos in the same order other repos are sorted

### DIFF
--- a/app/models/repo.js
+++ b/app/models/repo.js
@@ -23,6 +23,7 @@ const Repo = Model.extend({
   @oneWay('owner.@type') ownerType: null,
 
   @oneWay('currentBuild.finishedAt') currentBuildFinishedAt: null,
+  @oneWay('currentBuild.state') currentBuildState: null,
   @oneWay('currentBuild.id') currentBuildId: null,
 
 

--- a/app/routes/dashboard/repositories.js
+++ b/app/routes/dashboard/repositories.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import TravisRoute from 'travis/routes/basic';
+import dashboardRepositoriesSort from 'travis/utils/dashboard-repositories-sort';
 
 export default TravisRoute.extend({
   queryParams: {
@@ -30,7 +31,7 @@ export default TravisRoute.extend({
         offset: params.offset
       }, {
         filter: (repo) => repo.get('active') && repo.get('isCurrentUserACollaborator'),
-        sort: 'currentBuildId:desc',
+        sort: dashboardRepositoriesSort,
         dependencies: ['active', 'isCurrentUserACollaborator'],
         forceReload: true
       }),

--- a/app/templates/dashboard/repositories.hbs
+++ b/app/templates/dashboard/repositories.hbs
@@ -8,7 +8,7 @@
     <section class="dashboard-section dashboard-starred">
       <h2 class="small-title">Starred repositories</h2>
       <ul class="repo-list">
-      {{#each model.starredRepos as |repo|}}
+      {{#each starredRepos as |repo|}}
         {{dashboard-row repo=repo star=star unstar=unstar}}
       {{else}}
         <div class="starred-empty">

--- a/app/utils/dashboard-repositories-sort.js
+++ b/app/utils/dashboard-repositories-sort.js
@@ -1,0 +1,31 @@
+import Ember from 'ember';
+
+export default (a, b) => {
+  if (Ember.isBlank(a.get('currentBuild.state'))) {
+    return 1;
+  }
+  if (Ember.isBlank(b.get('currentBuild.state'))) {
+    return -1;
+  }
+  if (Ember.isBlank(a.get('currentBuild.finishedAt'))) {
+    return -1;
+  }
+  if (Ember.isBlank(b.get('currentBuild.finishedAt'))) {
+    return 1;
+  }
+  if (a.get('currentBuild.finishedAt') < b.get('currentBuild.finishedAt')) {
+    return 1;
+  }
+  if (a.get('currentBuild.finishedAt') > b.get('currentBuild.finishedAt')) {
+    return -1;
+  }
+  if (a.get('currentBuild.finishedAt') === b.get('currentBuild.finishedAt')) {
+    return 0;
+  }
+  if (Ember.isBlank(a.get('defaultBranch.lastBuild.state'))) {
+    return 1;
+  }
+  if (Ember.isBlank(b.get('defaultBranch.lastBuild.state'))) {
+    return -1;
+  }
+};


### PR DESCRIPTION
Before this PR starred repos were not explicitly sorted, which could
be confusing, because the list of all repositories is sorted by current
build - latest builds are shown first.