### PR TITLE
Fix filter function on store.paginated

### DIFF
--- a/app/utils/fetch-live-paginated-collection.js
+++ b/app/utils/fetch-live-paginated-collection.js
@@ -7,7 +7,7 @@ import LivePaginatedCollection from 'travis/utils/live-paginated-collection';
 // collection.
 let fetchLivePaginatedCollection = function (store, modelName, queryParams, options) {
   let dependencies = options.dependencies || [],
-    filter = filter || (() => true),
+    filter = options.filter || (() => true),
     filtered = store.filter(modelName, queryParams, filter, dependencies, options.forceReload);
 
   return filtered.then((filteredArray) => {


### PR DESCRIPTION
store.paginated tests didn't properly test a filter function and it was
improperly handled in fetchLivePaginatedCollection - the default (empty
filter function was always passed).