### PR TITLE
Make travis-web work with public repositories on pro version

### DIFF
--- a/app/components/repository-layout.js
+++ b/app/components/repository-layout.js
@@ -12,12 +12,14 @@ export default Ember.Component.extend({
 
   @computed('repo.slug', 'repo.defaultBranch.name')
   statusImageUrl(slug, branchName) {
-    return this.get('statusImages').imageUrl(slug, branchName);
+    const repo = this.get('repo');
+    return this.get('statusImages').imageUrl(repo, branchName);
   },
 
   @computed('repo.slug')
   urlGithub(slug) {
-    return this.get('externalLinks').githubRepo(slug);
+    const repo = this.get('repo');
+    return this.get('externalLinks').githubRepo(repo);
   },
 
   actions: {

--- a/app/components/status-images.js
+++ b/app/components/status-images.js
@@ -17,31 +17,35 @@ export default Ember.Component.extend({
     this.set('branch', this.get('repo.defaultBranch.name'));
   },
 
-  @computed('format', 'repo.slug', 'branch', 'repo.defaultBranch')
-  statusString(format, slug, branch, defaultBranch) {
-    const imageFormat = format || this.get('formats.firstObject');
-    const gitBranch = branch || defaultBranch.name;
-    return this.formatStatusImage(imageFormat, slug, gitBranch);
+  @computed('format', 'repo.slug', 'branch', 'repo.defaultBranch.name')
+  statusString(format, slug, branch, defaultBranchName) {
+    const repo = this.get('repo');
+    if (repo) {
+      const imageFormat = format || this.get('formats.firstObject');
+      const gitBranch = branch || defaultBranchName;
+
+      return this.formatStatusImage(imageFormat, repo, gitBranch);
+    }
   },
 
-  formatStatusImage(format, slug, branch) {
+  formatStatusImage(format, repo, branch) {
     switch (format) {
       case 'Image URL':
-        return this.get('statusImages').imageUrl(slug, branch);
+        return this.get('statusImages').imageUrl(repo, branch);
       case 'Markdown':
-        return this.get('statusImages').markdownImageString(slug, branch);
+        return this.get('statusImages').markdownImageString(repo, branch);
       case 'Textile':
-        return this.get('statusImages').textileImageString(slug, branch);
+        return this.get('statusImages').textileImageString(repo, branch);
       case 'Rdoc':
-        return this.get('statusImages').rdocImageString(slug, branch);
+        return this.get('statusImages').rdocImageString(repo, branch);
       case 'AsciiDoc':
-        return this.get('statusImages').asciidocImageString(slug, branch);
+        return this.get('statusImages').asciidocImageString(repo, branch);
       case 'RST':
-        return this.get('statusImages').rstImageString(slug, branch);
+        return this.get('statusImages').rstImageString(repo, branch);
       case 'Pod':
-        return this.get('statusImages').podImageString(slug, branch);
+        return this.get('statusImages').podImageString(repo, branch);
       case 'CCTray':
-        return this.get('statusImages').ccXml(slug, branch);
+        return this.get('statusImages').ccXml(repo, branch);
     }
   },
 

--- a/app/mixins/scroll-reset.js
+++ b/app/mixins/scroll-reset.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Mixin.create({
   beforeModel: function () {
-    this._super(...arguments);
     window.scrollTo(0, 0);
+    return this._super(...arguments);
   }
 });

--- a/app/routes/basic.js
+++ b/app/routes/basic.js
@@ -41,8 +41,5 @@ export default Ember.Route.extend({
        params.owner.owner === 'profile') {
       this.transitionTo('account', this.get('auth.currentUser.login'));
     }
-  },
-
-  // on pro, we need to auth on every route
-  @alias('features.proVersion') needsAuth: null,
+  }
 });

--- a/app/routes/owner.js
+++ b/app/routes/owner.js
@@ -1,8 +1,11 @@
 import Ember from 'ember';
 import TravisRoute from 'travis/routes/basic';
 import config from 'travis/config/environment';
+import { alias } from 'ember-decorators/object/computed';
+import { service } from 'ember-decorators/service';
 
 export default TravisRoute.extend({
+  @service auth: null,
   deactivate() {
     return this.controllerFor('loading').set('layoutName', null);
   },
@@ -31,11 +34,25 @@ export default TravisRoute.extend({
   actions: {
     error(error, /* transition, originRoute*/) {
       let is404 = error.status === 404;
-      let errorText = 'There was an error while loading data, please try again.';
-      let message = is404 ? this.transitionTo('error404') : errorText;
-      this.controllerFor('error').set('layoutName', 'simple');
-      this.controllerFor('error').set('message', message);
-      return true;
+
+      if (this.get('features.proVersion') && is404 && !this.get('auth.signedIn')) {
+        // TODO: once the merge happens we only need to do it for enterprise or
+        // possibly only for enterprise with disabled public repositories (or
+        // we could somehow unify it as well)
+        //
+        // The problem here is that the current behaviour on .com is that when
+        // you go to any owner page and you're not logged in, you will be
+        // redirected to auth page. After the merge all the owner pages will be
+        // accessible (just like on GitHub).
+        this.set('auth.redirected', true);
+        return this.transitionTo('auth');
+      } else {
+        let errorText = 'There was an error while loading data, please try again.';
+        let message = is404 ? this.transitionTo('error404') : errorText;
+        this.controllerFor('error').set('layoutName', 'simple');
+        this.controllerFor('error').set('message', message);
+        return true;
+      }
     }
   }
 });

--- a/app/services/status-images.js
+++ b/app/services/status-images.js
@@ -6,7 +6,7 @@ export default Ember.Service.extend({
   @service auth: null,
   @service features: null,
 
-  imageUrl(slug, branch) {
+  imageUrl(repo, branch) {
     let prefix = `${location.protocol}//${location.host}`;
 
     // the ruby app (waiter) does an indirect, internal redirect to api on build status images
@@ -16,7 +16,9 @@ export default Ember.Service.extend({
       prefix = config.apiEndpoint;
     }
 
-    if (this.get('features.proVersion')) {
+    let slug = repo.get('slug');
+
+    if (repo.get('private')) {
       const token = this.get('auth').assetToken();
       return `${prefix}/${slug}.svg?token=${token}${branch ? `&branch=${branch}` : ''}`;
     } else {
@@ -28,48 +30,48 @@ export default Ember.Service.extend({
     return `https://${location.host}/${slug}`;
   },
 
-  markdownImageString(slug, branch) {
-    const url = this.repositoryUrl(slug);
-    const imageUrl = this.imageUrl(slug, branch);
+  markdownImageString(repo, branch) {
+    const url = this.repositoryUrl(repo);
+    const imageUrl = this.imageUrl(repo, branch);
     return `[![Build Status](${imageUrl})](${url})`;
   },
 
-  textileImageString(slug, branch) {
-    const url = this.repositoryUrl(slug);
-    const imageUrl = this.imageUrl(slug, branch);
+  textileImageString(repo, branch) {
+    const url = this.repositoryUrl(repo);
+    const imageUrl = this.imageUrl(repo, branch);
     return `!${imageUrl}!:${url}`;
   },
 
-  rdocImageString(slug, branch) {
-    const url = this.repositoryUrl(slug);
-    const imageUrl = this.imageUrl(slug, branch);
+  rdocImageString(repo, branch) {
+    const url = this.repositoryUrl(repo);
+    const imageUrl = this.imageUrl(repo, branch);
     return `{<img src="${imageUrl}" alt="Build Status" />}[${url}]`;
   },
 
-  asciidocImageString(slug, branch) {
-    const url = this.repositoryUrl(slug);
-    const imageUrl = this.imageUrl(slug, branch);
+  asciidocImageString(repo, branch) {
+    const url = this.repositoryUrl(repo);
+    const imageUrl = this.imageUrl(repo, branch);
     return `image:${imageUrl}["Build Status", link="${url}"]`;
   },
 
-  rstImageString(slug, branch) {
-    const url = this.repositoryUrl(slug);
-    const imageUrl = this.imageUrl(slug, branch);
+  rstImageString(repo, branch) {
+    const url = this.repositoryUrl(repo);
+    const imageUrl = this.imageUrl(repo, branch);
     return `.. image:: ${imageUrl}\n    :target: ${url}`;
   },
 
-  podImageString(slug, branch) {
-    const url = this.repositoryUrl(slug);
-    const imageUrl = this.imageUrl(slug, branch);
+  podImageString(repo, branch) {
+    const url = this.repositoryUrl(repo);
+    const imageUrl = this.imageUrl(repo, branch);
     return `=for html <a href="${url}"><img src="${imageUrl}"></a>`;
   },
 
-  ccXml(slug, branch) {
+  ccXml(repo, branch) {
     let url = `#${config.apiEndpoint}/repos/${slug}/cc.xml`;
     if (branch) {
       url = `${url}?branch=${branch}`;
     }
-    if (this.get('features.proVersion')) {
+    if (repo.get('private')) {
       const token = this.get('auth').assetToken();
       const delimiter = url.indexOf('?') === -1 ? '?' : '&';
       url = `${url}${delimiter}token=${token}`;


### PR DESCRIPTION
We're preparing for the merge and one of the requirements is to be able
to view public repositories and owners profiles. This commit enables
such a possibility.