### PR TITLE
Add docker configurations for nightly quay releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,77 @@
+FROM ruby:2.3
+
+LABEL maintainer Travis CI GmbH <support+travis-app-docker-images@travis-ci.com>
+
+RUN groupadd --gid 1000 node \
+  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+
+# gpg keys listed at https://github.com/nodejs/node#release-team
+RUN set -ex \
+  && for key in \
+    9554F04D7259F04124DE6B476D5A82AC7E37093B \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+    56730D5401028683275BD23C23EFEFE93C4CFFFE \
+  ; do \
+    gpg --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" || \
+    gpg --keyserver hkp://keyserver.pgp.com:80 --recv-keys "$key" ; \
+  done
+
+ENV NPM_CONFIG_LOGLEVEL info
+ENV NODE_VERSION 6.10.2
+
+RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
+  && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+  && grep " node-v$NODE_VERSION-linux-x64.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 \
+  && rm "node-v$NODE_VERSION-linux-x64.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+ENV YARN_VERSION 0.22.0
+
+RUN set -ex \
+  && for key in \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
+  ; do \
+    gpg --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" || \
+    gpg --keyserver hkp://keyserver.pgp.com:80 --recv-keys "$key" ; \
+  done \
+  && curl -fSL -o yarn.js "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-legacy-$YARN_VERSION.js" \
+  && curl -fSL -o yarn.js.asc "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-legacy-$YARN_VERSION.js.asc" \
+  && gpg --batch --verify yarn.js.asc yarn.js \
+  && rm yarn.js.asc \
+  && mv yarn.js /usr/local/bin/yarn \
+  && chmod +x /usr/local/bin/yarn
+
+# throw errors if Gemfile has been modified since Gemfile.lock
+RUN bundle config --global frozen 1
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY Gemfile      /usr/src/app
+COPY Gemfile.lock /usr/src/app
+COPY waiter       /usr/src/app/waiter
+
+RUN bundle install --without assets development test
+
+COPY package.json /usr/src/app
+COPY bower.json   /usr/src/app
+
+RUN npm install -g bower
+
+RUN npm install --quiet
+RUN bower install --allow-root
+
+COPY . /usr/src/app
+
+RUN ./node_modules/.bin/ember build --environment=production
+
+CMD bundle exec je puma -I lib -p ${PORT:-4000} -t ${PUMA_MIN_THREADS:-8}:${PUMA_MAX_THREADS:-12} -w ${PUMA_WORKERS:-2} --preload waiter/config.ru

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "2"
+services:
+  web:
+    build:
+      context: .
+    ports:
+    - 4000:4000

--- a/scripts/docker-build-and-push
+++ b/scripts/docker-build-and-push
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -ev
+
+docker-compose build web;
+
+docker login -u=$QUAY_ROBOT_HANDLE -p=$QUAY_ROBOT_TOKEN quay.io;
+
+docker images;
+
+local_image=travisweb_web;
+quay_image=quay.io/travisci/travis-web;
+
+docker tag $local_image $quay_image:$TRAVIS_BRANCH;
+docker push $quay_image:$TRAVIS_BRANCH;
+
+docker tag $local_image $quay_image:${TRAVIS_COMMIT:0:7};
+docker push $quay_image:${TRAVIS_COMMIT:0:7};
+
+if [ ${TRAVIS_BRANCH} = "master" ]; then
+  docker tag $local_image $quay_image:latest;
+  docker push $quay_image:$TRAVIS_BRANCH;
+fi
+
+exit 0;

--- a/scripts/docker-build-and-push
+++ b/scripts/docker-build-and-push
@@ -19,5 +19,3 @@ docker push $quay_image:${TRAVIS_COMMIT:0:7};
 
 docker tag $local_image $quay_image:latest;
 docker push $quay_image:$TRAVIS_BRANCH;
-
-exit 0;

--- a/scripts/docker-build-and-push
+++ b/scripts/docker-build-and-push
@@ -17,9 +17,7 @@ docker push $quay_image:$TRAVIS_BRANCH;
 docker tag $local_image $quay_image:${TRAVIS_COMMIT:0:7};
 docker push $quay_image:${TRAVIS_COMMIT:0:7};
 
-if [ ${TRAVIS_BRANCH} = "master" ]; then
-  docker tag $local_image $quay_image:latest;
-  docker push $quay_image:$TRAVIS_BRANCH;
-fi
+docker tag $local_image $quay_image:latest;
+docker push $quay_image:$TRAVIS_BRANCH;
 
 exit 0;


### PR DESCRIPTION
This isn't needed for master/production builds, but referencing a non-master file when on a different branch is tedious. As crons are currently limited to a single branch and we're wanting to avoid having a conditional-littered build configuration, committing them here seems like a good compromise. Also handy in case you'd like to just work with Docker right out of the gate.