### PR TITLE
Prefer passed in branch over $TRAVIS_BRANCH

### DIFF
--- a/scripts/docker-build-and-push
+++ b/scripts/docker-build-and-push
@@ -10,12 +10,13 @@ docker images;
 
 local_image=travisweb_web;
 quay_image=quay.io/travisci/travis-web;
+branch=${1:-${TRAVIS_BRANCH}}
 
-docker tag $local_image $quay_image:$TRAVIS_BRANCH;
-docker push $quay_image:$TRAVIS_BRANCH;
+docker tag $local_image $quay_image:$branch;
+docker push $quay_image:$branch;
 
 docker tag $local_image $quay_image:${TRAVIS_COMMIT:0:7};
 docker push $quay_image:${TRAVIS_COMMIT:0:7};
 
 docker tag $local_image $quay_image:latest;
-docker push $quay_image:$TRAVIS_BRANCH;
+docker push $quay_image:$branch;


### PR DESCRIPTION
This allows us to call the script using `master` instead of worrying about what branch this is actually being executed on