### PR TITLE
Don't prefix pusher channels

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -46,21 +46,10 @@ const App = Ember.Application.extend(Ember.Evented, {
   },
 
   subscribePusher(user) {
-    let channels;
     if (!user.channels) {
       return;
     }
-    channels = user.channels;
-    if (proVersion) {
-      channels = channels.map((channel) => {
-        if (channel.match(/^private-/)) {
-          return channel;
-        } else {
-          return `private-${channel}`;
-        }
-      });
-    }
-    return Travis.pusher.subscribeAll(channels);
+    Travis.pusher.subscribeAll(user.channels);
   },
 
   identifyHSBeacon(user) {

--- a/app/utils/pusher.js
+++ b/app/utils/pusher.js
@@ -68,7 +68,6 @@ TravisPusher.prototype.subscribe = function (channel) {
   if (!channel) {
     return;
   }
-  channel = this.prefix(channel);
   if (!((ref = this.pusher) != null ? ref.channel(channel) : void 0)) {
     return this.pusher.subscribe(channel).bind_all((function (_this) {
       return function (event, data) {
@@ -83,20 +82,10 @@ TravisPusher.prototype.unsubscribe = function (channel) {
   if (!channel) {
     return;
   }
-  channel = this.prefix(channel);
   //eslint-disable-next-line
   console.log("unsubscribing from " + channel);
   if ((ref = this.pusher) != null ? ref.channel(channel) : void 0) {
     return this.pusher.unsubscribe(channel);
-  }
-};
-
-TravisPusher.prototype.prefix = function (channel) {
-  let prefix = ENV.pusher.channelPrefix || '';
-  if (channel.indexOf(prefix) !== 0) {
-    return `${prefix}${channel}`;
-  } else {
-    return channel;
   }
 };
 


### PR DESCRIPTION
We don't need to prefix pusher channels manually in travis-web, because
we either get pusher channels from the API (which are already prefixed
where needed) or we subscribe to public repositories (and then we don't
need to prefix). This commit removes prefixing logic and instead
subscribes to whatever we get from the API.