### PR TITLE
Rename event to ensure log removed

### DIFF
--- a/app/components/remove-log-popup.js
+++ b/app/components/remove-log-popup.js
@@ -8,7 +8,7 @@ export default Ember.Component.extend({
     removeLog() {
       let job = this.get('job');
 
-      this.get('onRemoveCloseModal')();
+      this.get('onCloseModal')();
 
       return job.removeLog().then(() => {
         this.get('flashes').success('Log has been successfully removed.');


### PR DESCRIPTION
This was failing without an error in production, so pushing this out. Will add a test case afterwards to ensure we do not inadvertently break it again