### PR TITLE
Ensure flash messages cleared when signing out

### DIFF
--- a/tests/acceptance/auth/sign-out-test.js
+++ b/tests/acceptance/auth/sign-out-test.js
@@ -1,0 +1,21 @@
+import { test } from 'qunit';
+import moduleForAcceptance from 'travis/tests/helpers/module-for-acceptance';
+import topPage from 'travis/tests/pages/top';
+
+moduleForAcceptance('Acceptance | auth/sign out', {
+  beforeEach() {
+    const currentUser = server.create('user');
+    signInUser(currentUser);
+  }
+});
+
+test('signing out clears flash messages', function (assert) {
+  visit('/');
+  this.application.__container__.lookup('service:flashes').success('TOTAL SUCCESS');
+  topPage.clickSigOutLink();
+
+  andThen(() => {
+    assert.equal(currentURL(), '/');
+    assert.ok(topPage.flashMessage.isHidden, 'Does not display a flash message');
+  });
+});

--- a/tests/pages/top.js
+++ b/tests/pages/top.js
@@ -55,6 +55,10 @@ export default PageObject.create({
 
     isSuccess: hasClass('success'),
     isNotice: hasClass('notice'),
-    isError: hasClass('error')
-  }
+    isError: hasClass('error'),
+
+    isNotShown: isHidden(),
+  },
+
+  clickSigOutLink: clickable('ul.navigation-nested li:last a'),
 });


### PR DESCRIPTION
This clears all flash messages unless it is showing the user their token has expired. See https://github.com/travis-pro/team-teal/issues/2232 for more details.