### PR TITLE
Subscribe to public repos on pro too

### DIFF
--- a/app/models/repo.js
+++ b/app/models/repo.js
@@ -38,9 +38,11 @@ const Repo = Model.extend({
   // added to a response with the repo
   @computed('auth.currentUser.permissions.[]')
   isCurrentUserACollaborator(permissions) {
-    let id = parseInt(this.get('id'));
+    if (permissions) {
+      let id = parseInt(this.get('id'));
 
-    return permissions.includes(id);
+      return permissions.includes(id);
+    }
   },
 
   sshKey: function () {

--- a/app/services/store.js
+++ b/app/services/store.js
@@ -23,7 +23,9 @@ export default DS.Store.extend({
   //
   // modelName      - a type of the model passed as a string, for example 'repo'
   // queryParams    - params that will be passed to the store.query function when
-  //                  fetching records on the initial call
+  //                  fetching records on the initial call. Passing null or
+  //                  undefined here will stop any requests from happening,
+  //                  filtering will be based only on existing records
   // filterFunction - a function that will be called to determine wheather a
   //                  record should be included in the filtered collection. A
   //                  passed function will be called with a record as an

--- a/app/utils/filtered-array-manager.js
+++ b/app/utils/filtered-array-manager.js
@@ -160,7 +160,11 @@ let FilteredArrayManagerForType = Ember.Object.extend({
   // Runs a store.query() function for a type that the array is handling with
   // queryParams passed as an argument.
   fetchQuery(queryParams) {
-    return this.get('store').query(this.get('modelName'), queryParams);
+    if (queryParams) {
+      return this.get('store').query(this.get('modelName'), queryParams);
+    } else {
+      return Ember.RSVP.resolve([]);
+    }
   },
 
   addObserver(record, property) {
@@ -180,8 +184,9 @@ let FilteredArrayManagerForType = Ember.Object.extend({
   },
 
   calculateId(queryParams, filterFunction, dependencies) {
+    const params = queryParams || {};
     let id = stringHash([
-      Object.entries(queryParams).map(([key, value]) => `${key}:${value}`).sort(),
+      Object.entries(params).map(([key, value]) => `${key}:${value}`).sort(),
       (dependencies || []).sort(),
       // not sure if this is a good idea, but I want to get the unique id for
       // each set of arguments to filter

--- a/app/utils/pusher.js
+++ b/app/utils/pusher.js
@@ -3,12 +3,11 @@ import ENV from 'travis/config/environment';
 import Ember from 'ember';
 
 let TravisPusher = function (config, ajaxService) {
+  this.active_channels = [];
   this.init(config, ajaxService);
   TravisPusher.ajaxService = ajaxService;
   return this;
 };
-
-TravisPusher.prototype.active_channels = [];
 
 TravisPusher.prototype.init = function (config, ajaxService) {
   if (!config.key) {
@@ -63,29 +62,19 @@ TravisPusher.prototype.unsubscribeAll = function (channels) {
   return results;
 };
 
-TravisPusher.prototype.subscribe = function (channel) {
-  let ref;
-  if (!channel) {
-    return;
-  }
-  if (!((ref = this.pusher) != null ? ref.channel(channel) : void 0)) {
-    return this.pusher.subscribe(channel).bind_all((function (_this) {
-      return function (event, data) {
-        return _this.receive(event, data);
-      };
-    })(this));
+TravisPusher.prototype.subscribe = function (channelName) {
+  if (channelName && this.pusher && !this.pusher.channel(channelName)) {
+    this.active_channels.push(channelName);
+    return this.pusher.subscribe(channelName).bind_all((event, data) => {
+      this.receive(event, data);
+    });
   }
 };
 
-TravisPusher.prototype.unsubscribe = function (channel) {
-  let ref;
-  if (!channel) {
-    return;
-  }
-  //eslint-disable-next-line
-  console.log("unsubscribing from " + channel);
-  if ((ref = this.pusher) != null ? ref.channel(channel) : void 0) {
-    return this.pusher.unsubscribe(channel);
+TravisPusher.prototype.unsubscribe = function (channelName) {
+  if (channelName && this.pusher) {
+    this.active_channels.removeObject(channelName);
+    return this.pusher.unsubscribe(channelName);
   }
 };
 

--- a/mirage/factories/repository.js
+++ b/mirage/factories/repository.js
@@ -30,6 +30,9 @@ export default Mirage.Factory.extend({
   afterCreate(repository, server) {
     if (!repository.attrs.skipPermissions) {
       // Creates permissions for first user in the database
+      // TODO: I'd like to remove it at some point as this is unexpected
+      // we should set up permissions as needed. Possibly whenever we fully
+      // switch to permissions from V3
       const user = server.schema.users.all().models[0];
       server.create('permissions', { user, repository });
     }

--- a/tests/acceptance/repo/show-public-repo-test.js
+++ b/tests/acceptance/repo/show-public-repo-test.js
@@ -1,0 +1,61 @@
+import { test } from 'qunit';
+import moduleForAcceptance from 'travis/tests/helpers/module-for-acceptance';
+import page from 'travis/tests/pages/repo-not-active';
+
+moduleForAcceptance('Acceptance | subscribing pusher to public repo');
+
+test('viewing public repo results in a repo pusher channel', function (assert) {
+  const repo = server.create('repository', {
+    slug: 'musterfrau/a-repo',
+    private: false
+  });
+
+  page.visit({ organization: 'musterfrau', repo: 'a-repo' });
+
+  andThen(() => {
+    let subscribed = this.application.resolveRegistration('pusher:main').active_channels.includes(`repo-${repo.id}`);
+    assert.ok(subscribed, 'user is subscribed to a repo channel');
+  });
+});
+
+test('viewing public repo as a signed in collaborator does not trigger subscription', function (assert) {
+  const user = server.create('user', {
+    name: 'Travis CI',
+    login: 'travisci',
+  });
+  const repository = server.create('repository', {
+    slug: 'musterfrau/a-repo',
+    private: false
+  });
+  server.create('permission', { user, repository, push: true });
+
+  signInUser(user);
+
+  page.visit({ organization: 'musterfrau', repo: 'a-repo' });
+
+  andThen(() => {
+    let subscribed = this.application.resolveRegistration('pusher:main').active_channels.includes(`repo-${repository.id}`);
+    assert.ok(!subscribed, 'user is not subscribed to a repo channel');
+  });
+});
+
+test('viewing public repo as a signed in user triggers subscription', function (assert) {
+  const user = server.create('user', {
+    name: 'Travis CI',
+    login: 'travisci',
+  });
+  const repository = server.create('repository', {
+    slug: 'musterfrau/a-repo',
+    private: false
+  });
+  server.schema.permissions.all().destroy();
+
+  signInUser(user);
+
+  page.visit({ organization: 'musterfrau', repo: 'a-repo' });
+
+  andThen(() => {
+    let subscribed = this.application.resolveRegistration('pusher:main').active_channels.includes(`repo-${repository.id}`);
+    assert.ok(subscribed, 'user is subscribed to a repo channel');
+  });
+});

--- a/tests/unit/store-filter-test.js
+++ b/tests/unit/store-filter-test.js
@@ -5,12 +5,43 @@ moduleForModel('repo', 'Unit | store.filter', {
   needs: ['model:repo', 'service:ajax', 'service:auth', 'service:store']
 });
 
+test('it does not run query if query params are not passed', function (assert) {
+  assert.expect(1);
+  let store = this.store();
+
+  store.query = function () {
+    assert.ok(false, 'store.query was called, but it should not');
+
+    return Ember.RSVP.resolve();
+  };
+
+  Ember.run(() => {
+    store.push({
+      data: {
+        id: 1,
+        type: 'repo',
+        attributes: { starred: true }
+      }
+    });
+  });
+
+  let result = store.filter('repo', null, () => true, ['starred']);
+
+  let done = assert.async();
+
+  result.then((collection) => {
+    done();
+
+    assert.deepEqual(collection.toArray().map((r) => r.get('id')), ['1']);
+  });
+});
+
 test('it adds records already in the store to filtered collection', function (assert) {
   assert.expect(3);
   let store = this.store();
 
   store.query = function () {
-    assert.ok('store.query was called');
+    assert.ok(true, 'store.query was called');
 
     return Ember.RSVP.resolve();
   };
@@ -55,7 +86,7 @@ test('it modifies filtered collection when dependencies change', function (asser
   let store = this.store();
 
   store.query = function () {
-    assert.ok('store.query was called');
+    assert.ok(true, 'store.query was called');
 
     return Ember.RSVP.resolve();
   };
@@ -140,7 +171,7 @@ test('it adds new records in the store to the filtered collection', function (as
   let store = this.store();
 
   store.query = function () {
-    assert.ok('store.query was called');
+    assert.ok(true, 'store.query was called');
 
     return Ember.RSVP.resolve();
   };


### PR DESCRIPTION
When a user opens a repo that they aren't a collaborator of, we will
subscribe them to a public repo channel, so they still get updates for
the repo. This was done only on .org, but now that we plan to merge the
platforms it should work on .com version too.

The code needed to be changed a little bit, because now we need to also
care about private repositories and also we don't want to subscribe to
repositories that are already covered on user channel (ie. if the
current user is a collaborator, they would get an update through a user
channel anyway).