### PR TITLE
set evetType alias on job model

### DIFF
--- a/app/models/job.js
+++ b/app/models/job.js
@@ -37,6 +37,7 @@ export default Model.extend(DurationCalculations, DurationAttributes, {
   @alias('build.branchName') branchName: null,
   @alias('build.isTag') isTag: null,
   @alias('build.tag') tag: null,
+  @alias('build.eventType') eventType: null,
 
   // TODO: DO NOT SET OTHER PROPERTIES WITHIN A COMPUTED PROPERTY!
   @computed()


### PR DESCRIPTION
Fixes occurrences of missing eventType icons in the job header like here https://travis-ci.org/ember-cli/ember-cli/jobs/269636611