### PR TITLE
Add 429-handling for build trigger failure

### DIFF
--- a/app/components/trigger-custom-build.js
+++ b/app/components/trigger-custom-build.js
@@ -114,7 +114,16 @@ export default Ember.Component.extend({
   },
 
   displayError(e) {
-    this.get('flashes').error('Oops, something went wrong, please try again.');
+    let message;
+
+    if (e.status === 429) {
+      message =
+        'You’ve exceeded the limit for triggering builds, please wait a while before trying again.';
+    } else {
+      message = 'Oops, something went wrong, please try again.';
+    }
+
+    this.get('flashes').error(message);
     return this.get('onClose')();
   },
 

--- a/tests/acceptance/repo/trigger-build-test.js
+++ b/tests/acceptance/repo/trigger-build-test.js
@@ -101,3 +101,18 @@ test('an error triggering a build is displayed', function (assert) {
     assert.equal(topPage.flashMessage.text, 'Oops, something went wrong, please try again.');
   });
 });
+
+test('a 429 shows a specific error message', function (assert) {
+  server.post('/repo/:repo_id/requests', function (schema, request) {
+    return new Mirage.Response(429, {}, {});
+  });
+
+  triggerBuildPage.visit({ slug: this.repo.slug });
+  triggerBuildPage.openPopup();
+  triggerBuildPage.selectBranch('master');
+  triggerBuildPage.clickSubmit();
+
+  andThen(() => {
+    assert.equal(topPage.flashMessage.text, 'You’ve exceeded the limit for triggering builds, please wait a while before trying again.');
+  });
+});

--- a/tests/acceptance/repo/trigger-build-test.js
+++ b/tests/acceptance/repo/trigger-build-test.js
@@ -1,6 +1,8 @@
 import { test } from 'qunit';
 import moduleForAcceptance from 'travis/tests/helpers/module-for-acceptance';
 import triggerBuildPage from 'travis/tests/pages/trigger-build';
+import topPage from 'travis/tests/pages/top';
+import Mirage from 'ember-cli-mirage';
 
 moduleForAcceptance('Acceptance | repo/trigger build');
 
@@ -82,5 +84,20 @@ test('triggering a custom build via the dropdown', function (assert) {
   andThen(() => {
     assert.ok(triggerBuildPage.popupIsHidden, 'modal is hidden again');
     assert.equal(currentURL(), '/adal/difference-engine/builds/9999', 'we transitioned after the build was triggered');
+  });
+});
+
+test('an error triggering a build is displayed', function (assert) {
+  server.post('/repo/:repo_id/requests', function (schema, request) {
+    return new Mirage.Response(500, {}, {});
+  });
+
+  triggerBuildPage.visit({ slug: this.repo.slug });
+  triggerBuildPage.openPopup();
+  triggerBuildPage.selectBranch('master');
+  triggerBuildPage.clickSubmit();
+
+  andThen(() => {
+    assert.equal(topPage.flashMessage.text, 'Oops, something went wrong, please try again.');
   });
 });


### PR DESCRIPTION
A `429` is a known error type for the requests API, might as well recognise it.