### PR TITLE
customized and separate oss project numbers on landing page

### DIFF
--- a/app/styles/app/pages/landing.sass
+++ b/app/styles/app/pages/landing.sass
@@ -28,7 +28,7 @@
   .hero, .oss-testing, .customers, .recent-builds, .free-for-oss, .private-repos, .landing-features-list, .build-flows, .user-testimonials
     padding: 70px 0 70px 0
 
-  .hero, .s-testing, .customers, .recent-builds-text, .free-for-oss, .private-repos, .landing-features-list, .build-flows, .user-testimonials, .oss-testing,
+  .hero, .oss-testing, .customers, .recent-builds-text, .free-for-oss, .private-repos, .landing-features-list, .build-flows, .user-testimonials
 
     h1, h2
       margin-top: 0

--- a/app/styles/app/pages/landing.sass
+++ b/app/styles/app/pages/landing.sass
@@ -28,7 +28,7 @@
   .hero, .oss-testing, .customers, .recent-builds, .free-for-oss, .private-repos, .landing-features-list, .build-flows, .user-testimonials
     padding: 70px 0 70px 0
 
-  .hero, .oss-testing, .customers, .recent-builds-text, .free-for-oss, .private-repos, .landing-features-list, .build-flows, .user-testimonials
+  .hero, .s-testing, .customers, .recent-builds-text, .free-for-oss, .private-repos, .landing-features-list, .build-flows, .user-testimonials, .oss-testing,
 
     h1, h2
       margin-top: 0
@@ -103,6 +103,23 @@
     width: 80%
     @media #{$medium-up}
       width: 60%
+
+  .oss-flip-numbers
+    width: 90%
+    display: inline-block
+    margin: 0 auto
+    @media #{$medium-up}
+      width: 80%
+      white-space: nowrap
+
+  .flip-num
+    display: inline-block
+    padding-right: 10px
+
+  .flip-num img
+    max-width: 55px
+    @media #{$medium-up}
+      max-width: 93px
 
   .customers
     text-align: center

--- a/app/styles/app/pages/landing.sass
+++ b/app/styles/app/pages/landing.sass
@@ -117,6 +117,7 @@
     padding-right: 10px
 
   .flip-num img
+    height: 140px
     max-width: 55px
     @media #{$medium-up}
       max-width: 93px

--- a/app/templates/components/landing-default-page.hbs
+++ b/app/templates/components/landing-default-page.hbs
@@ -38,7 +38,26 @@
       <div class="large-12 columns">
         <h2>The home of<br class="mobile-break"> open source testing</h2>
         <p>Over 900k open source projects<br class="mobile-break"> and 600k users are testing on Travis CI.</p>
-        {{svg-jar 'customer-numbers' class="os-numbers"}}
+        <div class="oss-flip-numbers">
+          <div class="flip-num oss-num-9">
+            <img src="../images/landing-page/oss-num-9.svg">
+          </div>
+          <div class="flip-num oss-num-3">
+            <img src="../images/landing-page/oss-num-3.svg">
+          </div>
+          <div class="flip-num oss-num-1">
+            <img src="../images/landing-page/oss-num-1.svg">
+          </div>
+          <div class="flip-num oss-num-3">
+            <img src="../images/landing-page/oss-num-3.svg">
+          </div>
+          <div class="flip-num oss-num-9">
+            <img src="../images/landing-page/oss-num-9.svg">
+          </div>
+          <div class="flip-num oss-num-9">
+            <img src="../images/landing-page/oss-num-9.svg">
+          </div>
+        </div>
       </div>
     </section>
   </div>

--- a/app/templates/components/landing-default-page.hbs
+++ b/app/templates/components/landing-default-page.hbs
@@ -46,16 +46,16 @@
             <img src="../images/landing-page/oss-num-3.svg">
           </div>
           <div class="flip-num oss-num-1">
-            <img src="../images/landing-page/oss-num-1.svg">
+            <img src="../images/landing-page/oss-num-2.svg">
           </div>
           <div class="flip-num oss-num-3">
-            <img src="../images/landing-page/oss-num-3.svg">
-          </div>
-          <div class="flip-num oss-num-9">
             <img src="../images/landing-page/oss-num-9.svg">
           </div>
           <div class="flip-num oss-num-9">
-            <img src="../images/landing-page/oss-num-9.svg">
+            <img src="../images/landing-page/oss-num-7.svg">
+          </div>
+          <div class="flip-num oss-num-9">
+            <img src="../images/landing-page/oss-num-7.svg">
           </div>
         </div>
       </div>

--- a/public/images/landing-page/oss-num-0.svg
+++ b/public/images/landing-page/oss-num-0.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 93 148.8" style="enable-background:new 0 0 93 148.8;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:url(#SVGID_1_);}
+	.st1{fill:url(#SVGID_2_);}
+	.st2{fill:url(#SVGID_3_);}
+	.st3{fill:url(#SVGID_4_);}
+</style>
+<title>oss-num</title>
+<g id="oss-num-0">
+	<g id="oss-0">
+		
+			<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="46.5" y1="151.4294" x2="46.5" y2="80.8075" gradientTransform="matrix(1 0 0 -1 0 151.4294)">
+			<stop  offset="0" style="stop-color:#61BB78"/>
+			<stop  offset="0.541" style="stop-color:#5FBA76"/>
+			<stop  offset="0.735" style="stop-color:#58B771"/>
+			<stop  offset="0.874" style="stop-color:#4DB267"/>
+			<stop  offset="0.985" style="stop-color:#3CAB58"/>
+			<stop  offset="1" style="stop-color:#39AA56"/>
+		</linearGradient>
+		<path class="st0" d="M93,8c0-4.4-3.6-8-8-8H8C3.6,0,0,3.6,0,8v62.6h93V8z"/>
+		
+			<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="46.5" y1="2.627" x2="46.5" y2="75.2451" gradientTransform="matrix(1 0 0 -1 0 151.4294)">
+			<stop  offset="0" style="stop-color:#88CC9A"/>
+			<stop  offset="0.465" style="stop-color:#86CA98"/>
+			<stop  offset="0.717" style="stop-color:#7EC490"/>
+			<stop  offset="0.918" style="stop-color:#70B982"/>
+			<stop  offset="1" style="stop-color:#68B37A"/>
+		</linearGradient>
+		<path class="st1" d="M0,140.8c0,4.4,3.6,8,8,8H85c4.4,0,8-3.6,8-8V76.2H0V140.8z"/>
+		
+			<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="44.9079" y1="123.9823" x2="44.9079" y2="80.8075" gradientTransform="matrix(1 0 0 -1 0 151.4294)">
+			<stop  offset="0" style="stop-color:#F0F0F0"/>
+			<stop  offset="0.533" style="stop-color:#EEEEEE"/>
+			<stop  offset="0.823" style="stop-color:#E6E6E6"/>
+			<stop  offset="1" style="stop-color:#DCDCDC"/>
+		</linearGradient>
+		<path class="st2" d="M70.4,42.8c-2.2-4.4-5.5-8.2-9.5-11c-4.1-2.9-9.4-4.3-16-4.3c-6.5,0-11.8,1.4-15.9,4.3
+			c-4.1,2.8-7.4,6.6-9.6,11c-2.3,4.7-3.9,9.7-4.6,14.9c-0.6,4.3-1,8.6-1.2,12.9h8.1c0.1-3,0.3-6.2,0.7-9.6c0.5-4.4,1.5-8.7,3.2-12.9
+			c1.5-3.8,3.9-7.2,7-9.9c3.1-2.7,7.2-4,12.3-4c5.1,0,9.3,1.3,12.3,4c3.1,2.7,5.5,6.1,7,9.9c1.6,4.1,2.7,8.5,3.2,12.9
+			c0.4,3.4,0.6,6.6,0.7,9.6h8.1c-0.1-4.3-0.5-8.7-1.2-12.9C74.3,52.5,72.8,47.4,70.4,42.8z"/>
+		
+			<linearGradient id="SVGID_4_" gradientUnits="userSpaceOnUse" x1="44.9132" y1="31.3695" x2="44.9132" y2="75.2504" gradientTransform="matrix(1 0 0 -1 0 151.4294)">
+			<stop  offset="0" style="stop-color:#FFFFFF"/>
+			<stop  offset="0.57" style="stop-color:#FDFDFD"/>
+			<stop  offset="0.879" style="stop-color:#F5F5F5"/>
+			<stop  offset="1" style="stop-color:#EFEFEF"/>
+		</linearGradient>
+		<path class="st3" d="M67.4,86.6c-0.5,4.4-1.5,8.7-3.2,12.9c-1.5,3.8-3.9,7.3-7,10c-3.1,2.7-7.2,4-12.3,4s-9.3-1.3-12.3-4
+			c-3.1-2.7-5.5-6.1-7-10c-1.6-4.1-2.7-8.5-3.2-12.9c-0.4-3.7-0.7-7.1-0.7-10.4h-8.1c0.1,4.6,0.5,9.2,1.2,13.8
+			c0.7,5.2,2.3,10.2,4.6,14.9c2.2,4.4,5.5,8.2,9.6,10.9c4.1,2.8,9.4,4.2,15.9,4.2c6.6,0,11.9-1.4,16-4.2c4-2.8,7.3-6.5,9.5-10.9
+			c2.3-4.7,3.9-9.7,4.6-14.9c0.7-4.6,1.1-9.2,1.2-13.8h-8.1C68.1,79.4,67.8,82.9,67.4,86.6z"/>
+	</g>
+</g>
+</svg>

--- a/public/images/landing-page/oss-num-1.svg
+++ b/public/images/landing-page/oss-num-1.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 93 148.8" style="enable-background:new 0 0 93 148.8;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:url(#SVGID_1_);}
+	.st1{fill:url(#SVGID_2_);}
+	.st2{fill:url(#SVGID_3_);}
+	.st3{fill:url(#SVGID_4_);}
+</style>
+<title>oss-num</title>
+<g id="oss-num-1">
+	<g id="oss-1">
+		
+			<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="46.5" y1="151.4252" x2="46.5" y2="80.8053" gradientTransform="matrix(1 0 0 -1 0 151.4252)">
+			<stop  offset="0" style="stop-color:#61BB78"/>
+			<stop  offset="0.541" style="stop-color:#5FBA76"/>
+			<stop  offset="0.735" style="stop-color:#58B771"/>
+			<stop  offset="0.874" style="stop-color:#4DB267"/>
+			<stop  offset="0.985" style="stop-color:#3CAB58"/>
+			<stop  offset="1" style="stop-color:#39AA56"/>
+		</linearGradient>
+		<path class="st0" d="M93,8c0-4.4-3.6-8-8-8H8C3.6,0,0,3.6,0,8v62.6h93V8z"/>
+		
+			<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="46.4993" y1="2.627" x2="46.4993" y2="75.2431" gradientTransform="matrix(1 0 0 -1 0 151.4252)">
+			<stop  offset="0" style="stop-color:#88CC9A"/>
+			<stop  offset="0.465" style="stop-color:#86CA98"/>
+			<stop  offset="0.717" style="stop-color:#7EC490"/>
+			<stop  offset="0.918" style="stop-color:#70B982"/>
+			<stop  offset="1" style="stop-color:#68B37A"/>
+		</linearGradient>
+		<path class="st1" d="M0,140.8c0,4.4,3.6,8,8,8H85c4.4,0,8-3.6,8-8V76.2H0V140.8z"/>
+		
+			<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="39.6246" y1="123.2072" x2="39.6246" y2="80.8053" gradientTransform="matrix(1 0 0 -1 0 151.4252)">
+			<stop  offset="0" style="stop-color:#F0F0F0"/>
+			<stop  offset="0.533" style="stop-color:#EEEEEE"/>
+			<stop  offset="0.823" style="stop-color:#E6E6E6"/>
+			<stop  offset="1" style="stop-color:#DCDCDC"/>
+		</linearGradient>
+		<path class="st2" d="M55.6,28.2H49c-0.4,3.4-1.4,6.6-3,9.6c-1.3,2.1-3.1,3.9-5.3,5.1c-2.3,1.2-4.9,1.9-7.5,2.1
+			c-2.9,0.3-6.1,0.5-9.6,0.6v5.8h23.8v19.3h8.1L55.6,28.2z"/>
+		
+			<linearGradient id="SVGID_4_" gradientUnits="userSpaceOnUse" x1="51.5195" y1="33.172" x2="51.5195" y2="75.2418" gradientTransform="matrix(1 0 0 -1 0 151.4252)">
+			<stop  offset="0" style="stop-color:#FFFFFF"/>
+			<stop  offset="0.57" style="stop-color:#FDFDFD"/>
+			<stop  offset="0.879" style="stop-color:#F5F5F5"/>
+			<stop  offset="1" style="stop-color:#EFEFEF"/>
+		</linearGradient>
+		<rect x="47.5" y="76.2" class="st3" width="8.1" height="42.1"/>
+	</g>
+</g>
+</svg>

--- a/public/images/landing-page/oss-num-2.svg
+++ b/public/images/landing-page/oss-num-2.svg
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 93 148.8" style="enable-background:new 0 0 93 148.8;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:url(#SVGID_1_);}
+	.st1{fill:url(#SVGID_2_);}
+	.st2{fill:url(#SVGID_3_);}
+	.st3{fill:url(#SVGID_4_);}
+</style>
+<title>oss-num</title>
+<g id="oss-num-2">
+	<g id="oss-2">
+		
+			<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="46.5" y1="151.4252" x2="46.5" y2="80.8053" gradientTransform="matrix(1 0 0 -1 0 151.4252)">
+			<stop  offset="0" style="stop-color:#61BB78"/>
+			<stop  offset="0.541" style="stop-color:#5FBA76"/>
+			<stop  offset="0.735" style="stop-color:#58B771"/>
+			<stop  offset="0.874" style="stop-color:#4DB267"/>
+			<stop  offset="0.985" style="stop-color:#3CAB58"/>
+			<stop  offset="1" style="stop-color:#39AA56"/>
+		</linearGradient>
+		<path class="st0" d="M93,8c0-4.4-3.6-8-8-8H8C3.6,0,0,3.6,0,8v62.6h93L93,8L93,8z"/>
+		
+			<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="46.4993" y1="2.627" x2="46.4993" y2="75.2431" gradientTransform="matrix(1 0 0 -1 0 151.4252)">
+			<stop  offset="0" style="stop-color:#88CC9A"/>
+			<stop  offset="0.465" style="stop-color:#86CA98"/>
+			<stop  offset="0.717" style="stop-color:#7EC490"/>
+			<stop  offset="0.918" style="stop-color:#70B982"/>
+			<stop  offset="1" style="stop-color:#68B37A"/>
+		</linearGradient>
+		<path class="st1" d="M0,140.8c0,4.4,3.6,8,8,8H85c4.4,0,8-3.6,8-8V76.2H0V140.8z"/>
+		
+			<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="46.9601" y1="123.9878" x2="46.9601" y2="80.8053" gradientTransform="matrix(1 0 0 -1 0 151.4252)">
+			<stop  offset="0" style="stop-color:#F0F0F0"/>
+			<stop  offset="0.533" style="stop-color:#EEEEEE"/>
+			<stop  offset="0.823" style="stop-color:#E6E6E6"/>
+			<stop  offset="1" style="stop-color:#DCDCDC"/>
+		</linearGradient>
+		<path class="st2" d="M75.3,52.8c0.1-3.8-0.6-7.6-2.1-11.1c-1.3-3.1-3.4-5.8-5.9-7.9c-2.6-2.1-5.6-3.8-8.9-4.8
+			c-3.6-1.1-7.3-1.6-11-1.6c-4.4-0.1-8.7,0.7-12.8,2.4c-3.5,1.5-6.6,3.7-9.1,6.6c-2.5,3-4.3,6.4-5.3,10.1c-1.2,4.2-1.7,8.5-1.6,12.8
+			h8.1c-0.1-3.2,0.2-6.4,1-9.5c0.7-2.9,1.9-5.6,3.5-8c1.6-2.3,3.8-4.2,6.4-5.5c2.9-1.4,6.2-2.2,9.4-2.1c2.6,0,5.3,0.4,7.8,1.2
+			c2.4,0.8,4.5,2,6.4,3.6c1.9,1.6,3.3,3.6,4.4,5.8c1.1,2.4,1.7,5.1,1.6,7.8c0.1,3.2-0.6,6.4-1.9,9.3c-1.4,2.9-3.3,5.4-5.6,7.7
+			c-0.3,0.3-0.7,0.7-1,1h10.4c1.8-2.3,3.2-4.8,4.3-7.5C74.7,59.8,75.4,56.3,75.3,52.8z"/>
+		
+			<linearGradient id="SVGID_4_" gradientUnits="userSpaceOnUse" x1="46.0662" y1="33.172" x2="46.0662" y2="75.2365" gradientTransform="matrix(1 0 0 -1 0 151.4252)">
+			<stop  offset="0" style="stop-color:#FFFFFF"/>
+			<stop  offset="0.57" style="stop-color:#FDFDFD"/>
+			<stop  offset="0.879" style="stop-color:#F5F5F5"/>
+			<stop  offset="1" style="stop-color:#EFEFEF"/>
+		</linearGradient>
+		<path class="st3" d="M51.3,76.6c-3.1,2.2-6.3,4.3-9.4,6.4c-3.2,2.1-6.3,4.3-9.3,6.6c-3,2.2-5.7,4.7-8.1,7.5
+			c-2.4,2.8-4.4,5.9-5.8,9.3c-1.5,3.8-2.3,7.8-2.3,11.8h59.3v-7.5h-50c0.5-3.1,1.9-5.9,3.9-8.3c2.1-2.6,4.5-4.9,7.1-7
+			c2.7-2.1,5.5-4.1,8.4-5.8c2.9-1.8,5.4-3.4,7.6-4.8c3-1.9,5.8-3.9,8.6-6.1c1-0.8,1.9-1.7,2.9-2.5H52C51.8,76.3,51.6,76.5,51.3,76.6
+			z"/>
+	</g>
+</g>
+</svg>

--- a/public/images/landing-page/oss-num-3.svg
+++ b/public/images/landing-page/oss-num-3.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 93 148.8" style="enable-background:new 0 0 93 148.8;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:url(#SVGID_1_);}
+	.st1{fill:url(#SVGID_2_);}
+	.st2{fill:url(#SVGID_3_);}
+	.st3{fill:url(#SVGID_4_);}
+</style>
+<title>oss-num</title>
+<g id="oss-num-3">
+	<g id="oss-3">
+		
+			<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="46.5" y1="2.627" x2="46.5" y2="75.2451" gradientTransform="matrix(1 0 0 -1 0 151.4294)">
+			<stop  offset="0" style="stop-color:#88CC9A"/>
+			<stop  offset="0.465" style="stop-color:#86CA98"/>
+			<stop  offset="0.717" style="stop-color:#7EC490"/>
+			<stop  offset="0.918" style="stop-color:#70B982"/>
+			<stop  offset="1" style="stop-color:#68B37A"/>
+		</linearGradient>
+		<path class="st0" d="M0,140.8c0,4.4,3.6,8,8,8H85c4.4,0,8-3.6,8-8V76.2H0V140.8z"/>
+		
+			<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="46.5" y1="151.4294" x2="46.5" y2="80.8075" gradientTransform="matrix(1 0 0 -1 0 151.4294)">
+			<stop  offset="0" style="stop-color:#61BB78"/>
+			<stop  offset="0.541" style="stop-color:#5FBA76"/>
+			<stop  offset="0.735" style="stop-color:#58B771"/>
+			<stop  offset="0.874" style="stop-color:#4DB267"/>
+			<stop  offset="0.985" style="stop-color:#3CAB58"/>
+			<stop  offset="1" style="stop-color:#39AA56"/>
+		</linearGradient>
+		<path class="st1" d="M93,8c0-4.4-3.6-8-8-8H8C3.6,0,0,3.6,0,8v62.6h93V8z"/>
+		
+			<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="45.2662" y1="123.9896" x2="45.2662" y2="80.8075" gradientTransform="matrix(1 0 0 -1 0 151.4294)">
+			<stop  offset="0" style="stop-color:#F0F0F0"/>
+			<stop  offset="0.533" style="stop-color:#EEEEEE"/>
+			<stop  offset="0.823" style="stop-color:#E6E6E6"/>
+			<stop  offset="1" style="stop-color:#DCDCDC"/>
+		</linearGradient>
+		<path class="st2" d="M58.3,70.5v-0.3c4.5-1,8.5-3.5,11.3-7.2c2.6-3.7,4-8.2,3.9-12.7c0.1-3.6-0.7-7.2-2.4-10.4
+			c-1.5-2.8-3.7-5.2-6.3-7.1C62,31,59,29.6,55.8,28.8c-3.4-0.9-6.8-1.4-10.3-1.4c-4.1-0.1-8.1,0.7-11.8,2.3
+			c-3.4,1.4-6.4,3.5-8.9,6.2c-2.5,2.7-4.4,5.9-5.7,9.3c-1.4,3.8-2,7.8-2,11.8h8.1c-0.1-3.1,0.3-6.2,1.2-9.2c0.8-2.7,2.1-5.1,3.9-7.2
+			c1.8-2,4-3.6,6.5-4.7c2.8-1.2,5.8-1.7,8.9-1.7c2.6,0,5.2,0.3,7.7,1c2.3,0.6,4.4,1.6,6.2,3.1c1.8,1.4,3.3,3.2,4.2,5.3
+			c1.1,2.4,1.6,5,1.5,7.7c0.1,2.5-0.5,5.1-1.7,7.3c-1.1,2-2.5,3.7-4.3,5.1c-1.8,1.3-3.8,2.3-5.9,3c-2.1,0.6-4.2,0.9-6.4,1h-6.8v3
+			h18.4C58.5,70.6,58.4,70.6,58.3,70.5z"/>
+		
+			<linearGradient id="SVGID_4_" gradientUnits="userSpaceOnUse" x1="45.8506" y1="31.3753" x2="45.8506" y2="75.2386" gradientTransform="matrix(1 0 0 -1 0 151.4294)">
+			<stop  offset="0" style="stop-color:#FFFFFF"/>
+			<stop  offset="0.57" style="stop-color:#FDFDFD"/>
+			<stop  offset="0.879" style="stop-color:#F5F5F5"/>
+			<stop  offset="1" style="stop-color:#EFEFEF"/>
+		</linearGradient>
+		<path class="st3" d="M62.4,79.1c2,1.6,3.6,3.6,4.6,5.9c1.2,2.7,1.7,5.5,1.7,8.4c0.1,2.9-0.6,5.9-1.9,8.5c-1.2,2.4-3,4.6-5.1,6.3
+			c-2.2,1.7-4.7,3-7.3,3.9c-2.8,0.9-5.7,1.3-8.6,1.3c-3.3,0.1-6.6-0.5-9.7-1.7c-2.7-1.1-5.2-2.7-7.2-4.8c-2-2.1-3.5-4.7-4.4-7.5
+			c-1-3.2-1.4-6.5-1.2-9.8H15c-0.4,4.4,0.1,8.8,1.6,13c1.3,3.6,3.5,6.9,6.3,9.5c2.9,2.6,6.3,4.6,10,5.9c4.1,1.4,8.4,2.1,12.8,2.1
+			c4,0,8-0.6,11.8-1.7c3.6-1.1,7-2.8,9.9-5.2c2.8-2.3,5.1-5.2,6.8-8.6c1.7-3.7,2.6-7.7,2.5-11.8c0.2-5.4-1.5-10.6-4.8-14.9
+			c-0.5-0.6-1-1.2-1.6-1.7h-13C59.1,76.9,60.8,77.9,62.4,79.1z"/>
+	</g>
+</g>
+</svg>

--- a/public/images/landing-page/oss-num-4.svg
+++ b/public/images/landing-page/oss-num-4.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 93 148.8" style="enable-background:new 0 0 93 148.8;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:url(#SVGID_1_);}
+	.st1{fill:url(#SVGID_2_);}
+	.st2{fill:url(#SVGID_3_);}
+	.st3{fill:url(#SVGID_4_);}
+</style>
+<title>oss-num</title>
+<g id="oss-num-4">
+	<g id="oss-4">
+		
+			<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="46.5" y1="2.627" x2="46.5" y2="75.2451" gradientTransform="matrix(1 0 0 -1 0 151.4294)">
+			<stop  offset="0" style="stop-color:#88CC9A"/>
+			<stop  offset="0.465" style="stop-color:#86CA98"/>
+			<stop  offset="0.717" style="stop-color:#7EC490"/>
+			<stop  offset="0.918" style="stop-color:#70B982"/>
+			<stop  offset="1" style="stop-color:#68B37A"/>
+		</linearGradient>
+		<path class="st0" d="M0,140.8c0,4.4,3.6,8,8,8H85c4.4,0,8-3.6,8-8V76.2H0V140.8z"/>
+		
+			<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="46.5" y1="151.4294" x2="46.5" y2="80.8075" gradientTransform="matrix(1 0 0 -1 0 151.4294)">
+			<stop  offset="0" style="stop-color:#61BB78"/>
+			<stop  offset="0.541" style="stop-color:#5FBA76"/>
+			<stop  offset="0.735" style="stop-color:#58B771"/>
+			<stop  offset="0.874" style="stop-color:#4DB267"/>
+			<stop  offset="0.985" style="stop-color:#3CAB58"/>
+			<stop  offset="1" style="stop-color:#39AA56"/>
+		</linearGradient>
+		<path class="st1" d="M93,8c0-4.4-3.6-8-8-8H8C3.6,0,0,3.6,0,8v62.6h93V8z"/>
+		
+			<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="45.8575" y1="33.1729" x2="45.8575" y2="75.2451" gradientTransform="matrix(1 0 0 -1 0 151.4294)">
+			<stop  offset="0" style="stop-color:#FFFFFF"/>
+			<stop  offset="0.57" style="stop-color:#FDFDFD"/>
+			<stop  offset="0.879" style="stop-color:#F5F5F5"/>
+			<stop  offset="1" style="stop-color:#EFEFEF"/>
+		</linearGradient>
+		<polygon class="st2" points="56.1,89.1 21.9,89.1 30.9,76.2 22.9,76.2 14.6,88 14.6,95.9 56.1,95.9 56.1,118.3 63.6,118.3 
+			63.6,95.9 77.1,95.9 77.1,89.1 63.6,89.1 63.6,76.2 56.1,76.2 		"/>
+		
+			<linearGradient id="SVGID_4_" gradientUnits="userSpaceOnUse" x1="45.1691" y1="123.2092" x2="45.1691" y2="80.8075" gradientTransform="matrix(1 0 0 -1 0 151.4294)">
+			<stop  offset="0" style="stop-color:#F0F0F0"/>
+			<stop  offset="0.533" style="stop-color:#EEEEEE"/>
+			<stop  offset="0.823" style="stop-color:#E6E6E6"/>
+			<stop  offset="1" style="stop-color:#DCDCDC"/>
+		</linearGradient>
+		<polygon class="st3" points="55.9,40.1 56.1,40.1 56.1,70.6 63.6,70.6 63.6,28.2 56.3,28.2 26.7,70.6 34.7,70.6 		"/>
+	</g>
+</g>
+</svg>

--- a/public/images/landing-page/oss-num-5.svg
+++ b/public/images/landing-page/oss-num-5.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 93 148.8" style="enable-background:new 0 0 93 148.8;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:url(#SVGID_1_);}
+	.st1{fill:url(#SVGID_2_);}
+	.st2{fill:url(#SVGID_3_);}
+	.st3{fill:url(#SVGID_4_);}
+</style>
+<title>oss-num</title>
+<g id="oss-num-5">
+	<g id="oss-5">
+		
+			<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="46.5" y1="151.4252" x2="46.5" y2="80.8053" gradientTransform="matrix(1 0 0 -1 0 151.4252)">
+			<stop  offset="0" style="stop-color:#61BB78"/>
+			<stop  offset="0.541" style="stop-color:#5FBA76"/>
+			<stop  offset="0.735" style="stop-color:#58B771"/>
+			<stop  offset="0.874" style="stop-color:#4DB267"/>
+			<stop  offset="0.985" style="stop-color:#3CAB58"/>
+			<stop  offset="1" style="stop-color:#39AA56"/>
+		</linearGradient>
+		<path class="st0" d="M93,8c0-4.4-3.6-8-8-8H8C3.6,0,0,3.6,0,8v62.6h93V8z"/>
+		
+			<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="46.4993" y1="2.627" x2="46.4993" y2="75.2431" gradientTransform="matrix(1 0 0 -1 0 151.4252)">
+			<stop  offset="0" style="stop-color:#88CC9A"/>
+			<stop  offset="0.465" style="stop-color:#86CA98"/>
+			<stop  offset="0.717" style="stop-color:#7EC490"/>
+			<stop  offset="0.918" style="stop-color:#70B982"/>
+			<stop  offset="1" style="stop-color:#68B37A"/>
+		</linearGradient>
+		<path class="st1" d="M0,140.8c0,4.4,3.6,8,8,8H85c4.4,0,8-3.6,8-8V76.2H0V140.8z"/>
+		
+			<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="45.6659" y1="122.3645" x2="45.6659" y2="80.8053" gradientTransform="matrix(1 0 0 -1 0 151.4252)">
+			<stop  offset="0" style="stop-color:#F0F0F0"/>
+			<stop  offset="0.533" style="stop-color:#EEEEEE"/>
+			<stop  offset="0.823" style="stop-color:#E6E6E6"/>
+			<stop  offset="1" style="stop-color:#DCDCDC"/>
+		</linearGradient>
+		<path class="st2" d="M68.3,67c-2.7-2.8-5.9-5-9.5-6.4c-4-1.6-8.2-2.4-12.5-2.3c-3.6,0-7.2,0.7-10.5,2.2c-3.3,1.3-6.2,3.5-8.5,6.2
+			l-0.3-0.3l5.8-29.8h39.4v-7.4H27l-7.8,41.6h10.5c1.3-1.1,2.6-2,4.1-2.8c3.5-1.8,7.5-2.8,11.4-2.8c3.2,0,6.3,0.6,9.3,1.8
+			c2.2,0.9,4.2,2.2,6,3.7h10.6C70.3,69.3,69.3,68.1,68.3,67z"/>
+		
+			<linearGradient id="SVGID_4_" gradientUnits="userSpaceOnUse" x1="46.0226" y1="31.6859" x2="46.0226" y2="75.2431" gradientTransform="matrix(1 0 0 -1 0 151.4252)">
+			<stop  offset="0" style="stop-color:#FFFFFF"/>
+			<stop  offset="0.57" style="stop-color:#FDFDFD"/>
+			<stop  offset="0.879" style="stop-color:#F5F5F5"/>
+			<stop  offset="1" style="stop-color:#EFEFEF"/>
+		</linearGradient>
+		<path class="st3" d="M66.6,79.2c1.2,2.9,1.8,6.1,1.7,9.3c0,3.2-0.5,6.3-1.5,9.3c-1,2.9-2.5,5.5-4.5,7.8c-2,2.3-4.4,4.1-7.1,5.4
+			c-2.9,1.4-6.1,2.1-9.4,2c-2.9,0-5.9-0.5-8.6-1.5c-5.2-1.9-9.4-5.8-11.6-10.9c-1.2-2.7-1.8-5.6-1.9-8.5h-8.1c0,4,0.9,7.9,2.4,11.6
+			c1.4,3.3,3.6,6.3,6.2,8.7c2.7,2.4,5.8,4.2,9.3,5.4c3.7,1.3,7.7,1.9,11.6,1.9c4.2,0,8.3-0.7,12.2-2.3c3.7-1.4,7.1-3.6,10-6.3
+			c2.9-2.7,5.1-6,6.7-9.6c1.7-3.8,2.5-8,2.4-12.2c0-4.3-0.7-8.5-2.1-12.5c-0.1-0.2-0.2-0.4-0.3-0.7h-9
+			C65.7,77.2,66.2,78.2,66.6,79.2z"/>
+	</g>
+</g>
+</svg>

--- a/public/images/landing-page/oss-num-6.svg
+++ b/public/images/landing-page/oss-num-6.svg
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 93 148.8" style="enable-background:new 0 0 93 148.8;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:url(#SVGID_1_);}
+	.st1{fill:url(#SVGID_2_);}
+	.st2{fill:url(#SVGID_3_);}
+	.st3{fill:url(#SVGID_4_);}
+	.st4{fill:url(#SVGID_5_);}
+</style>
+<title>oss-num</title>
+<g id="oss-num-6">
+	<g id="oss-6">
+		
+			<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="46.5" y1="151.4252" x2="46.5" y2="80.8053" gradientTransform="matrix(1 0 0 -1 0 151.4252)">
+			<stop  offset="0" style="stop-color:#61BB78"/>
+			<stop  offset="0.541" style="stop-color:#5FBA76"/>
+			<stop  offset="0.735" style="stop-color:#58B771"/>
+			<stop  offset="0.874" style="stop-color:#4DB267"/>
+			<stop  offset="0.985" style="stop-color:#3CAB58"/>
+			<stop  offset="1" style="stop-color:#39AA56"/>
+		</linearGradient>
+		<path class="st0" d="M93,8c0-4.4-3.6-8-8-8H8C3.6,0,0,3.6,0,8v62.6h93L93,8L93,8z"/>
+		
+			<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="46.4993" y1="2.627" x2="46.4993" y2="75.2431" gradientTransform="matrix(1 0 0 -1 0 151.4252)">
+			<stop  offset="0" style="stop-color:#88CC9A"/>
+			<stop  offset="0.465" style="stop-color:#86CA98"/>
+			<stop  offset="0.717" style="stop-color:#7EC490"/>
+			<stop  offset="0.918" style="stop-color:#70B982"/>
+			<stop  offset="1" style="stop-color:#68B37A"/>
+		</linearGradient>
+		<path class="st1" d="M0,140.8c0,4.4,3.6,8,8,8H85c4.4,0,8-3.6,8-8V76.2H0V140.8z"/>
+		
+			<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="48.4228" y1="91.827" x2="48.4228" y2="80.8053" gradientTransform="matrix(1 0 0 -1 0 151.4252)">
+			<stop  offset="0" style="stop-color:#F0F0F0"/>
+			<stop  offset="0.533" style="stop-color:#EEEEEE"/>
+			<stop  offset="0.823" style="stop-color:#E6E6E6"/>
+			<stop  offset="1" style="stop-color:#DCDCDC"/>
+		</linearGradient>
+		<path class="st2" d="M59.6,61.9c-3.9-1.5-8.1-2.3-12.3-2.3c-5,0-10,1.4-14.2,4.1c-2.9,1.8-5.4,4.1-7.4,6.9h8
+			c1.3-0.9,2.6-1.7,4-2.3c3-1.3,6.2-1.9,9.4-1.9c3.2-0.1,6.3,0.6,9.2,1.9c1.4,0.6,2.7,1.4,3.9,2.3h10.8c-0.7-0.9-1.4-1.7-2.1-2.5
+			C66.3,65.4,63.1,63.3,59.6,61.9z"/>
+		
+			<linearGradient id="SVGID_4_" gradientUnits="userSpaceOnUse" x1="44.988" y1="123.9886" x2="44.988" y2="80.7988" gradientTransform="matrix(1 0 0 -1 0 151.4252)">
+			<stop  offset="0" style="stop-color:#F0F0F0"/>
+			<stop  offset="0.533" style="stop-color:#EEEEEE"/>
+			<stop  offset="0.823" style="stop-color:#E6E6E6"/>
+			<stop  offset="1" style="stop-color:#DCDCDC"/>
+		</linearGradient>
+		<path class="st3" d="M35.3,38.3c3.6-2.8,8.2-4.2,12.7-4c4.7-0.2,9.3,1.5,12.8,4.6c3.4,3.2,5.5,7.5,6,12.1h8.1
+			c-0.9-8-3.8-13.9-8.5-17.7c-4.7-3.9-11.1-5.8-19.2-5.8c-4.3-0.1-8.7,0.8-12.6,2.6c-3.4,1.6-6.4,3.9-8.8,6.7
+			c-2.4,2.7-4.3,5.9-5.7,9.2c-1.4,3.2-2.5,6.6-3.3,10c-0.7,3.1-1.2,6.2-1.5,9.3c-0.2,2.1-0.2,3.8-0.3,5.4h8.2c0.1-3,0.4-6.1,0.8-9.3
+			c0.6-4.5,1.8-8.9,3.6-13.1C29.4,44.4,32,40.9,35.3,38.3z"/>
+		
+			<linearGradient id="SVGID_5_" gradientUnits="userSpaceOnUse" x1="46.0889" y1="31.3589" x2="46.0889" y2="75.2431" gradientTransform="matrix(1 0 0 -1 0 151.4252)">
+			<stop  offset="0" style="stop-color:#FFFFFF"/>
+			<stop  offset="0.57" style="stop-color:#FDFDFD"/>
+			<stop  offset="0.879" style="stop-color:#F5F5F5"/>
+			<stop  offset="1" style="stop-color:#EFEFEF"/>
+		</linearGradient>
+		<path class="st4" d="M67.5,81c1,3,1.5,6.1,1.5,9.3c0,3-0.5,6-1.5,8.9c-1.9,5.5-6,9.9-11.3,12.4c-2.8,1.3-5.8,1.9-8.8,1.9
+			c-3.5,0.1-6.9-0.5-10.2-1.8c-2.7-1.1-5.1-2.8-7-4.9c-1.9-2.1-3.3-4.7-4.1-7.4c-0.9-2.9-1.3-6-1.3-9c0-3.2,0.5-6.3,1.5-9.3
+			c0.6-1.7,1.3-3.2,2.3-4.7H15.1c0.1,6.2,0.7,12.4,1.8,18.5c0.9,5.2,2.9,10.2,5.7,14.7c2.4,3.6,5.8,6.5,9.8,8.2
+			c4.5,1.8,9.3,2.6,14.1,2.5c4.2,0,8.4-0.7,12.3-2.3c7.3-2.9,13.1-8.6,15.9-16c1.5-3.9,2.3-8,2.3-12.2c0-4.1-0.7-8.2-2.1-12.1
+			c-0.2-0.5-0.4-1-0.6-1.4h-9.1C66.2,77.7,66.9,79.3,67.5,81z"/>
+	</g>
+</g>
+</svg>

--- a/public/images/landing-page/oss-num-7.svg
+++ b/public/images/landing-page/oss-num-7.svg
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 93 148.8" style="enable-background:new 0 0 93 148.8;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:url(#SVGID_1_);}
+	.st1{fill:url(#SVGID_2_);}
+	.st2{fill:url(#SVGID_3_);}
+	.st3{fill:url(#SVGID_4_);}
+</style>
+<title>oss-num</title>
+<g id="oss-num-7">
+	<g id="oss-7">
+		
+			<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="46.5" y1="151.4252" x2="46.5" y2="80.8053" gradientTransform="matrix(1 0 0 -1 0 151.4252)">
+			<stop  offset="0" style="stop-color:#61BB78"/>
+			<stop  offset="0.541" style="stop-color:#5FBA76"/>
+			<stop  offset="0.735" style="stop-color:#58B771"/>
+			<stop  offset="0.874" style="stop-color:#4DB267"/>
+			<stop  offset="0.985" style="stop-color:#3CAB58"/>
+			<stop  offset="1" style="stop-color:#39AA56"/>
+		</linearGradient>
+		<path class="st0" d="M93,8c0-4.4-3.6-8-8-8H8C3.6,0,0,3.6,0,8v62.6h93V8z"/>
+		
+			<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="46.4993" y1="2.627" x2="46.4993" y2="75.2431" gradientTransform="matrix(1 0 0 -1 0 151.4252)">
+			<stop  offset="0" style="stop-color:#88CC9A"/>
+			<stop  offset="0.465" style="stop-color:#86CA98"/>
+			<stop  offset="0.717" style="stop-color:#7EC490"/>
+			<stop  offset="0.918" style="stop-color:#70B982"/>
+			<stop  offset="1" style="stop-color:#68B37A"/>
+		</linearGradient>
+		<path class="st1" d="M0,140.8c0,4.4,3.6,8,8,8H85c4.4,0,8-3.6,8-8V76.2H0V140.8z"/>
+		
+			<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="47.4627" y1="122.694" x2="47.4627" y2="80.8053" gradientTransform="matrix(1 0 0 -1 0 151.4252)">
+			<stop  offset="0" style="stop-color:#F0F0F0"/>
+			<stop  offset="0.533" style="stop-color:#EEEEEE"/>
+			<stop  offset="0.823" style="stop-color:#E6E6E6"/>
+			<stop  offset="1" style="stop-color:#DCDCDC"/>
+		</linearGradient>
+		<path class="st2" d="M54.7,65.6c3.3-6.2,7.2-12.1,11.5-17.6c3.9-4.9,7.3-8.9,10.2-11.8v-7.5H18.5v7.5h49.8
+			c-5.8,6.5-11.1,13.3-16,20.5c-3.1,4.5-5.8,9.2-8.4,14h8.2C53,68.9,53.8,67.2,54.7,65.6z"/>
+		
+			<linearGradient id="SVGID_4_" gradientUnits="userSpaceOnUse" x1="40.4508" y1="33.8164" x2="40.4508" y2="75.2392" gradientTransform="matrix(1 0 0 -1 0 151.4252)">
+			<stop  offset="0" style="stop-color:#FFFFFF"/>
+			<stop  offset="0.57" style="stop-color:#FDFDFD"/>
+			<stop  offset="0.879" style="stop-color:#F5F5F5"/>
+			<stop  offset="1" style="stop-color:#EFEFEF"/>
+		</linearGradient>
+		<path class="st3" d="M34.4,96c-1.6,7.1-2.7,14.3-3.1,21.6H40c0.4-9.8,2.1-19.4,5-28.7c1.4-4.5,3-8.7,4.7-12.7h-8.4
+			C38.3,82.5,36,89.2,34.4,96z"/>
+	</g>
+</g>
+</svg>

--- a/public/images/landing-page/oss-num-8.svg
+++ b/public/images/landing-page/oss-num-8.svg
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 93 148.8" style="enable-background:new 0 0 93 148.8;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:url(#SVGID_1_);}
+	.st1{fill:url(#SVGID_2_);}
+	.st2{fill:url(#SVGID_3_);}
+	.st3{fill:url(#SVGID_4_);}
+</style>
+<title>oss-num</title>
+<g id="oss-num-8">
+	<g id="oss-8">
+		
+			<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="46.5" y1="2.627" x2="46.5" y2="75.2451" gradientTransform="matrix(1 0 0 -1 0 151.4294)">
+			<stop  offset="0" style="stop-color:#88CC9A"/>
+			<stop  offset="0.465" style="stop-color:#86CA98"/>
+			<stop  offset="0.717" style="stop-color:#7EC490"/>
+			<stop  offset="0.918" style="stop-color:#70B982"/>
+			<stop  offset="1" style="stop-color:#68B37A"/>
+		</linearGradient>
+		<path class="st0" d="M0,140.8c0,4.4,3.6,8,8,8H85c4.4,0,8-3.6,8-8V76.2H0V140.8z"/>
+		
+			<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="46.5" y1="151.4294" x2="46.5" y2="80.8075" gradientTransform="matrix(1 0 0 -1 0 151.4294)">
+			<stop  offset="0" style="stop-color:#61BB78"/>
+			<stop  offset="0.541" style="stop-color:#5FBA76"/>
+			<stop  offset="0.735" style="stop-color:#58B771"/>
+			<stop  offset="0.874" style="stop-color:#4DB267"/>
+			<stop  offset="0.985" style="stop-color:#3CAB58"/>
+			<stop  offset="1" style="stop-color:#39AA56"/>
+		</linearGradient>
+		<path class="st1" d="M93,8c0-4.4-3.6-8-8-8H8C3.6,0,0,3.6,0,8v62.6h93V8z"/>
+		
+			<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="45.867" y1="30.0559" x2="45.867" y2="75.2491" gradientTransform="matrix(1 0 0 -1 0 151.4294)">
+			<stop  offset="0" style="stop-color:#FFFFFF"/>
+			<stop  offset="0.57" style="stop-color:#FDFDFD"/>
+			<stop  offset="0.879" style="stop-color:#F5F5F5"/>
+			<stop  offset="1" style="stop-color:#EFEFEF"/>
+		</linearGradient>
+		<path class="st2" d="M61.9,79.6c4.5,3.5,7.1,9,6.9,14.7c0.1,3.1-0.5,6.2-1.8,9c-1.1,2.5-2.8,4.6-4.9,6.4c-2.1,1.7-4.6,3-7.3,3.7
+			c-2.9,0.8-5.9,1.2-8.9,1.2c-3,0-6-0.4-8.9-1.3c-2.6-0.8-5.1-2.1-7.3-3.8c-2.1-1.7-3.8-3.9-4.9-6.4c-1.2-2.8-1.9-5.8-1.8-8.9
+			c-0.1-3,0.6-5.9,1.9-8.6c1.2-2.4,2.9-4.5,5-6.2c1.8-1.5,4-2.6,6.2-3.3H22.7c-1,0.9-2,1.9-2.8,3c-3.2,4.4-5,9.7-5,15.2
+			c-0.1,4.1,0.7,8.2,2.4,11.9c1.6,3.3,3.8,6.2,6.7,8.4c2.9,2.3,6.3,4,9.9,5c3.9,1.1,7.9,1.7,12,1.7c4.1,0,8.1-0.5,12-1.7
+			c3.6-1,6.9-2.7,9.8-5c2.9-2.3,5.1-5.1,6.7-8.4c1.7-3.7,2.5-7.8,2.4-11.9c0.2-5.5-1.5-10.9-4.8-15.2c-0.9-1.1-1.8-2.1-2.9-2.9H55.4
+			C57.7,76.9,59.9,78.1,61.9,79.6z"/>
+		
+			<linearGradient id="SVGID_4_" gradientUnits="userSpaceOnUse" x1="45.7913" y1="122.6702" x2="45.7913" y2="80.8062" gradientTransform="matrix(1 0 0 -1 0 151.4294)">
+			<stop  offset="0" style="stop-color:#F0F0F0"/>
+			<stop  offset="0.533" style="stop-color:#EEEEEE"/>
+			<stop  offset="0.823" style="stop-color:#E6E6E6"/>
+			<stop  offset="1" style="stop-color:#DCDCDC"/>
+		</linearGradient>
+		<path class="st3" d="M69.3,63.8c2.6-3.6,4-8.1,3.9-12.5c0.1-3.5-0.7-7-2.4-10c-1.5-2.8-3.7-5.2-6.3-7c-2.7-1.9-5.7-3.3-8.8-4.1
+			c-6.5-1.8-13.3-1.8-19.8,0c-3.1,0.8-6.1,2.2-8.7,4.1c-2.6,1.8-4.7,4.2-6.2,7c-1.6,3.1-2.5,6.5-2.4,10c-0.2,4.5,1.2,8.9,3.8,12.5
+			c2.4,3.2,5.8,5.5,9.5,6.8h28C63.6,69.4,66.9,67,69.3,63.8z M45.9,68c-2.4,0.1-4.8-0.2-7.1-0.8c-2.2-0.6-4.3-1.6-6.2-3
+			c-1.8-1.4-3.3-3.2-4.4-5.3c-1.2-2.4-1.7-5-1.7-7.7c0-2.4,0.5-4.7,1.6-6.8c1-1.9,2.5-3.6,4.3-4.9c1.9-1.3,4-2.3,6.2-3
+			c2.3-0.7,4.8-1,7.2-1c2.6,0,5.1,0.3,7.6,1c2.2,0.6,4.2,1.6,6,3c1.7,1.3,3.1,3,4.1,4.9c1,2.1,1.5,4.5,1.5,6.8
+			c0.1,2.6-0.5,5.2-1.6,7.6c-1,2.1-2.5,3.9-4.2,5.3c-1.8,1.4-3.9,2.4-6.1,3C50.7,67.8,48.3,68.1,45.9,68z"/>
+	</g>
+</g>
+</svg>

--- a/public/images/landing-page/oss-num-9.svg
+++ b/public/images/landing-page/oss-num-9.svg
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 93 148.8" style="enable-background:new 0 0 93 148.8;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:url(#SVGID_1_);}
+	.st1{fill:url(#SVGID_2_);}
+	.st2{fill:url(#SVGID_3_);}
+	.st3{fill:url(#SVGID_4_);}
+	.st4{fill:url(#SVGID_5_);}
+</style>
+<title>oss-num</title>
+<g id="oss-num-9">
+	<g id="oss-9">
+		
+			<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="46.5" y1="2.627" x2="46.5" y2="75.2451" gradientTransform="matrix(1 0 0 -1 0 151.4294)">
+			<stop  offset="0" style="stop-color:#88CC9A"/>
+			<stop  offset="0.465" style="stop-color:#86CA98"/>
+			<stop  offset="0.717" style="stop-color:#7EC490"/>
+			<stop  offset="0.918" style="stop-color:#70B982"/>
+			<stop  offset="1" style="stop-color:#68B37A"/>
+		</linearGradient>
+		<path class="st0" d="M0,140.8c0,4.4,3.6,8,8,8H85c4.4,0,8-3.6,8-8V76.2H0V140.8z"/>
+		
+			<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="46.5" y1="151.4294" x2="46.5" y2="80.8075" gradientTransform="matrix(1 0 0 -1 0 151.4294)">
+			<stop  offset="0" style="stop-color:#61BB78"/>
+			<stop  offset="0.541" style="stop-color:#5FBA76"/>
+			<stop  offset="0.735" style="stop-color:#58B771"/>
+			<stop  offset="0.874" style="stop-color:#4DB267"/>
+			<stop  offset="0.985" style="stop-color:#3CAB58"/>
+			<stop  offset="1" style="stop-color:#39AA56"/>
+		</linearGradient>
+		<path class="st1" d="M93,8c0-4.4-3.6-8-8-8H8C3.6,0,0,3.6,0,8v62.6h93V8z"/>
+		
+			<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="45.7273" y1="123.9867" x2="45.7273" y2="80.7983" gradientTransform="matrix(1 0 0 -1 0 151.4294)">
+			<stop  offset="0" style="stop-color:#F0F0F0"/>
+			<stop  offset="0.533" style="stop-color:#EEEEEE"/>
+			<stop  offset="0.823" style="stop-color:#E6E6E6"/>
+			<stop  offset="1" style="stop-color:#DCDCDC"/>
+		</linearGradient>
+		<path class="st2" d="M24.3,66.7c-1-3-1.5-6.1-1.5-9.3c0-3,0.5-6,1.5-8.9c1.9-5.5,6-10,11.3-12.4c2.7-1.3,5.7-1.9,8.7-1.9
+			c3.5-0.1,6.9,0.5,10.2,1.8c2.7,1.1,5.1,2.8,7,5c1.9,2.1,3.2,4.6,4.1,7.3c0.9,2.9,1.3,6,1.3,9.1c0,3.2-0.5,6.3-1.5,9.3
+			c-0.5,1.3-1,2.6-1.8,3.9h12.9C76.6,64.7,76,58.8,74.9,53C74,47.8,72,42.7,69.2,38.2c-2.4-3.6-5.8-6.5-9.8-8.2
+			c-4.5-1.8-9.3-2.6-14.1-2.5c-4.2,0-8.4,0.7-12.3,2.3c-3.6,1.5-6.9,3.6-9.6,6.4c-2.7,2.8-4.9,6-6.3,9.6c-1.5,3.9-2.3,8-2.3,12.2
+			c0,4.1,0.7,8.2,2.1,12.1c0.1,0.2,0.2,0.4,0.3,0.6h8.9C25.4,69.4,24.8,68,24.3,66.7z"/>
+		
+			<linearGradient id="SVGID_4_" gradientUnits="userSpaceOnUse" x1="46.8511" y1="31.3638" x2="46.8511" y2="75.2438" gradientTransform="matrix(1 0 0 -1 0 151.4294)">
+			<stop  offset="0" style="stop-color:#FFFFFF"/>
+			<stop  offset="0.57" style="stop-color:#FDFDFD"/>
+			<stop  offset="0.879" style="stop-color:#F5F5F5"/>
+			<stop  offset="1" style="stop-color:#EFEFEF"/>
+		</linearGradient>
+		<path class="st3" d="M68.6,76.2c-0.1,3.2-0.4,6.6-0.8,10.1c-0.6,4.5-1.8,8.9-3.6,13.1c-1.7,3.9-4.3,7.3-7.5,10
+			c-3.2,2.7-7.5,4-12.8,4c-4.7,0.2-9.3-1.5-12.8-4.6c-3.4-3.2-5.5-7.5-6-12.1H17c0.9,8,3.8,13.9,8.5,17.7c4.7,3.8,11.1,5.7,19.2,5.7
+			c4.3,0.1,8.7-0.8,12.6-2.6c3.4-1.6,6.4-3.8,8.8-6.6c2.4-2.7,4.3-5.8,5.7-9.1c1.4-3.2,2.5-6.6,3.3-10c0.7-3.1,1.2-6.2,1.5-9.3
+			c0.2-2.5,0.3-4.5,0.3-6.2L68.6,76.2z"/>
+		
+			<linearGradient id="SVGID_5_" gradientUnits="userSpaceOnUse" x1="43.4117" y1="63.3973" x2="43.4117" y2="75.2438" gradientTransform="matrix(1 0 0 -1 0 151.4294)">
+			<stop  offset="0" style="stop-color:#FFFFFF"/>
+			<stop  offset="0.57" style="stop-color:#FDFDFD"/>
+			<stop  offset="0.879" style="stop-color:#F5F5F5"/>
+			<stop  offset="1" style="stop-color:#EFEFEF"/>
+		</linearGradient>
+		<path class="st4" d="M32.3,85.8c3.9,1.5,8,2.3,12.2,2.3c8.9,0,17.2-4.5,22.2-11.8h-7.5c-1.5,1.3-3.2,2.4-5.1,3.2
+			c-3,1.3-6.2,1.9-9.5,1.9c-3.2,0.1-6.3-0.6-9.2-1.9c-1.8-0.8-3.4-1.9-4.9-3.2H20.2c0.8,1.2,1.7,2.3,2.7,3.4
+			C25.5,82.3,28.7,84.4,32.3,85.8z"/>
+	</g>
+</g>
+</svg>


### PR DESCRIPTION
Addresses [design-tasks issue #68](https://github.com/travis-pro/design-tasks/issues/68)
To make our testing numbers more accurate, created new svgs and styles to make each number individual which will allow us to customize them when needed. Unfortunately this is static atm.