### PR TITLE
Componentize oss usage numbers

### DIFF
--- a/app/components/oss-usage-digit.js
+++ b/app/components/oss-usage-digit.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+import { computed } from 'ember-decorators/object';
+
+export default Ember.Component.extend({
+  tagName: '',
+
+  @computed('digit')
+  digitClass(digit) {
+    return `oss-num-${digit}`;
+  },
+});

--- a/app/components/oss-usage-numbers.js
+++ b/app/components/oss-usage-numbers.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+import { computed } from 'ember-decorators/object';
+
+export default Ember.Component.extend({
+  @computed('numbers')
+  individualDigits(numbers) {
+    return numbers.toString().split('');
+  },
+});

--- a/app/styles/app/pages/landing.sass
+++ b/app/styles/app/pages/landing.sass
@@ -116,11 +116,11 @@
     display: inline-block
     padding-right: 10px
 
-  .flip-num img
-    height: 140px
-    max-width: 55px
-    @media #{$medium-up}
-      max-width: 93px
+    img
+      height: 140px
+      max-width: 55px
+      @media #{$medium-up}
+        max-width: 93px
 
   .customers
     text-align: center

--- a/app/templates/components/landing-default-page.hbs
+++ b/app/templates/components/landing-default-page.hbs
@@ -38,26 +38,7 @@
       <div class="large-12 columns">
         <h2>The home of<br class="mobile-break"> open source testing</h2>
         <p>Over 900k open source projects<br class="mobile-break"> and 600k users are testing on Travis CI.</p>
-        <div class="oss-flip-numbers">
-          <div class="flip-num oss-num-9">
-            <img src="../images/landing-page/oss-num-9.svg">
-          </div>
-          <div class="flip-num oss-num-3">
-            <img src="../images/landing-page/oss-num-3.svg">
-          </div>
-          <div class="flip-num oss-num-1">
-            <img src="../images/landing-page/oss-num-2.svg">
-          </div>
-          <div class="flip-num oss-num-3">
-            <img src="../images/landing-page/oss-num-9.svg">
-          </div>
-          <div class="flip-num oss-num-9">
-            <img src="../images/landing-page/oss-num-7.svg">
-          </div>
-          <div class="flip-num oss-num-9">
-            <img src="../images/landing-page/oss-num-7.svg">
-          </div>
-        </div>
+        {{oss-usage-numbers numbers=932977}}
       </div>
     </section>
   </div>

--- a/app/templates/components/oss-usage-digit.hbs
+++ b/app/templates/components/oss-usage-digit.hbs
@@ -1,0 +1,3 @@
+<div class="flip-num {{digitClass}}">
+  <img src="../images/landing-page/oss-num-{{digit}}.svg">
+</div>

--- a/app/templates/components/oss-usage-numbers.hbs
+++ b/app/templates/components/oss-usage-numbers.hbs
@@ -1,0 +1,5 @@
+<div class="oss-flip-numbers">
+  {{#each individualDigits as |digit|}}
+    {{oss-usage-digit digit=digit}}
+  {{/each}}
+</div>

--- a/tests/integration/components/oss-usage-digit-test.js
+++ b/tests/integration/components/oss-usage-digit-test.js
@@ -1,0 +1,13 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('oss-usage-digit', 'Integration | Component | oss usage digit', {
+  integration: true
+});
+
+test('it renders', function (assert) {
+  this.set('digit', 1);
+  this.render(hbs`{{oss-usage-digit digit=digit}}`);
+
+  assert.equal(this.$().find('img').attr('src'), '../images/landing-page/oss-num-1.svg');
+});

--- a/tests/integration/components/oss-usage-numbers-test.js
+++ b/tests/integration/components/oss-usage-numbers-test.js
@@ -1,0 +1,13 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('oss-usage-numbers', 'Integration | Component | oss usage numbers', {
+  integration: true
+});
+
+test('it renders correct images', function (assert) {
+  this.set('numbers', 1000);
+  this.render(hbs`{{oss-usage-numbers numbers=numbers}}`);
+
+  assert.equal(this.$('img').length, 4, 'renders image for each digit');
+});


### PR DESCRIPTION
This was previously hard-coded, meaning any change was more laborious than it needs to be. Instead, we can now just pass a value to a component and it renders the images as expected.