### PR TITLE
Fix subscribing to private jobs

### DIFF
--- a/app/components/job-infrastructure-notification.js
+++ b/app/components/job-infrastructure-notification.js
@@ -34,7 +34,7 @@ export default Ember.Component.extend({
   @equal('queue', 'builds.macstadium6') isMacStadium6: null,
 
   @computed('queue', 'job.config')
-  isPreciseEOL(queue, config) {
+  isPreciseEOL(queue, config = {}) {
     if (queue === 'builds.gce' && config.dist === 'precise') {
       if (config.language !== 'android') {
         return true;

--- a/tests/acceptance/builds/current-tab-test.js
+++ b/tests/acceptance/builds/current-tab-test.js
@@ -1,3 +1,4 @@
+/* global Travis */
 import { test } from 'qunit';
 import moduleForAcceptance from 'travis/tests/helpers/module-for-acceptance';
 import currentRepoTab from 'travis/tests/pages/repo-tabs/current';
@@ -59,6 +60,29 @@ test('renders most recent repository and most recent build when builds present, 
   });
 
   percySnapshot(assert);
+});
+
+test('renders the repository and subscribes to private log channel for a private repository', function (assert) {
+  server.logging = true;
+  let repository =  server.create('repository', { slug: 'travis-ci/travis-web', private: true });
+
+  const branch = server.create('branch', { name: 'acceptance-tests' });
+  let commit = server.create('commit', { author_email: 'mrt@travis-ci.org', author_name: 'Mr T', committer_email: 'mrt@travis-ci.org', committer_name: 'Mr T', branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
+  let build = server.create('build', { number: '5', state: 'started', repository, branch, commit });
+  let job = server.create('job', { number: '1234.1', state: 'received', build, commit, repository, config: { language: 'Hello' } });
+  server.create('log', { id: job.id, content: 'teh log' });
+
+  commit.update('build', build);
+  commit.update('job', job);
+
+  currentRepoTab
+    .visit();
+
+  andThen(() => {
+    assert.ok(currentRepoTab.showsCurrentBuild, 'Shows current build');
+    assert.ok(jobTabs.logTab.isShowing, 'Displays the log');
+    assert.ok(Travis.pusher.active_channels.includes(`private-job-${job.id}`));
+  });
 });
 
 test('error message when build jobs array is empty', function (assert) {


### PR DESCRIPTION
Subscription to private jobs was recently changed in a way that we allow
to subscribe to both private and public jobs, regardless of the
platform. This check requires access to a `repo.private` property and
unfortunately in certain cituations the `job.subscribe()` method may be
called when job is still not fully loaded (meaning that repository won't
be loaded either).

This commit fixes the situation by waiting to load the job before
subscribing. This is a bit hacky and we should probably fix the app to
not even reach this place when the job is not loaded, but this was the
best way to do it at the moment.

I also removed changed bulk_ajax authorizer to travis_ajax authorizer.
We don't need to authorize multiple channels anymore, so I could
simplify the authroizer and thanks to that also remove some code from
subscribing logic (no need for explicit ajax call when subscribing for a
log channels anymore).