### PR TITLE
Correct `ember` invocation in README [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ In order to run the app you need to install dependencies with:
 
 Now you can run the server:
 
-    ember serve
+    ./node_modules/.bin/ember serve
 
 And open http://localhost:4200 in the browser.
 


### PR DESCRIPTION
`./node_modules/.bin` is unlikely to be in `$PATH`, so we should
explicitly state it.