### PR TITLE
Silence production error due to missing method

### DIFF
--- a/app/controllers/account.js
+++ b/app/controllers/account.js
@@ -10,12 +10,6 @@ export default Ember.Controller.extend({
 
   @alias('auth.currentUser') user: null,
 
-  init() {
-    this._super(...arguments);
-
-    return Travis.on('user:synced', () => { this.reloadHooks(); });
-  },
-
   @action
   sync() {
     return this.get('user').sync();

--- a/app/controllers/account.js
+++ b/app/controllers/account.js
@@ -1,4 +1,3 @@
-/* global Travis */
 import Ember from 'ember';
 import { service } from 'ember-decorators/service';
 import { computed, action } from 'ember-decorators/object';


### PR DESCRIPTION
`reloadHooks` no longer exists, so this was throwing an exception in production.

Also, given pagination, the previous logic of reloading the entire collection is no longer applicable