### PR TITLE
Fix fetching a single stage

### DIFF
--- a/app/adapters/stage.js
+++ b/app/adapters/stage.js
@@ -22,5 +22,14 @@ export default V3Adapter.extend({
   findMany(store, modelClass, ids, snapshots) {
     let buildId = snapshots[0].belongsTo('build').id;
     return this.ajax(`${this.buildURL()}/build/${buildId}/stages`);
+  },
+
+  findRecord(store, type, id, snapshot) {
+    let buildId = snapshot.belongsTo('build').id;
+    // TODO: I'd rather implement /stage/:id endpoint in API, but for now this
+    // is a simpler way to fetch a single stage
+    return this.ajax(`${this.buildURL()}/build/${buildId}/stages`).then((data) =>
+      data.stages.filterBy('id', id)[0]
+    );
   }
 });

--- a/tests/acceptance/builds/build-stages-test.js
+++ b/tests/acceptance/builds/build-stages-test.js
@@ -10,6 +10,36 @@ function futureTime(secondsAhead) {
   return new Date(jobTime.getTime() + secondsAhead * 1000);
 }
 
+test('visiting build with one stage', function (assert) {
+  let repo =  server.create('repository', { slug: 'travis-ci/travis-web' });
+  server.create('branch', {});
+
+  let commit = server.create('commit', { author_email: 'mrt@travis-ci.org', author_name: 'Mr T', committer_email: 'mrt@travis-ci.org', committer_name: 'Mr T', branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
+  let build = server.create('build', { repository: repo, state: 'passed', commit_id: commit.id, commit });
+
+  let firstStage = build.createStage({ number: 1, name: 'first :two_men_holding_hands:', state: 'passed', started_at: jobTime, finished_at: futureTime(71), allow_failure: true });
+
+  let firstJob = server.create('job', { number: '1234.1', repository: repo, state: 'passed', config: { env: 'JORTS', os: 'linux', language: 'node_js', node_js: 5 }, commit, build, stage: firstStage, startedAt: jobTime, finishedAt: futureTime(30) });
+  commit.job = firstJob;
+
+  firstJob.save();
+  commit.save();
+
+  server.create('job', { number: '1234.2', repository: repo, state: 'failed', allow_failure: true, config: { env: 'JANTS', os: 'osx', language: 'ruby', rvm: 2.2 }, commit, build, stage: firstStage, startedAt: jobTime, finishedAt: futureTime(40) });
+
+  visit(`/travis-ci/travis-web/builds/${build.id}`);
+
+  andThen(function () {
+    assert.equal(buildPage.stages().count, 1, 'expected one build stage');
+
+    buildPage.stages(0).as(stage => {
+      assert.ok(stage.isPassed);
+    });
+  });
+
+  percySnapshot(assert);
+});
+
 test('visiting build with stages', function (assert) {
   let repo =  server.create('repository', { slug: 'travis-ci/travis-web' });
   server.create('branch', {});


### PR DESCRIPTION
At the moment API only implements /build/:id/stages endpoint for
fetching stages info. We implemented findMany method in stage adapter in
order where we use the endpoint, but it fails when there's only one
stage in build. Ember Data won't fire findMany then, but instead it will
use findRecord, which by default would go to /stages/:id; API doesn't
support it.

This commit implements findRecord method in the stage adapter to use
/build/:id/stages endpoint, but return only one stage.