### PR TITLE
Convert id in stages adapter findRecord to int

### DIFF
--- a/app/adapters/stage.js
+++ b/app/adapters/stage.js
@@ -29,7 +29,7 @@ export default V3Adapter.extend({
     // TODO: I'd rather implement /stage/:id endpoint in API, but for now this
     // is a simpler way to fetch a single stage
     return this.ajax(`${this.buildURL()}/build/${buildId}/stages`).then((data) =>
-      data.stages.filterBy('id', id)[0]
+      data.stages.filterBy('id', parseInt(id))[0]
     );
   }
 });

--- a/mirage/serializers/v3.js
+++ b/mirage/serializers/v3.js
@@ -177,7 +177,7 @@ export default JSONAPISerializer.extend({
   },
 
   normalizeId(_model, id) {
-    return id;
+    return parseInt(id);
   },
 
   representation(model, request, options) {


### PR DESCRIPTION
Ids returned from the API are ints, so we need to convert the id to int
in order to properly fetch the stage by id. The tests didn't catch this,
because Mirage was returning ids as strings.

This commit fixes the bug by converting the id to int before filtering,
but also changes tests to also return id as int to prevent these kind of
problems in the future