### PR TITLE
Add default for profile offset

### DIFF
--- a/app/controllers/account.js
+++ b/app/controllers/account.js
@@ -9,6 +9,8 @@ export default Ember.Controller.extend({
 
   @alias('auth.currentUser') user: null,
 
+  offset: 0,
+
   @action
   sync() {
     return this.get('user').sync();

--- a/tests/acceptance/profile/redirect-test.js
+++ b/tests/acceptance/profile/redirect-test.js
@@ -12,6 +12,6 @@ test('visiting /profile redirects to /profile/:username', function (assert) {
   visit('/profile');
 
   andThen(() => {
-    assert.equal(currentURL(), '/profile/testuser?offset=0');
+    assert.equal(currentURL(), '/profile/testuser');
   });
 });


### PR DESCRIPTION
This removes the unsightly `?offset=0` when you first view
the profile route.