### PR TITLE
Bump mirage to 0.2.9

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -21,7 +21,8 @@ export default function () {
     };
   });
 
-  this.namespace = apiEndpoint;
+  this.urlPrefix = apiEndpoint;
+  this.namespace = '';
 
   this.get('/users/:id');
   this.get('/accounts', (schema/* , request*/) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5389,9 +5389,9 @@
       "dev": true
     },
     "ember-cli-mirage": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/ember-cli-mirage/-/ember-cli-mirage-0.2.8.tgz",
-      "integrity": "sha1-h47OW2/AfBlaC47bjheFpl00as8=",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/ember-cli-mirage/-/ember-cli-mirage-0.2.9.tgz",
+      "integrity": "sha1-9xC7l+aJWzkYg5Enq15XBTjWaLQ=",
       "dev": true,
       "requires": {
         "broccoli-funnel": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ember-cli-htmlbars-inline-precompile": "^1.0.0",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-inline-images": "^0.0.4",
-    "ember-cli-mirage": "0.2.8",
+    "ember-cli-mirage": "0.2.9",
     "ember-cli-page-object": "1.10.0",
     "ember-cli-qunit": "4.0.0",
     "ember-cli-sass": "7.0.0",


### PR DESCRIPTION
I've tried moving directly to 0.3.4, but have encountered many issues along the way:
- missing explicit inverse statements, which throws errors such as `The repository model has multiple possible inverse associations for the repository association on the build model.` (That's fixable, but others e.g. branches/builds were harder and led to the next error)
- removing the models and letting Mirage infer them from our models currently leads to memory leaks and `Maximum stack size exceeded` errors.

For that reason, I figured I'd bring in the single fix for the hostname, as the logic for that apparently changed and it will apply to later versions as well.