### PR TITLE
Only apply settings switch state locally if successfully persisted

### DIFF
--- a/app/components/settings-switch.js
+++ b/app/components/settings-switch.js
@@ -24,10 +24,9 @@ export default Ember.Component.extend({
   },
 
   save: task(function* () {
-    this.toggleProperty('active');
-
     try {
       yield this.get('repo').saveSetting(this.get('key'), this.get('active'));
+      this.toggleProperty('active');
     } catch (e) {
       this.get('flashes').error('There was an error while saving your settings. Please try again.');
     }

--- a/app/components/settings-switch.js
+++ b/app/components/settings-switch.js
@@ -25,7 +25,9 @@ export default Ember.Component.extend({
 
   save: task(function* () {
     try {
-      yield this.get('repo').saveSetting(this.get('key'), this.get('active'));
+      // try saving with the new state, only change local state if successful
+      const futureState = !this.get('active');
+      yield this.get('repo').saveSetting(this.get('key'), futureState);
       this.toggleProperty('active');
     } catch (e) {
       this.get('flashes').error('There was an error while saving your settings. Please try again.');

--- a/app/templates/components/settings-switch.hbs
+++ b/app/templates/components/settings-switch.hbs
@@ -7,6 +7,3 @@
   </span>
 </div>
 <span class="label">{{description}}</span>
-{{#if save.isRunning}}
-  {{loading-indicator}}
-{{/if}}


### PR DESCRIPTION
This should address https://github.com/travis-pro/team-teal/issues/2146 by preventing the switch from ever getting into a bad state in first place.