### PR TITLE
fix profile hook length

### DIFF
--- a/app/styles/app/layouts/profile.sass
+++ b/app/styles/app/layouts/profile.sass
@@ -112,13 +112,13 @@ p.profile-user-last
   display: inline-block !important
 
 .profile-repo
-  border-radius: 2px
+  display: inline-block
   position: relative
-  width: grid-calc(13, 24)
   padding: .25em .5em .3em
   white-space: nowrap
   overflow: hidden
   vertical-align: middle
+  border-radius: 2px
   span:not(.loading-indicator)
     display: none
     margin-left: 1rem


### PR DESCRIPTION
Restore 'full' width profile hooks on hover
![screen shot 2017-10-05 at 15 57 49](https://user-images.githubusercontent.com/1006478/31231034-003f6870-a9e6-11e7-8dfe-bc805593d307.png)
