### PR TITLE
Update Ember projects to 2.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,11 @@ cache:
     - node_modules
     - bower_components
 
+env:
+  global:
+    # See https://git.io/vdao3 for details.
+    - JOBS=1
+
 before_install:
   - npm config set spin false
   - npm install -g npm@5

--- a/app/utils/live-paginated-collection.js
+++ b/app/utils/live-paginated-collection.js
@@ -1,4 +1,7 @@
-import { defineProperty, computed as emberComputed } from '@ember/object';
+import {
+  defineProperty,
+  computed as emberComputed
+} from '@ember/object';
 import ArrayProxy from '@ember/array/proxy';
 import { alias } from 'ember-decorators/object/computed';
 import { computed } from 'ember-decorators/object';

--- a/package-lock.json
+++ b/package-lock.json
@@ -110,7 +110,7 @@
       "requires": {
         "@glimmer/interfaces": "0.25.3",
         "@glimmer/util": "0.25.3",
-        "handlebars": "4.0.10",
+        "handlebars": "4.0.11",
         "simple-html-tokenizer": "0.3.0"
       },
       "dependencies": {
@@ -312,9 +312,9 @@
       "dev": true
     },
     "ansi-escapes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
       "dev": true
     },
     "ansi-regex": {
@@ -1877,6 +1877,24 @@
         "error": "7.0.2",
         "raw-body": "1.1.7",
         "safe-json-parse": "1.0.1"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
+          "integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g=",
+          "dev": true
+        },
+        "raw-body": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
+          "integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
+          "dev": true,
+          "requires": {
+            "bytes": "1.0.0",
+            "string_decoder": "0.10.31"
+          }
+        }
       }
     },
     "body-parser": {
@@ -1952,20 +1970,14 @@
         "hoek": "2.16.3"
       }
     },
-    "bower": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.2.tgz",
-      "integrity": "sha1-rfU1KcjUrwLvJPuNU0HBQZ0z4vc=",
-      "dev": true
-    },
     "bower-config": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-1.4.0.tgz",
-      "integrity": "sha1-FsOMETX4BxwZ8lk41hsNjL8Y0/E=",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-1.4.1.tgz",
+      "integrity": "sha1-hf2d82fCuNu9DKpMXyutQM2Ewsw=",
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
-        "mout": "1.0.0",
+        "mout": "1.1.0",
         "optimist": "0.6.1",
         "osenv": "0.1.4",
         "untildify": "2.1.0"
@@ -2402,7 +2414,7 @@
       "integrity": "sha1-kvTh+5p5HqmGJFpwd/NcxkjasJc=",
       "dev": true,
       "requires": {
-        "handlebars": "4.0.10",
+        "handlebars": "4.0.11",
         "mime": "1.3.6"
       }
     },
@@ -2794,27 +2806,64 @@
       }
     },
     "broccoli-uglify-sourcemap": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/broccoli-uglify-sourcemap/-/broccoli-uglify-sourcemap-1.5.2.tgz",
-      "integrity": "sha1-BPhKsNtTkDH6hozPpWPJky1Qzts=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/broccoli-uglify-sourcemap/-/broccoli-uglify-sourcemap-2.0.0.tgz",
+      "integrity": "sha1-LcV06dMwwuDcyDSz0kx5S0BaOAM=",
       "dev": true,
       "requires": {
         "broccoli-plugin": "1.3.0",
-        "debug": "2.6.8",
-        "lodash.merge": "4.6.0",
-        "matcher-collection": "1.0.4",
+        "debug": "3.1.0",
+        "lodash.defaultsdeep": "4.6.0",
+        "matcher-collection": "1.0.5",
         "mkdirp": "0.5.1",
-        "source-map-url": "0.3.0",
+        "source-map-url": "0.4.0",
         "symlink-or-copy": "1.1.8",
-        "uglify-js": "2.8.29",
-        "walk-sync": "0.1.3"
+        "uglify-es": "3.1.3",
+        "walk-sync": "0.3.2"
       },
       "dependencies": {
-        "walk-sync": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.1.3.tgz",
-          "integrity": "sha1-igcmGgC9ps+xviXp8QD61XVG9YM=",
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "matcher-collection": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.5.tgz",
+          "integrity": "sha512-nUCmzKipcJEwYsBVAFh5P+d7JBuhJaW1xs85Hara9xuMLqtCVUrW6DSC0JVIkluxEH2W45nPBM/wjHtBXa/tYA==",
+          "dev": true,
+          "requires": {
+            "minimatch": "3.0.4"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "source-map-url": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+          "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
           "dev": true
+        },
+        "uglify-es": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.1.3.tgz",
+          "integrity": "sha512-Nuo5gkv/Q6PmLa+Ui2LvK+87YdMAcuXfRIWF0uVfkHVSfpT3Ue0euCSu4t0b8xv4Bt05lmXUT8bLI9OmnyPj8A==",
+          "dev": true,
+          "requires": {
+            "commander": "2.11.0",
+            "source-map": "0.5.6"
+          }
         }
       }
     },
@@ -3313,18 +3362,18 @@
       }
     },
     "cli-cursor": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "1.0.1"
+        "restore-cursor": "2.0.0"
       }
     },
     "cli-spinners": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
-      "integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.1.0.tgz",
+      "integrity": "sha1-8YR7FohE2RemceudFH499JfJDQY=",
       "dev": true
     },
     "cli-table": {
@@ -3545,18 +3594,35 @@
       }
     },
     "compression": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.0.tgz",
-      "integrity": "sha1-AwyfGY8WQ6BX13anOOki2kNzAS0=",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.1.tgz",
+      "integrity": "sha1-7/JgPvwuIs+G810uuTWJ+YdTc9s=",
       "dev": true,
       "requires": {
         "accepts": "1.3.4",
-        "bytes": "2.5.0",
+        "bytes": "3.0.0",
         "compressible": "2.0.11",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "on-headers": "1.0.1",
         "safe-buffer": "5.1.1",
-        "vary": "1.1.1"
+        "vary": "1.1.2"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "concat-map": {
@@ -3622,15 +3688,46 @@
       "dev": true
     },
     "console-ui": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/console-ui/-/console-ui-1.0.3.tgz",
-      "integrity": "sha1-McUkRhtjQidp+eicFzSV2ROTchw=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/console-ui/-/console-ui-2.0.0.tgz",
+      "integrity": "sha1-FZ730JikkfhHBbtpzWPs7Jo2exQ=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "inquirer": "1.2.3",
-        "ora": "0.2.3",
+        "chalk": "2.1.0",
+        "inquirer": "3.3.0",
+        "ora": "1.3.0",
         "through": "2.3.8"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.4.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
       }
     },
     "consolidate": {
@@ -3639,13 +3736,13 @@
       "integrity": "sha1-WiUEe8dvcwcmZ8jLUsmJiI9JTGM=",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.0"
+        "bluebird": "3.5.1"
       },
       "dependencies": {
         "bluebird": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
           "dev": true
         }
       }
@@ -3918,12 +4015,6 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
-    "deep-freeze": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/deep-freeze/-/deep-freeze-0.0.1.tgz",
-      "integrity": "sha1-OgsABd4YZygZ39OM0x+RF5yJPoQ=",
-      "dev": true
-    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -4125,9 +4216,9 @@
       }
     },
     "diff": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
+      "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
       "dev": true
     },
     "diffie-hellman": {
@@ -4353,15 +4444,14 @@
       }
     },
     "ember-cli": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/ember-cli/-/ember-cli-2.15.0.tgz",
-      "integrity": "sha1-TygvhfCFjclu1Sbl9HJFAsdP4m4=",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/ember-cli/-/ember-cli-2.16.2.tgz",
+      "integrity": "sha1-U7kiBzqObzQlWm4NyxeUqRuj4bc=",
       "dev": true,
       "requires": {
-        "amd-name-resolver": "0.0.7",
+        "amd-name-resolver": "1.0.0",
         "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "bower": "1.8.2",
-        "bower-config": "1.4.0",
+        "bower-config": "1.4.1",
         "bower-endpoint-parser": "0.2.2",
         "broccoli-babel-transpiler": "6.1.2",
         "broccoli-brocfile-loader": "0.18.0",
@@ -4369,7 +4459,8 @@
         "broccoli-concat": "3.2.2",
         "broccoli-config-loader": "1.0.1",
         "broccoli-config-replace": "1.1.2",
-        "broccoli-funnel": "1.2.0",
+        "broccoli-debug": "0.6.3",
+        "broccoli-funnel": "2.0.1",
         "broccoli-funnel-reducer": "1.0.0",
         "broccoli-merge-trees": "2.0.0",
         "broccoli-middleware": "1.0.0",
@@ -4377,31 +4468,30 @@
         "broccoli-stew": "1.5.0",
         "calculate-cache-key-for-tree": "1.1.0",
         "capture-exit": "1.2.0",
-        "chalk": "1.1.3",
+        "chalk": "2.1.0",
         "clean-base-url": "1.0.0",
-        "compression": "1.7.0",
+        "compression": "1.7.1",
         "configstore": "3.1.1",
-        "console-ui": "1.0.3",
+        "console-ui": "2.0.0",
         "core-object": "3.1.5",
         "dag-map": "2.0.2",
-        "deep-freeze": "0.0.1",
-        "diff": "3.3.1",
+        "diff": "3.4.0",
         "ember-cli-broccoli-sane-watcher": "2.0.4",
         "ember-cli-is-package-missing": "1.0.0",
         "ember-cli-legacy-blueprints": "0.1.5",
-        "ember-cli-lodash-subset": "1.0.12",
+        "ember-cli-lodash-subset": "2.0.1",
         "ember-cli-normalize-entity-name": "1.0.0",
         "ember-cli-preprocess-registry": "3.1.1",
         "ember-cli-string-utils": "1.1.0",
-        "ember-try": "0.2.16",
+        "ember-try": "0.2.17",
         "ensure-posix-path": "1.0.2",
-        "execa": "0.7.0",
+        "execa": "0.8.0",
         "exists-sync": "0.0.4",
         "exit": "0.1.2",
-        "express": "4.15.4",
+        "express": "4.16.2",
         "filesize": "3.5.10",
         "find-up": "2.1.0",
-        "fs-extra": "3.0.1",
+        "fs-extra": "4.0.2",
         "fs-tree-diff": "0.5.6",
         "get-caller-file": "1.0.2",
         "git-repo-info": "1.4.1",
@@ -4445,6 +4535,15 @@
         "yam": "0.0.22"
       },
       "dependencies": {
+        "amd-name-resolver": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.0.0.tgz",
+          "integrity": "sha1-Dlk7KNb6MyarF5gQftrqlhBG6Ng=",
+          "dev": true,
+          "requires": {
+            "ensure-posix-path": "1.0.2"
+          }
+        },
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
@@ -4505,6 +4604,28 @@
             "workerpool": "2.2.2"
           },
           "dependencies": {
+            "broccoli-funnel": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+              "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+              "dev": true,
+              "requires": {
+                "array-equal": "1.0.0",
+                "blank-object": "1.0.2",
+                "broccoli-plugin": "1.3.0",
+                "debug": "2.6.8",
+                "exists-sync": "0.0.4",
+                "fast-ordered-set": "1.0.3",
+                "fs-tree-diff": "0.5.6",
+                "heimdalljs": "0.2.5",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "path-posix": "1.0.0",
+                "rimraf": "2.6.1",
+                "symlink-or-copy": "1.1.8",
+                "walk-sync": "0.3.2"
+              }
+            },
             "broccoli-merge-trees": {
               "version": "1.2.4",
               "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
@@ -4523,6 +4644,38 @@
             }
           }
         },
+        "broccoli-funnel": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz",
+          "integrity": "sha512-C8Lnp9TVsSSiZMGEF16C0dCiNg2oJqUKwuZ1K4kVC6qRPG/2Cj/rtB5kRCC9qEbwqhX71bDbfHROx0L3J7zXQg==",
+          "dev": true,
+          "requires": {
+            "array-equal": "1.0.0",
+            "blank-object": "1.0.2",
+            "broccoli-plugin": "1.3.0",
+            "debug": "2.6.8",
+            "fast-ordered-set": "1.0.3",
+            "fs-tree-diff": "0.5.6",
+            "heimdalljs": "0.2.5",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "path-posix": "1.0.0",
+            "rimraf": "2.6.1",
+            "symlink-or-copy": "1.1.8",
+            "walk-sync": "0.3.2"
+          }
+        },
+        "chalk": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.4.0"
+          }
+        },
         "core-object": {
           "version": "3.1.5",
           "resolved": "https://registry.npmjs.org/core-object/-/core-object-3.1.5.tgz",
@@ -4530,19 +4683,6 @@
           "dev": true,
           "requires": {
             "chalk": "2.1.0"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-              "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "3.2.0",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "4.4.0"
-              }
-            }
           }
         },
         "find-up": {
@@ -5375,6 +5515,12 @@
         "silent-error": "1.1.0"
       },
       "dependencies": {
+        "ember-cli-lodash-subset": {
+          "version": "1.0.12",
+          "resolved": "https://registry.npmjs.org/ember-cli-lodash-subset/-/ember-cli-lodash-subset-1.0.12.tgz",
+          "integrity": "sha1-ry5366XcsNd/MwjTpv19NFD25Tc=",
+          "dev": true
+        },
         "exists-sync": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.3.tgz",
@@ -5396,9 +5542,9 @@
       }
     },
     "ember-cli-lodash-subset": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/ember-cli-lodash-subset/-/ember-cli-lodash-subset-1.0.12.tgz",
-      "integrity": "sha1-ry5366XcsNd/MwjTpv19NFD25Tc=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-lodash-subset/-/ember-cli-lodash-subset-2.0.1.tgz",
+      "integrity": "sha1-IMtop5D+D94kiN39jvu332/nZvI=",
       "dev": true
     },
     "ember-cli-mirage": {
@@ -5645,6 +5791,12 @@
             "symlink-or-copy": "1.1.8"
           }
         },
+        "ember-cli-lodash-subset": {
+          "version": "1.0.12",
+          "resolved": "https://registry.npmjs.org/ember-cli-lodash-subset/-/ember-cli-lodash-subset-1.0.12.tgz",
+          "integrity": "sha1-ry5366XcsNd/MwjTpv19NFD25Tc=",
+          "dev": true
+        },
         "exists-sync": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.3.tgz",
@@ -5755,12 +5907,13 @@
       }
     },
     "ember-cli-uglify": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-uglify/-/ember-cli-uglify-1.2.0.tgz",
-      "integrity": "sha1-MgjDK1S8J4MFbouw1c/pu68X/7I=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-uglify/-/ember-cli-uglify-2.0.0.tgz",
+      "integrity": "sha1-sJZyfX0XGKzJv+XRvIHOJsr99so=",
       "dev": true,
       "requires": {
-        "broccoli-uglify-sourcemap": "1.5.2"
+        "broccoli-uglify-sourcemap": "2.0.0",
+        "lodash.defaultsdeep": "4.6.0"
       }
     },
     "ember-cli-valid-component-name": {
@@ -5873,9 +6026,9 @@
       }
     },
     "ember-data": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-2.15.0.tgz",
-      "integrity": "sha512-eDoRu4x3JR3KG90/iTHRziaRiWupJ2nyanxdijM55FJQCSL0TGCuHPQm3WRaXtBBZBeiC+gjkcDFa5pXe9kuug==",
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-2.16.3.tgz",
+      "integrity": "sha512-gZ+ZD7XD6z0m5bQBHJcISWlY2SoAQM0i5HCXjhmxhByT6x+ydVxqsuRnT1hyZ6b8sRYZNOzWCqGUmCqDb8OYlw==",
       "dev": true,
       "requires": {
         "amd-name-resolver": "0.0.7",
@@ -5885,10 +6038,12 @@
         "babel6-plugin-strip-class-callcheck": "6.0.0",
         "babel6-plugin-strip-heimdall": "6.0.1",
         "broccoli-babel-transpiler": "6.1.2",
+        "broccoli-debug": "0.6.3",
         "broccoli-file-creator": "1.1.1",
         "broccoli-funnel": "1.2.0",
-        "broccoli-merge-trees": "1.2.4",
+        "broccoli-merge-trees": "2.0.0",
         "broccoli-rollup": "1.3.0",
+        "calculate-cache-key-for-tree": "1.1.0",
         "chalk": "1.1.3",
         "ember-cli-babel": "6.8.2",
         "ember-cli-path-utils": "1.0.0",
@@ -5903,8 +6058,7 @@
         "inflection": "1.12.0",
         "npm-git-info": "1.0.3",
         "semver": "5.4.1",
-        "silent-error": "1.1.0",
-        "testem": "1.15.0"
+        "silent-error": "1.1.0"
       },
       "dependencies": {
         "babel-core": {
@@ -5940,12 +6094,6 @@
           "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
           "dev": true
         },
-        "bluebird": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
-          "dev": true
-        },
         "broccoli-babel-transpiler": {
           "version": "6.1.2",
           "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.1.2.tgz",
@@ -5962,24 +6110,24 @@
             "json-stable-stringify": "1.0.1",
             "rsvp": "3.6.2",
             "workerpool": "2.2.2"
-          }
-        },
-        "broccoli-merge-trees": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
-          "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
-          "dev": true,
-          "requires": {
-            "broccoli-plugin": "1.3.0",
-            "can-symlink": "1.0.0",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.6",
-            "heimdalljs": "0.2.5",
-            "heimdalljs-logger": "0.1.9",
-            "rimraf": "2.6.1",
-            "symlink-or-copy": "1.1.8"
           },
           "dependencies": {
+            "broccoli-merge-trees": {
+              "version": "1.2.4",
+              "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
+              "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
+              "dev": true,
+              "requires": {
+                "broccoli-plugin": "1.3.0",
+                "can-symlink": "1.0.0",
+                "fast-ordered-set": "1.0.3",
+                "fs-tree-diff": "0.5.6",
+                "heimdalljs": "0.2.5",
+                "heimdalljs-logger": "0.1.9",
+                "rimraf": "2.6.1",
+                "symlink-or-copy": "1.1.8"
+              }
+            },
             "heimdalljs": {
               "version": "0.2.5",
               "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.5.tgz",
@@ -5987,13 +6135,15 @@
               "dev": true,
               "requires": {
                 "rsvp": "3.2.1"
+              },
+              "dependencies": {
+                "rsvp": {
+                  "version": "3.2.1",
+                  "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+                  "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo=",
+                  "dev": true
+                }
               }
-            },
-            "rsvp": {
-              "version": "3.2.1",
-              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
-              "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo=",
-              "dev": true
             }
           }
         },
@@ -6039,39 +6189,6 @@
           "dev": true,
           "requires": {
             "brace-expansion": "1.1.8"
-          }
-        },
-        "testem": {
-          "version": "1.15.0",
-          "resolved": "https://registry.npmjs.org/testem/-/testem-1.15.0.tgz",
-          "integrity": "sha1-LjqeesKfFqIPcY6wxLEuekSQBnU=",
-          "dev": true,
-          "requires": {
-            "backbone": "1.3.3",
-            "bluebird": "3.5.0",
-            "charm": "1.0.2",
-            "commander": "2.11.0",
-            "consolidate": "0.14.5",
-            "cross-spawn": "5.1.0",
-            "express": "4.15.4",
-            "fireworm": "0.7.1",
-            "glob": "7.1.2",
-            "http-proxy": "1.16.2",
-            "js-yaml": "3.9.1",
-            "lodash.assignin": "4.2.0",
-            "lodash.clonedeep": "4.5.0",
-            "lodash.find": "4.6.0",
-            "mkdirp": "0.5.1",
-            "mustache": "2.3.0",
-            "node-notifier": "5.1.2",
-            "npmlog": "4.1.2",
-            "printf": "0.2.5",
-            "rimraf": "2.6.1",
-            "socket.io": "1.6.0",
-            "spawn-args": "0.2.0",
-            "styled_string": "0.0.1",
-            "tap-parser": "5.4.0",
-            "xmldom": "0.1.27"
           }
         }
       }
@@ -6755,15 +6872,6 @@
         }
       }
     },
-    "ember-router-service-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ember-router-service-polyfill/-/ember-router-service-polyfill-1.0.1.tgz",
-      "integrity": "sha512-EtdqtIsJ+YXXd/S0397Ckl5XI3Sd1dF8L515pCARphILODpFqrYyWq8mRX3A4jw1I6xz9ShJwb5pXgdF/ENrbA==",
-      "dev": true,
-      "requires": {
-        "ember-cli-babel": "6.8.2"
-      }
-    },
     "ember-runtime-enumerable-includes-polyfill": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ember-runtime-enumerable-includes-polyfill/-/ember-runtime-enumerable-includes-polyfill-2.0.0.tgz",
@@ -6775,16 +6883,15 @@
       }
     },
     "ember-source": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-2.15.0.tgz",
-      "integrity": "sha1-kBy+Or7gkpI3Kwb2qo3TQmg74tU=",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-2.16.0.tgz",
+      "integrity": "sha1-K+zXlmJ4/kUwRrkReO3mZcLPJBo=",
       "dev": true,
       "requires": {
         "@glimmer/compiler": "0.25.3",
         "@glimmer/node": "0.25.3",
         "@glimmer/reference": "0.25.3",
         "@glimmer/runtime": "0.25.3",
-        "@glimmer/util": "0.25.3",
         "broccoli-funnel": "1.2.0",
         "broccoli-merge-trees": "2.0.0",
         "ember-cli-get-component-path-option": "1.0.0",
@@ -6796,12 +6903,12 @@
         "ember-cli-valid-component-name": "1.0.0",
         "ember-cli-version-checker": "1.3.1",
         "ember-router-generator": "1.2.3",
-        "handlebars": "4.0.10",
+        "inflection": "1.12.0",
         "jquery": "3.2.1",
         "resolve": "1.4.0",
         "rsvp": "3.6.2",
         "simple-dom": "0.3.2",
-        "simple-html-tokenizer": "0.4.1"
+        "simple-html-tokenizer": "0.4.3"
       }
     },
     "ember-svg-jar": {
@@ -7067,9 +7174,9 @@
       }
     },
     "ember-try": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/ember-try/-/ember-try-0.2.16.tgz",
-      "integrity": "sha512-AQZEwMv6BIrVq/ysRcWULvw5tr6RQtUfSYuCpvtdxxJWho74d16YKhGyWAdID+QSmWHrVVGx+O1kDgjf7YKu9A==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/ember-try/-/ember-try-0.2.17.tgz",
+      "integrity": "sha1-D//2h2MCkbTPlPWxlucowaktiuw=",
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
@@ -7109,7 +7216,7 @@
       "dev": true,
       "requires": {
         "lodash": "4.17.4",
-        "node-fetch": "1.7.2",
+        "node-fetch": "1.7.3",
         "rsvp": "3.6.2",
         "semver": "5.4.1"
       },
@@ -7831,9 +7938,9 @@
       "dev": true
     },
     "etag": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
-      "integrity": "sha1-b2Ma7zNtbEY2K1F2QETOIWvjwFE=",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
     "event-emitter": {
@@ -7874,18 +7981,18 @@
       }
     },
     "exec-sh": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.0.tgz",
-      "integrity": "sha1-FPdd4/INKG75MwmbLOUKkDWc7xA=",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
+      "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
       "dev": true,
       "requires": {
         "merge": "1.2.0"
       }
     },
     "execa": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
+      "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
       "dev": true,
       "requires": {
         "cross-spawn": "5.1.0",
@@ -7913,12 +8020,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
-      "dev": true
-    },
-    "exit-hook": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
       "dev": true
     },
     "expand-brackets": {
@@ -7949,39 +8050,94 @@
       }
     },
     "express": {
-      "version": "4.15.4",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.15.4.tgz",
-      "integrity": "sha1-Ay4iU0ic+PzgJma+yj0R7XotrtE=",
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
+      "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
       "dev": true,
       "requires": {
         "accepts": "1.3.4",
         "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
-        "content-type": "1.0.2",
+        "content-type": "1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "depd": "1.1.1",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
-        "etag": "1.8.0",
-        "finalhandler": "1.0.4",
-        "fresh": "0.5.0",
+        "etag": "1.8.1",
+        "finalhandler": "1.1.0",
+        "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
         "methods": "1.1.2",
         "on-finished": "2.3.0",
-        "parseurl": "1.3.1",
+        "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "1.1.5",
-        "qs": "6.5.0",
+        "proxy-addr": "2.0.2",
+        "qs": "6.5.1",
         "range-parser": "1.2.0",
-        "send": "0.15.4",
-        "serve-static": "1.12.4",
-        "setprototypeof": "1.0.3",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.1",
+        "serve-static": "1.13.1",
+        "setprototypeof": "1.1.0",
         "statuses": "1.3.1",
         "type-is": "1.6.15",
-        "utils-merge": "1.0.0",
-        "vary": "1.1.1"
+        "utils-merge": "1.0.1",
+        "vary": "1.1.2"
+      },
+      "dependencies": {
+        "body-parser": {
+          "version": "1.18.2",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+          "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+          "dev": true,
+          "requires": {
+            "bytes": "3.0.0",
+            "content-type": "1.0.4",
+            "debug": "2.6.9",
+            "depd": "1.1.1",
+            "http-errors": "1.6.2",
+            "iconv-lite": "0.4.19",
+            "on-finished": "2.3.0",
+            "qs": "6.5.1",
+            "raw-body": "2.3.2",
+            "type-is": "1.6.15"
+          }
+        },
+        "bytes": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+          "dev": true
+        },
+        "content-type": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+          "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.19",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+          "dev": true
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+          "dev": true
+        }
       }
     },
     "extend": {
@@ -7991,20 +8147,20 @@
       "dev": true
     },
     "external-editor": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-1.1.1.tgz",
-      "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
+      "integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
       "dev": true,
       "requires": {
-        "extend": "3.0.1",
-        "spawn-sync": "1.0.15",
-        "tmp": "0.0.29"
+        "iconv-lite": "0.4.18",
+        "jschardet": "1.5.1",
+        "tmp": "0.0.33"
       },
       "dependencies": {
         "tmp": {
-          "version": "0.0.29",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
-          "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
+          "version": "0.0.33",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
           "dev": true,
           "requires": {
             "os-tmpdir": "1.0.2"
@@ -8156,7 +8312,7 @@
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
       "dev": true,
       "requires": {
-        "websocket-driver": "0.6.5"
+        "websocket-driver": "0.7.0"
       }
     },
     "fb-watchman": {
@@ -8169,13 +8325,12 @@
       }
     },
     "figures": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.1"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "file-entry-cache": {
@@ -8220,18 +8375,29 @@
       }
     },
     "finalhandler": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.4.tgz",
-      "integrity": "sha512-16l/r8RgzlXKmFOhZpHBztvye+lAhC5SU7hXavnerC9UfZqZxxXl3BzL8MhffPT3kF61lj9Oav2LKEzh0ei7tg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+      "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "on-finished": "2.3.0",
-        "parseurl": "1.3.1",
+        "parseurl": "1.3.2",
         "statuses": "1.3.1",
         "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "find-index": {
@@ -8354,15 +8520,15 @@
       }
     },
     "forwarded": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
-      "integrity": "sha1-Ge+YdMSuHCl7zweP3mOgm2aoQ2M=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
       "dev": true
     },
     "fresh": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
-      "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44=",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
     },
     "fs-exists-sync": {
@@ -8372,20 +8538,20 @@
       "dev": true
     },
     "fs-extra": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
-      "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
+      "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
-        "jsonfile": "3.0.1",
+        "jsonfile": "4.0.0",
         "universalify": "0.1.1"
       },
       "dependencies": {
         "jsonfile": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
-          "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11"
@@ -9628,9 +9794,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
-      "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
         "async": "1.5.2",
@@ -9910,6 +10076,12 @@
         "statuses": "1.3.1"
       }
     },
+    "http-parser-js": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.9.tgz",
+      "integrity": "sha1-6hoE+2St/wJC6ZdPKX3Uw8rSceE=",
+      "dev": true
+    },
     "http-proxy": {
       "version": "1.16.2",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
@@ -10072,32 +10244,92 @@
       }
     },
     "inquirer": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-1.2.3.tgz",
-      "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
+        "ansi-escapes": "3.0.0",
+        "chalk": "2.1.0",
+        "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
-        "external-editor": "1.1.1",
-        "figures": "1.7.0",
+        "external-editor": "2.0.5",
+        "figures": "2.0.0",
         "lodash": "4.17.4",
-        "mute-stream": "0.0.6",
-        "pinkie-promise": "2.0.1",
+        "mute-stream": "0.0.7",
         "run-async": "2.3.0",
-        "rx": "4.1.0",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
+        "rx-lite": "4.0.8",
+        "rx-lite-aggregates": "4.0.8",
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
         "through": "2.3.8"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.4.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
           "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
         }
       }
     },
@@ -10139,9 +10371,9 @@
       "dev": true
     },
     "ipaddr.js": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz",
-      "integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA=",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
+      "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A=",
       "dev": true
     },
     "is-arrayish": {
@@ -11202,6 +11434,15 @@
         "lodash.keys": "2.3.0"
       }
     },
+    "log-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+      "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3"
+      }
+    },
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
@@ -11598,9 +11839,9 @@
       }
     },
     "mout": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mout/-/mout-1.0.0.tgz",
-      "integrity": "sha1-m98dSvV9ZtR8s1OmM1oygQmOFQE=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mout/-/mout-1.1.0.tgz",
+      "integrity": "sha512-XsP0vf4As6BfqglxZqbqQ8SR6KQot2AgxvR0gG+WtUkf90vUXchMOZQtPf/Hml1rEffJupqL/tIrU6EYhsUQjw==",
       "dev": true
     },
     "ms": {
@@ -11616,9 +11857,9 @@
       "dev": true
     },
     "mute-stream": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
-      "integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s=",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
     "nan": {
@@ -11646,9 +11887,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.2.tgz",
-      "integrity": "sha512-xZZUq2yDhKMIn/UgG5q//IZSNLJIwW2QxS14CNH5spuiXkITM2pUitjdq58yLSaU7m4M0wBNaM2Gh/ggY4YJig==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "dev": true,
       "requires": {
         "encoding": "0.1.12",
@@ -11915,10 +12156,13 @@
       }
     },
     "onetime": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-      "dev": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "1.1.0"
+      }
     },
     "optimist": {
       "version": "0.6.1",
@@ -11967,15 +12211,15 @@
       "dev": true
     },
     "ora": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
-      "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-1.3.0.tgz",
+      "integrity": "sha1-gAeN0rkqk0r2ajrXKluRBpTt5Ro=",
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-spinners": "0.1.2",
-        "object-assign": "4.1.1"
+        "cli-cursor": "2.1.0",
+        "cli-spinners": "1.1.0",
+        "log-symbols": "1.0.2"
       }
     },
     "os-browserify": {
@@ -11998,12 +12242,6 @@
       "requires": {
         "lcid": "1.0.0"
       }
-    },
-    "os-shim": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
-      "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc=",
-      "dev": true
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -12225,9 +12463,9 @@
       }
     },
     "parseurl": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
-      "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
       "dev": true
     },
     "path-browserify": {
@@ -12532,13 +12770,13 @@
       }
     },
     "proxy-addr": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
-      "integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
+      "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
       "dev": true,
       "requires": {
-        "forwarded": "0.1.0",
-        "ipaddr.js": "1.4.0"
+        "forwarded": "0.1.2",
+        "ipaddr.js": "1.5.2"
       }
     },
     "proxy-agent": {
@@ -12597,9 +12835,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
-      "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
       "dev": true
     },
     "querystring": {
@@ -12733,19 +12971,27 @@
       "dev": true
     },
     "raw-body": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
-      "integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
       "dev": true,
       "requires": {
-        "bytes": "1.0.0",
-        "string_decoder": "0.10.31"
+        "bytes": "3.0.0",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.19",
+        "unpipe": "1.0.0"
       },
       "dependencies": {
         "bytes": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
-          "integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+          "dev": true
+        },
+        "iconv-lite": {
+          "version": "0.4.19",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
           "dev": true
         }
       }
@@ -13112,13 +13358,13 @@
       "dev": true
     },
     "restore-cursor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "exit-hook": "1.1.1",
-        "onetime": "1.1.0"
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
       }
     },
     "right-align": {
@@ -13190,12 +13436,6 @@
         "is-promise": "2.1.0"
       }
     },
-    "rx": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
-      "dev": true
-    },
     "rx-lite": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
@@ -13230,7 +13470,7 @@
       "dev": true,
       "requires": {
         "anymatch": "1.3.2",
-        "exec-sh": "0.2.0",
+        "exec-sh": "0.2.1",
         "fb-watchman": "2.0.0",
         "minimatch": "3.0.4",
         "minimist": "1.2.0",
@@ -13357,44 +13597,53 @@
       "dev": true
     },
     "send": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.15.4.tgz",
-      "integrity": "sha1-mF+qPihLAnPHkzZKNcZze9k5Bbk=",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
+      "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "depd": "1.1.1",
         "destroy": "1.0.4",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
-        "etag": "1.8.0",
-        "fresh": "0.5.0",
+        "etag": "1.8.1",
+        "fresh": "0.5.2",
         "http-errors": "1.6.2",
-        "mime": "1.3.4",
+        "mime": "1.4.1",
         "ms": "2.0.0",
         "on-finished": "2.3.0",
         "range-parser": "1.2.0",
         "statuses": "1.3.1"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "mime": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-          "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
           "dev": true
         }
       }
     },
     "serve-static": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.4.tgz",
-      "integrity": "sha1-m2qpjutyU8Tu3Ewfb9vKYJkBqWE=",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
+      "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
       "dev": true,
       "requires": {
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
-        "parseurl": "1.3.1",
-        "send": "0.15.4"
+        "parseurl": "1.3.2",
+        "send": "0.16.1"
       }
     },
     "set-blocking": {
@@ -13515,9 +13764,9 @@
       }
     },
     "simple-html-tokenizer": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.4.1.tgz",
-      "integrity": "sha1-AomIu3/osuZkVnbYIFJYfUQLAtM=",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.4.3.tgz",
+      "integrity": "sha512-OpUzgR+P/Qsu6ztZehr4PxvTbV4sDW91hAqc2tnz4fjuFTqErWIUdUMbnzX+19F4IEpSSfa0vCAz5xJSs0LpPw==",
       "dev": true
     },
     "simple-is": {
@@ -13812,16 +14061,6 @@
       "resolved": "https://registry.npmjs.org/spawn-args/-/spawn-args-0.2.0.tgz",
       "integrity": "sha1-+30L0dcP1DFr2ePew4nmX51jYbs=",
       "dev": true
-    },
-    "spawn-sync": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
-      "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
-      "dev": true,
-      "requires": {
-        "concat-stream": "1.5.2",
-        "os-shim": "0.1.3"
-      }
     },
     "spdx-correct": {
       "version": "1.0.2",
@@ -14215,12 +14454,12 @@
       "dev": true,
       "requires": {
         "backbone": "1.3.3",
-        "bluebird": "3.5.0",
+        "bluebird": "3.5.1",
         "charm": "1.0.2",
         "commander": "2.11.0",
         "consolidate": "0.14.5",
         "cross-spawn": "5.1.0",
-        "express": "4.15.4",
+        "express": "4.16.2",
         "fireworm": "0.7.1",
         "glob": "7.1.2",
         "http-proxy": "1.16.2",
@@ -14243,9 +14482,9 @@
       },
       "dependencies": {
         "bluebird": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
           "dev": true
         }
       }
@@ -14317,7 +14556,7 @@
         "faye-websocket": "0.10.0",
         "livereload-js": "2.2.2",
         "object-assign": "4.1.1",
-        "qs": "6.5.0"
+        "qs": "6.5.1"
       }
     },
     "tmp": {
@@ -14482,6 +14721,7 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
+      "optional": true,
       "requires": {
         "source-map": "0.5.6",
         "uglify-to-browserify": "1.0.2",
@@ -14492,13 +14732,15 @@
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
           "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yargs": {
           "version": "3.10.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "camelcase": "1.2.1",
             "cliui": "2.1.0",
@@ -14627,9 +14869,9 @@
       "dev": true
     },
     "utils-merge": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
     },
     "uuid": {
@@ -14658,9 +14900,9 @@
       }
     },
     "vary": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
-      "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
     },
     "verror": {
@@ -14739,18 +14981,19 @@
       "optional": true
     },
     "websocket-driver": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
-      "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
+      "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "dev": true,
       "requires": {
-        "websocket-extensions": "0.1.1"
+        "http-parser-js": "0.4.9",
+        "websocket-extensions": "0.1.2"
       }
     },
     "websocket-extensions": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
-      "integrity": "sha1-domUmcGEtu91Q3fC27DNbLVdKec=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.2.tgz",
+      "integrity": "sha1-Dhh4HeYpoYMIzhSBZQ9n/6JpOl0=",
       "dev": true
     },
     "whatwg-url-compat": {

--- a/package.json
+++ b/package.json
@@ -1,19 +1,20 @@
 {
   "name": "travis",
   "version": "0.0.0",
+  "private": true,
   "description": "Small description for travis goes here",
+  "license": "MIT",
+  "author": "Travis CI Web Team and Contributors",
   "directories": {
     "doc": "doc",
     "test": "tests"
   },
+  "repository": "https://github.com/travis-ci/travis-web",
   "scripts": {
     "build": "ember build",
     "start": "ember server",
     "test": "ember test --reporter dot"
   },
-  "repository": "https://github.com/travis-ci/travis-web",
-  "license": "MIT",
-  "author": "Travis CI Web Team and Contributors",
   "devDependencies": {
     "active-model-adapter": "2.1.1",
     "ansiparse": "0.1.0",
@@ -25,7 +26,7 @@
     "broccoli-merge-trees": "^2.0.0",
     "ember-ajax": "3.0.0",
     "ember-browserify": "^1.1.13",
-    "ember-cli": "2.15.0",
+    "ember-cli": "~2.16.2",
     "ember-cli-app-version": "^3.0.0",
     "ember-cli-autoprefixer": "^0.7.0",
     "ember-cli-babel": "6.8.2",
@@ -49,9 +50,9 @@
     "ember-cli-shims": "^1.1.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^2.1.0",
-    "ember-cli-uglify": "^1.2.0",
+    "ember-cli-uglify": "^2.0.0",
     "ember-concurrency": "0.8.7",
-    "ember-data": "2.15.0",
+    "ember-data": "~2.16.2",
     "ember-data-filter": "1.13.0",
     "ember-decorators": "1.2.2",
     "ember-disable-proxy-controllers": "^1.0.1",
@@ -68,8 +69,7 @@
     "ember-qunit-nice-errors": "1.1.2",
     "ember-resolver": "4.1.0",
     "ember-route-action-helper": "^2.0.3",
-    "ember-router-service-polyfill": "^1.0.1",
-    "ember-source": "2.15.0",
+    "ember-source": "~2.16.0",
     "ember-svg-jar": "^0.10.3",
     "ember-test-assets": "^1.1.0",
     "ember-tether": "^1.0.0-beta.0",
@@ -86,6 +86,5 @@
   "engines": {
     "node": "8.5.0",
     "npm": "5.4.2"
-  },
-  "private": true
+  }
 }

--- a/testem.js
+++ b/testem.js
@@ -1,12 +1,22 @@
 /* eslint-env node */
-
 module.exports = {
-  framework: 'qunit',
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
-  launch_in_ci: ['Chrome'],
-  launch_in_dev: ['Chrome'],
+  launch_in_ci: [
+    'Chrome'
+  ],
+  launch_in_dev: [
+    'Chrome'
+  ],
   browser_args: {
-    'Chrome': ['--headless', '--disable-gpu', '--remote-debugging-port=9222'],
-  },
+    Chrome: {
+      mode: 'ci',
+      args: [
+        '--disable-gpu',
+        '--headless',
+        '--remote-debugging-port=9222',
+        '--window-size=1440,900'
+      ]
+    },
+  }
 };

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -1,5 +1,5 @@
-import { resolve } from 'rsvp';
 import { module } from 'qunit';
+import { resolve } from 'rsvp';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
 import '../helpers/percy/register-helpers';

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,14 +1,12 @@
-import { run } from '@ember/runloop';
-import { merge } from '@ember/polyfills';
 import Application from '../../app';
 import config from '../../config/environment';
+import { merge } from '@ember/polyfills';
+import { run } from '@ember/runloop';
 
 import './sign-in-user';
 import './wait-for-element';
 
 export default function startApp(attrs) {
-  let application;
-
   let attributes = merge({}, config.APP);
   attributes = merge(attributes, attrs); // use defaults, but you can override;
 
@@ -21,7 +19,7 @@ export default function startApp(attrs) {
   clearStorage(sessionStorage);
 
   return run(() => {
-    application = Application.create(attributes);
+    let application = Application.create(attributes);
     application.setupForTesting();
     application.injectTestHelpers();
     return application;


### PR DESCRIPTION
I removed ember-router-service-polyfill, as advised by a notification
while building.

This includes some simple line-switchings where the modules codemod
put things in a different order than the blueprints. I also replaced
testem.js with the blueprint version because our differences were
negligible, might as well reduce friction during updates.