### PR TITLE
Remove deprecated alias

### DIFF
--- a/app/controllers/repo.js
+++ b/app/controllers/repo.js
@@ -21,7 +21,7 @@ export default Controller.extend({
   @alias('repositories.accessible') repos: null,
   @alias('auth.currentUser') currentUser: null,
   @alias('buildController.build') build: null,
-  @alias('buildsController.content') builds: null,
+  @alias('buildsController.model') builds: null,
   @alias('jobController.job') job: null,
 
   classNames: ['repo'],


### PR DESCRIPTION
This will be removed in Ember 2.17. I think it‘s the only one…
https://emberjs.com/deprecations/v2.x/#toc_controller-content-alias