### PR TITLE
fullscreen logs button

### DIFF
--- a/app/components/log-content.js
+++ b/app/components/log-content.js
@@ -72,8 +72,9 @@ export default Component.extend({
   @service permissions: null,
   @service externalLinks: null,
 
-  classNameBindings: ['logIsVisible:is-open'],
+  classNameBindings: ['logIsVisible:is-open', 'isFullScreenLog:is-fullscreen'],
   logIsVisible: false,
+  isFullScreenLog: false,
 
   @alias('auth.currentUser') currentUser: null,
 
@@ -237,7 +238,11 @@ export default Component.extend({
   actions: {
     toTop() {
       Travis.tailing.stop();
-      return $(window).scrollTop(0);
+      if (this.get('isFullScreenLog')) {
+        return $('.log').scrollTop(0);
+      } else {
+        return $(window).scrollTop(0);
+      }
     },
 
     toggleTailing() {
@@ -252,6 +257,10 @@ export default Component.extend({
 
     toggleRemoveLogModal() {
       this.toggleProperty('isShowingRemoveLogModal');
+    },
+
+    toggleFullScreenLog() {
+      this.toggleProperty('isFullScreenLog');
     }
   },
 

--- a/app/styles/app/layouts/log.sass
+++ b/app/styles/app/layouts/log.sass
@@ -1,3 +1,16 @@
+.is-fullscreen
+  .log
+    position: fixed
+    top: 0
+    bottom: 0
+    left: 0
+    right: 0
+    width: 100%
+    height: 100vh
+    overflow: scroll
+    background-color: $color-bg-log-fold
+    +z-index(dialog)
+
 .log
   position: relative
 
@@ -81,17 +94,11 @@
   padding: .7em .8em .6em
   text-align: right
   background-color: $log-header-bg
-
   @media #{$small-only}
     display: flex
-  a
-    margin-left: .4em
-    @media #{$small-only}
-      flex-grow: 1
 
 .log-main
   display: none
-  margin-bottom: 5em
   &.is-visible
     display: block
   @media #{$medium-up}
@@ -120,7 +127,7 @@
     border-color: $oxide-blue
     color: $oxide-blue
     +colorSVG($oxide-blue)
-.toggle-log-button--dark
+.toggle-log-button--dark,
   @extend %log-button
   width: 50%
   background-color: transparent
@@ -143,7 +150,7 @@
     word-wrap: break-word
     background-color: $color-bg-log-fold
     counter-reset: line-numbering
-    margin-top: 0
+    margin: 0
 
   .cut
     padding: 20px 15px 0 55px

--- a/app/styles/app/modules/buttons.sass
+++ b/app/styles/app/modules/buttons.sass
@@ -175,7 +175,8 @@
   @media #{$medium-up}
     display: inline-block
 
-.download-log-button
+.download-log-button,
+.fullscreen-log-button
   @extend %log-button
   &:hover,
   &:active

--- a/app/templates/components/log-content.hbs
+++ b/app/templates/components/log-content.hbs
@@ -5,20 +5,22 @@
   {{/if}}
 
   <div class="log-container {{if job.notStarted 'hidden'}}">
-      <button type="button" class="toggle-log-button {{if logIsVisible 'hidden'}}" title="Display the log" {{action "toggleLog"}}>
+    <button type="button" class="toggle-log-button {{if logIsVisible 'hidden'}}" title="Display the log" {{action "toggleLog"}}>
       {{svg-jar 'icon-seemore' class="icon"}}
       <span class="label-align">View log</span></button>
 
     <div class="log-main {{if logIsVisible 'is-visible'}} {{if job.notStarted 'hidden'}}">
       <div class="log-header">
-          <button type="button" class="toggle-log-button--dark {{unless logIsVisible 'hidden'}}" title="Display the log" {{action "toggleLog"}}>
-              {{svg-jar 'icon-seemore' class="icon"}}<span class="label-align">Hide log</span></button>
+        <button type="button" class="toggle-log-button--dark {{unless logIsVisible 'hidden'}}" title="Display the log" {{action "toggleLog"}}>
+          {{svg-jar 'icon-seemore' class="icon"}}<span class="label-align">Hide log</span></button>
         {{#if canRemoveLog}}
           <button class="remove-log-button open-popup" {{action "toggleRemoveLogModal"}} title="Remove the log" type="button">
             {{svg-jar 'icon-deletelogs' class="icon"}} Remove log</button>
         {{/if}}
         <a class="download-log-button" href={{plainTextLogUrl}} title="Display the log in plaintext">
           {{svg-jar 'icon-downloadlogs' class="icon"}} Raw log</a>
+        <button type="button" class="fullscreen-log-button" title="Show logs full screen" {{action "toggleFullScreenLog"}}>
+          {{svg-jar 'icon-seemore' class="icon"}}<span class="label-align">Fullscreen log</span></button>
       </div>
       <div class="log-body">
         {{#if showTailing}}


### PR DESCRIPTION
I couldn't figure out how to make log tailing work in fullscreen mode.
Other than that it seems to work.

![screen shot 2017-10-18 at 15 06 05](https://user-images.githubusercontent.com/1006478/31720101-ec0f3c38-b415-11e7-8a6e-5773c438bf1b.png)

Video of the button:

[fullscreen-logs.webm.zip](https://github.com/travis-ci/travis-web/files/1394680/fullscreen-logs.webm.zip)