### PR TITLE
fix white-space in extra colored logs

### DIFF
--- a/app/styles/app/layouts/log.sass
+++ b/app/styles/app/layouts/log.sass
@@ -153,6 +153,7 @@
     padding: 0 15px 0 55px
     margin: 0
     min-height: 16px
+    white-space: normal
     &:hover
       background-color: $color-bg-log-hover !important
     &.highlight


### PR DESCRIPTION
Turns 

![screen shot 2017-10-20 at 11 43 45](https://user-images.githubusercontent.com/1006478/31815137-1e204290-b58c-11e7-908c-1e9c652bc5a2.png)

into

![screen shot 2017-10-20 at 11 43 50](https://user-images.githubusercontent.com/1006478/31815141-205aca58-b58c-11e7-887d-f748d0502d07.png)
