### PR TITLE
Load pusher data from api when needed

### DIFF
--- a/app/adapters/build.js
+++ b/app/adapters/build.js
@@ -7,5 +7,15 @@ export default V3Adapter.extend({
     if (type === 'query' && query.repository_id) {
       return `repo/${query.repository_id}`;
     }
+  },
+
+  buildURL(modelName, id, snapshot, requestType, query) {
+    if (requestType == 'queryRecord' && query.id) {
+      let id = query.id;
+      delete query.id;
+      return this._super(modelName, id, snapshot, 'findRecord', query);
+    } else {
+      return this._super(...arguments);
+    }
   }
 });

--- a/app/adapters/v3.js
+++ b/app/adapters/v3.js
@@ -57,7 +57,7 @@ export default RESTAdapter.extend({
     return hash;
   },
 
-  buildURL: function (modelName, id) {
+  buildURL: function (modelName, id, snapshot, requestType, query) {
     let url = [];
     const host = get(this, 'host');
     const prefix = this.urlPrefix();

--- a/app/instance-initializers/pusher.js
+++ b/app/instance-initializers/pusher.js
@@ -11,6 +11,7 @@ export function initialize(applicationInstance) {
   app.inject('route', 'pusher', 'pusher:main');
   app.inject('component', 'pusher', 'pusher:main');
   app.pusher.store = applicationInstance.lookup('service:store');
+  app.pusher.pusherService = applicationInstance.lookup('service:pusher');
 }
 
 export default {

--- a/app/services/live-updates-record-fetcher.js
+++ b/app/services/live-updates-record-fetcher.js
@@ -1,0 +1,76 @@
+import Service from '@ember/service';
+import { task, timeout } from 'ember-concurrency';
+import config from 'travis/config/environment';
+import { service } from 'ember-decorators/service';
+
+/*
+ * travis-live doesn't always send full payload. In such a situation we need to
+ * query the API, but ideally we don't want to flood it with requests. This
+ * service saves all the records that we need to fetch and flushes the list
+ * after a specified time. That way if a few updates for jobs for the same build
+ * are sent one after another, we will still send only one query.
+ */
+export default Service.extend({
+  @service store: null,
+
+  init() {
+    this.recordsToFetch = [];
+
+    return this._super(...arguments);
+  },
+
+  fetch(type, id, payload = {}) {
+    this.recordsToFetch.push({ type: type, id: id, payload: payload });
+    this.get('flushPusherFetches').perform();
+  },
+
+  flushPusherFetches: task(function* () {
+    let interval = this.get('interval') ||
+      config.intervals.fetchRecordsForPusherUpdatesThrottle;
+
+    yield timeout(interval);
+
+    this.fetchRecordsFromPusher();
+  }).drop(),
+
+  fetchRecordsFromPusher() {
+    let recordsToFetch = this.recordsToFetch;
+    this.recordsToFetch = [];
+
+    let jobsByBuildId = {};
+    let buildIds = [];
+
+    recordsToFetch.forEach((data) => {
+      let id = parseInt(data.id);
+      if (data.type == 'job') {
+        let buildId = data.payload.build_id;
+        jobsByBuildId[buildId] = jobsByBuildId[buildId] || [];
+        if (!jobsByBuildId[buildId].includes(id)) {
+          jobsByBuildId[buildId].push(id);
+        }
+      } else if (data.type == 'build' && !buildIds.includes(id)) {
+        buildIds.push(id);
+      }
+    });
+
+    Object.keys(jobsByBuildId).forEach((buildId) => {
+      buildId = parseInt(buildId);
+      let jobsData = jobsByBuildId[buildId];
+      let needToFetchBuild = buildIds.includes(buildId);
+
+      // if we need to fetch build anyway or if we have more than one build,
+      // just query for the build with jobs included
+      if (needToFetchBuild || jobsData.length > 1) {
+        let index = buildIds.indexOf(buildId);
+        buildIds.splice(index, 1);
+        this.get('store').queryRecord('build', { id: buildId, include: 'build.jobs' });
+      } else {
+        this.get('store').findRecord('job', jobsData[0], { reload: true });
+      }
+    });
+
+    buildIds.forEach((id) => {
+      this.get('store').findRecord('build', id, { reload: true });
+    });
+  }
+});

--- a/app/services/pusher.js
+++ b/app/services/pusher.js
@@ -1,0 +1,111 @@
+import Service from '@ember/service';
+import { later } from '@ember/runloop';
+import config from 'travis/config/environment';
+import { service } from 'ember-decorators/service';
+
+export default Service.extend({
+  @service store: null,
+  @service liveUpdatesRecordFetcher: null,
+
+  receive(event, data) {
+    let build, commit, job;
+    let store = this.get('store');
+    let [name, type] = event.split(':');
+
+    if (name === 'job' && data.job && data.job.commit) {
+      store.push(store.normalize('commit', data.job.commit));
+    }
+
+    if (name === 'build' && data.build && data.build.commit) {
+      build = data.build;
+      commit = {
+        id: build.commit_id,
+        author_email: build.author_email,
+        author_name: build.author_name,
+        branch: build.branch,
+        committed_at: build.committed_at,
+        committer_email: build.committer_email,
+        committer_name: build.committer_name,
+        compare_url: build.compare_url,
+        message: build.message,
+        sha: build.commit
+      };
+      delete data.build.commit;
+      store.push(store.normalize('commit', commit));
+    }
+
+    if (name === 'branch') {
+      // force reload of repo branches
+      // delay to resolve race between github-sync and live
+      const branchName = data.branch;
+
+      later(() => {
+        store.findRecord('branch', `/repo/${data.repository_id}/branch/${branchName}`);
+      }, config.intervals.branchCreatedSyncDelay);
+
+      delete data.branch;
+    }
+
+    if (event === 'job:log') {
+      data = data.job;
+      job = store.recordForId('job', data.id);
+      return job.appendLog({
+        number: parseInt(data.number),
+        content: data._log,
+        final: data.final
+      });
+    } else if (data[name]) {
+      if (data._no_full_payload) {
+        // if payload is too big, travis-live will send us only the id of the
+        // object or id with build_id for jobs. If that happens, just load the
+        // object from the API
+        let payload = {};
+        if (name === 'job') {
+          payload['build_id'] = data.job.build_id;
+        }
+        this.get('liveUpdatesRecordFetcher').fetch(name, data[name].id, payload);
+      } else {
+        return this.loadOne(name, data);
+      }
+    } else {
+      if (!type) {
+        throw `can't load data for ${name}`;
+      }
+    }
+  },
+
+  loadOne(type, json) {
+    let data, defaultBranch, lastBuildId;
+    let store = this.get('store');
+
+    store.push(store.normalize(type, json));
+
+    // we get other types of records only in a few situations and
+    // it's not always needed to update data, so I'm specyfing which
+    // things I want to update here:
+    if (type === 'build' && (json.repository || json.repo)) {
+      data = json.repository || json.repo;
+      defaultBranch = data.default_branch;
+      if (defaultBranch) {
+        defaultBranch.default_branch = true;
+        defaultBranch['@href'] = `/repo/${data.id}/branch/${defaultBranch.name}`;
+      }
+      lastBuildId = defaultBranch.last_build_id;
+
+      // a build is a synchronous relationship on a branch model, so we need to
+      // have a build record present when we put default_branch from a repository
+      // model into the store. We don't send last_build's payload in pusher, so
+      // we need to get it here, if it's not already in the store. In the future
+      // we may decide to make this relationship async, but I don't want to
+      // change the code at the moment
+      let lastBuild = store.peekRecord('build', lastBuildId);
+      if (!lastBuildId || lastBuild) {
+        return store.push(store.normalize('repo', data));
+      } else {
+        return store.findRecord('build', lastBuildId).then(() => {
+          store.push(store.normalize('repo', data));
+        });
+      }
+    }
+  }
+});

--- a/app/services/store.js
+++ b/app/services/store.js
@@ -16,7 +16,6 @@ export default DS.Store.extend({
   init() {
     this._super(...arguments);
     this.filteredArraysManager = FilteredArrayManager.create({ store: this });
-    return this.set('pusherEventHandlerGuards', {});
   },
 
   // Fetch a filtered collection.
@@ -127,37 +126,11 @@ export default DS.Store.extend({
     }
   },
 
-  addPusherEventHandlerGuard(name, callback) {
-    return this.get('pusherEventHandlerGuards')[name] = callback;
-  },
-
-  removePusherEventHandlerGuard(name) {
-    return delete this.get('pusherEventHandlerGuards')[name];
-  },
-
-  canHandleEvent(event, data) {
-    let callback, name, ref, ref1;
-    ref = event.split(':');
-    name = ref[0];
-    ref1 = this.get('pusherEventHandlerGuards');
-    for (name in ref1) {
-      callback = ref1[name];
-      if (!callback(event, data)) {
-        return false;
-      }
-    }
-    return true;
-  },
-
   receivePusherEvent(event, data) {
     let build, commit, job, name, ref, ref1, ref2, type;
     ref = event.split(':');
     name = ref[0];
     type = ref[1];
-
-    if (!this.canHandleEvent(event, data)) {
-      return;
-    }
 
     if (name === 'job' && ((ref1 = data.job) != null ? ref1.commit : void 0)) {
       this.push(this.normalize('commit', data.job.commit));

--- a/app/services/store.js
+++ b/app/services/store.js
@@ -1,8 +1,6 @@
 /* eslint-disable camelcase */
-import { later } from '@ember/runloop';
 import DS from 'ember-data';
 import PaginatedCollectionPromise from 'travis/utils/paginated-collection-promise';
-import config from 'travis/config/environment';
 import { service } from 'ember-decorators/service';
 import FilteredArrayManager from 'travis/utils/filtered-array-manager';
 import fetchLivePaginatedCollection from 'travis/utils/fetch-live-paginated-collection';
@@ -123,97 +121,6 @@ export default DS.Store.extend({
       return PaginatedCollectionPromise.create({
         content: this.query(...arguments)
       });
-    }
-  },
-
-  receivePusherEvent(event, data) {
-    let build, commit, job, name, ref, ref1, ref2, type;
-    ref = event.split(':');
-    name = ref[0];
-    type = ref[1];
-
-    if (name === 'job' && ((ref1 = data.job) != null ? ref1.commit : void 0)) {
-      this.push(this.normalize('commit', data.job.commit));
-    }
-
-    if (name === 'build' && ((ref2 = data.build) != null ? ref2.commit : void 0)) {
-      build = data.build;
-      commit = {
-        id: build.commit_id,
-        author_email: build.author_email,
-        author_name: build.author_name,
-        branch: build.branch,
-        committed_at: build.committed_at,
-        committer_email: build.committer_email,
-        committer_name: build.committer_name,
-        compare_url: build.compare_url,
-        message: build.message,
-        sha: build.commit
-      };
-      delete data.build.commit;
-      this.push(this.normalize('commit', commit));
-    }
-
-    if (name === 'branch') {
-      // force reload of repo branches
-      // delay to resolve race between github-sync and live
-      const branchName = data.branch;
-
-      later(() => {
-        this.findRecord('branch', `/repo/${data.repository_id}/branch/${branchName}`);
-      }, config.intervals.branchCreatedSyncDelay);
-
-      delete data.branch;
-    }
-
-    if (event === 'job:log') {
-      data = data.job;
-      job = this.recordForId('job', data.id);
-      return job.appendLog({
-        number: parseInt(data.number),
-        content: data._log,
-        final: data.final
-      });
-    } else if (data[name]) {
-      return this.loadOne(name, data);
-    } else {
-      if (!type) {
-        throw `can't load data for ${name}`;
-      }
-    }
-  },
-
-  loadOne(type, json) {
-    let data, default_branch, last_build_id;
-
-    this.push(this.normalize(type, json));
-
-    // we get other types of records only in a few situations and
-    // it's not always needed to update data, so I'm specyfing which
-    // things I want to update here:
-    if (type === 'build' && (json.repository || json.repo)) {
-      data = json.repository || json.repo;
-      default_branch = data.default_branch;
-      if (default_branch) {
-        default_branch.default_branch = true;
-        default_branch['@href'] = `/repo/${data.id}/branch/${default_branch.name}`;
-      }
-      last_build_id = default_branch.last_build_id;
-
-      // a build is a synchronous relationship on a branch model, so we need to
-      // have a build record present when we put default_branch from a repository
-      // model into the store. We don't send last_build's payload in pusher, so
-      // we need to get it here, if it's not already in the store. In the future
-      // we may decide to make this relationship async, but I don't want to
-      // change the code at the moment
-      let lastBuild = this.peekRecord('build', last_build_id);
-      if (!last_build_id || lastBuild) {
-        return this.push(this.normalize('repo', data));
-      } else {
-        return this.findRecord('build', last_build_id).then(() => {
-          this.push(this.normalize('repo', data));
-        });
-      }
     }
   }
 });

--- a/app/utils/pusher.js
+++ b/app/utils/pusher.js
@@ -94,11 +94,8 @@ TravisPusher.prototype.receive = function (event, data) {
       job.clearLog();
     }
   }
-  return next((function (_this) {
-    return function () {
-      return _this.store.receivePusherEvent(event, data);
-    };
-  })(this));
+
+  next(() => this.pusherService.receive(event, data));
 };
 
 TravisPusher.prototype.normalize = function (event, data) {
@@ -118,7 +115,8 @@ TravisPusher.prototype.normalize = function (event, data) {
         data.queue = data.queue.replace('builds.', '');
       }
       return {
-        job: data
+        job: data,
+        _no_full_payload: data._no_full_payload
       };
     case 'worker:added':
     case 'worker:updated':

--- a/config/environment.js
+++ b/config/environment.js
@@ -37,7 +37,8 @@ module.exports = function (environment) {
       updateTimes: 1000,
       branchCreatedSyncDelay: 2000,
       repositorySearchDebounceRate: 500,
-      triggerBuildRequestDelay: 3000
+      triggerBuildRequestDelay: 3000,
+      fetchRecordsForPusherUpdatesThrottle: 1000
     },
     githubOrgsOauthAccessSettingsUrl: 'https://github.com/settings/connections/applications/f244293c729d5066cf27',
     ajaxPolling: false,
@@ -90,6 +91,14 @@ module.exports = function (environment) {
 
     if (process.env.API_ENDPOINT) {
       ENV.apiEndpoint = process.env.API_ENDPOINT;
+
+      if (ENV.apiEndpoint === 'https://api-staging.travis-ci.org') {
+        ENV.pusher.key = 'dd3f11c013317df48b50';
+      }
+
+      if (ENV.apiEndpoint === 'https://api-staging.travis-ci.com') {
+        ENV.pusher.key = '87d0723b25c51e36def8';
+      }
     }
 
     if (process.env.AUTH_ENDPOINT) {
@@ -114,6 +123,7 @@ module.exports = function (environment) {
     ENV.intervals.searchDebounceRate = 0;
     ENV.intervals.branchCreatedSyncDelay = 0;
     ENV.intervals.triggerBuildRequestDelay = 0;
+    ENV.intervals.fetchRecordsForPusherUpdatesThrottle = 0;
 
     ENV.APP.rootElement = '#ember-testing';
 

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "ember-qunit-nice-errors": "1.1.2",
     "ember-resolver": "4.1.0",
     "ember-route-action-helper": "^2.0.3",
+    "ember-sinon": "^1.0.1",
     "ember-source": "~2.16.0",
     "ember-svg-jar": "^0.10.3",
     "ember-test-assets": "^1.1.0",

--- a/tests/unit/services/live-updates-record-fetcher-test.js
+++ b/tests/unit/services/live-updates-record-fetcher-test.js
@@ -1,0 +1,116 @@
+import Service from '@ember/service';
+import { moduleFor, test } from 'ember-qunit';
+import sinon from 'sinon';
+
+moduleFor('service:live-updates-record-fetcher', 'Unit | Service | live updates record fetcher', {
+  needs: [],
+  beforeEach() {
+    this.register('service:store', Service.extend({
+      queryRecord() {},
+      findRecord() {},
+    }));
+  }
+});
+
+test('it fetches single job records when requests can not be grouped', function (assert) {
+  let service = this.subject({ interval: 5 }),
+    store = service.get('store'),
+    done  = assert.async(),
+    findRecordSpy = sinon.spy(store, 'findRecord'),
+    queryRecordSpy = sinon.spy(store, 'queryRecord');
+
+  service.fetch('job', 1, { build_id: 1 });
+  service.fetch('job', 2, { build_id: 2 });
+
+  setTimeout(() => {
+    done();
+
+    assert.equal(0, queryRecordSpy.getCalls().length, 'queryRecord should not have been called');
+    assert.equal(2, findRecordSpy.getCalls().length, 'findRecord should have been called 2 times');
+    assert.deepEqual(['job', 1, { reload: true }], findRecordSpy.getCall(0).args);
+    assert.deepEqual(['job', 2, { reload: true }], findRecordSpy.getCall(1).args);
+  }, 10);
+});
+
+test('it fetches build records and not job records when builds need to be fetched anyway', function (assert) {
+  let service = this.subject({ interval: 5 }),
+    store = service.get('store'),
+    done  = assert.async(),
+    findRecordSpy = sinon.spy(store, 'findRecord'),
+    queryRecordSpy = sinon.spy(store, 'queryRecord');
+
+  service.fetch('job', 1, { build_id: 1 });
+  service.fetch('build', 1);
+  service.fetch('job', 2, { build_id: 2 });
+
+  setTimeout(() => {
+    done();
+
+    assert.equal(1, queryRecordSpy.getCalls().length, 'queryRecord should have been called 1 time');
+    assert.equal(1, findRecordSpy.getCalls().length, 'findRecord should have been called 1 time');
+    assert.deepEqual(['job', 2, { reload: true }], findRecordSpy.getCall(0).args);
+    assert.deepEqual(['build', { id: 1, include: 'build.jobs' }], queryRecordSpy.getCall(0).args);
+  }, 10);
+});
+
+test('it groups job records when there are at leat 2 for one build', function (assert) {
+  let service = this.subject({ interval: 5 }),
+    store = service.get('store'),
+    done  = assert.async(),
+    findRecordSpy = sinon.spy(store, 'findRecord'),
+    queryRecordSpy = sinon.spy(store, 'queryRecord');
+
+  service.fetch('job', 1, { build_id: 1 });
+  service.fetch('job', 2, { build_id: 1 });
+
+  setTimeout(() => {
+    done();
+
+    assert.equal(1, queryRecordSpy.getCalls().length, 'queryRecord should have been called 1 time');
+    assert.equal(0, findRecordSpy.getCalls().length, 'findRecord should not have been called');
+    assert.deepEqual(['build', { id: 1, include: 'build.jobs' }], queryRecordSpy.getCall(0).args);
+  }, 10);
+});
+
+test('it ignores duplicated calls', function (assert) {
+  let service = this.subject({ interval: 5 }),
+    store = service.get('store'),
+    done  = assert.async(),
+    findRecordSpy = sinon.spy(store, 'findRecord'),
+    queryRecordSpy = sinon.spy(store, 'queryRecord');
+
+  service.fetch('build', 1);
+  service.fetch('build', 1);
+  service.fetch('build', 1);
+  service.fetch('build', 1);
+
+  setTimeout(() => {
+    done();
+
+    assert.equal(0, queryRecordSpy.getCalls().length, 'queryRecord should not have been called');
+    assert.equal(1, findRecordSpy.getCalls().length, 'findRecord should have been called 1 time');
+    assert.deepEqual(['build', 1, { reload: true }], findRecordSpy.getCall(0).args);
+  }, 10);
+});
+
+test('it throttles with given interval', function (assert) {
+  let service = this.subject({ interval: 20 }),
+    store = service.get('store'),
+    done  = assert.async(),
+    findRecordSpy = sinon.spy(store, 'findRecord'),
+    queryRecordSpy = sinon.spy(store, 'queryRecord');
+
+  service.fetch('build', 1);
+
+  setTimeout(() => {
+    service.fetch('build', 1);
+
+    setTimeout(() => {
+      done();
+
+      assert.equal(0, queryRecordSpy.getCalls().length, 'queryRecord should not have been called');
+      assert.equal(2, findRecordSpy.getCalls().length, 'findRecord should have been called 2 times');
+      assert.deepEqual(['build', 1, { reload: true }], findRecordSpy.getCall(0).args);
+    }, 30);
+  }, 30);
+});


### PR DESCRIPTION
travis-live doesn't always have the ability to send full payloads. This PR addresses situations where only ids are sent