### PR TITLE
add yellow circle for maintenance status page status

### DIFF
--- a/app/styles/app/layouts/footer.sass
+++ b/app/styles/app/layouts/footer.sass
@@ -65,6 +65,8 @@
   vertical-align: middle
   &.none
     background: $turf-green
+  &.maintenance
+    background: $dozer-yellow
   &.degraded
     background: $dozer-yellow
   &.minor


### PR DESCRIPTION
That should fix this:

<img width="182" alt="screen shot 2017-11-03 at 10 01 05" src="https://user-images.githubusercontent.com/11158255/32366328-f034e51e-c07d-11e7-9f2a-a0cdb81f1c58.png">

And make it look more like this:

<img width="175" alt="screen shot 2017-11-03 at 10 02 09" src="https://user-images.githubusercontent.com/11158255/32366363-164ede1c-c07e-11e7-888b-4c8e936e8345.png">
