### PR TITLE
Don't update records with stale data

### DIFF
--- a/app/models/build.js
+++ b/app/models/build.js
@@ -30,6 +30,7 @@ export default Model.extend(DurationCalculations, {
   tag: attr(),
   eventType: attr('string'),
   _config: attr(),
+  updatedAt: attr('date'),
 
   repo: belongsTo('repo'),
   branch: belongsTo('branch', { async: false, inverse: 'builds' }),

--- a/app/models/job.js
+++ b/app/models/job.js
@@ -29,6 +29,7 @@ export default Model.extend(DurationCalculations, DurationAttributes, {
   tags: attr(),
   repositoryPrivate: attr(),
   repositorySlug: attr(),
+  updatedAt: attr('date'),
 
   repo: belongsTo('repo'),
   build: belongsTo('build', { async: true }),


### PR DESCRIPTION
From the commit message:

```
Data updates doesn't arrive to the browser in any specific order.
Because of that it's possible that data in an update delivered by
Pusher is older than data that we have available locally.

This commit overrides `store._pushInternalModel` function in order to
guard against such situations by checking the `updatedAt` attribute. If
a record that is being pushed to the store is older than a record that
we already have, we will just return the existing record.
```