### PR TITLE
Add more Percy breakpoints

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -157,7 +157,7 @@ module.exports = function (environment) {
         tablet: 768,
         desktop: 1280
       },
-      defaultBreakpoints: ['desktop']
+      defaultBreakpoints: ['mobile', 'tablet', 'desktop']
     };
 
     ENV.featureFlags['debug-logging'] = false;


### PR DESCRIPTION
These are the defaults and they should cover our major breakpoints.
I’m hoping this won’t be annoying because it’ll mean triple the
snapshot diffs to approve, but we can tweak as desired.