### PR TITLE
Fix `offset=0` on the profile page

### DIFF
--- a/app/components/repository-status-toggle.js
+++ b/app/components/repository-status-toggle.js
@@ -25,7 +25,9 @@ export default Component.extend({
 
   @computed('repository.permissions')
   admin(permissions) {
-    return permissions.admin;
+    if (permissions) {
+      return permissions.admin;
+    }
   },
 
   toggleRepositoryTask: task(function* () {

--- a/app/controllers/account/repositories.js
+++ b/app/controllers/account/repositories.js
@@ -2,6 +2,8 @@ import Controller from '@ember/controller';
 import { computed } from 'ember-decorators/object';
 
 export default Controller.extend({
+  offset: 0,
+
   @computed('model')
   sortedRepositories(repos) {
     return repos.sortBy('name');

--- a/app/services/store.js
+++ b/app/services/store.js
@@ -114,7 +114,7 @@ export default DS.Store.extend({
   //     }
   //
   paginated(modelName, queryParams, options) {
-    if (!queryParams.offset) {
+    if (!parseInt(queryParams.offset)) {
       // we're on the first page, live updates can be enabled
       return fetchLivePaginatedCollection(this, ...arguments);
     } else {

--- a/app/utils/filtered-array-manager.js
+++ b/app/utils/filtered-array-manager.js
@@ -191,7 +191,7 @@ let FilteredArrayManagerForType = EmberObject.extend({
   calculateId(queryParams, filterFunction, dependencies) {
     const params = queryParams || {};
     let id = stringHash([
-      Object.entries(params).map(([key, value]) => `${key}:${value}`).sort(),
+      JSON.stringify(params),
       (dependencies || []).sort(),
       // not sure if this is a good idea, but I want to get the unique id for
       // each set of arguments to filter

--- a/app/utils/live-paginated-collection.js
+++ b/app/utils/live-paginated-collection.js
@@ -106,4 +106,8 @@ LivePaginatedCollection.reopenClass({
   }
 });
 
+LivePaginatedCollection.toString = function () {
+  return 'LivePaginatedCollection';
+};
+
 export default LivePaginatedCollection;

--- a/tests/acceptance/profile/redirect-test.js
+++ b/tests/acceptance/profile/redirect-test.js
@@ -12,6 +12,6 @@ test('visiting /profile redirects to /profile/:username', function (assert) {
   visit('/profile');
 
   andThen(() => {
-    assert.equal(currentURL(), '/profile/testuser?offset=0');
+    assert.equal(currentURL(), '/profile/testuser');
   });
 });

--- a/tests/unit/store-filter-test.js
+++ b/tests/unit/store-filter-test.js
@@ -207,3 +207,28 @@ test('it adds new records in the store to the filtered collection', function (as
     assert.deepEqual(collection.toArray().map((r) => r.get('id')), ['1']);
   });
 });
+
+test('it takes into account nested query params when caching collections', function (assert) {
+  assert.expect(2);
+  let store = this.store();
+
+  let queryCount = 0;
+  store.query = function () {
+    queryCount += 1;
+
+    return resolve();
+  };
+
+  let promises = [];
+  promises.push(store.filter('repo', { foo: { bar: 'baz' } }, () => true, []));
+  promises.push(store.filter('repo', { foo: { bar: 'qux' } }, () => true, []));
+
+  let done = assert.async();
+
+  all(promises).then((results) => {
+    done();
+
+    assert.notEqual(results[0], results[1]);
+    assert.equal(queryCount, 2);
+  });
+});

--- a/tests/unit/store-paginated-test.js
+++ b/tests/unit/store-paginated-test.js
@@ -224,3 +224,23 @@ test('it updates pagination data when forceReload is set to true', function (ass
   });
 });
 
+test('it returns live paginated collection even if offset is a string', function (assert) {
+  assert.expect(1);
+
+  let store = this.store();
+  store.query = function () {
+    let queryResult = ArrayProxy.create({ content: [] });
+    queryResult.set('meta', {});
+    queryResult.set('meta.pagination', { count: 1, limit: 1, offset: 0 });
+    return resolve(queryResult);
+  };
+
+  let done = assert.async();
+  let collection = store.paginated('repo', { offset: '0' }, {});
+
+  collection.then((collection) => {
+    assert.equal(collection.constructor.toString(), 'LivePaginatedCollection', 'paginated should return live paginated collection instance');
+
+    done();
+  });
+});


### PR DESCRIPTION
There was a bug in my custom filtering code that was improperly caching collections - we were caching by calculating id based on filter parameters, but not taking into account nested query params. This PR fixes it and then also adds `offset: 0` to `account/repositories` controller to avoid adding it to query params by default.