### PR TITLE
Fix auto sign out

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -16,6 +16,13 @@ export default TravisRoute.extend(BuildFaviconMixin, KeyboardShortcuts, {
 
   needsAuth: false,
 
+  init() {
+    this.get('auth').afterSignOut(() => {
+      this.afterSignOut();
+    });
+    return this._super(...arguments);
+  },
+
   renderTemplate: function () {
     if (this.get('config').pro) {
       $('body').addClass('pro');
@@ -102,9 +109,7 @@ export default TravisRoute.extend(BuildFaviconMixin, KeyboardShortcuts, {
     },
 
     signOut() {
-      this.get('featureFlags').reset();
       this.get('auth').signOut();
-      this.afterSignOut();
     },
 
     disableTailing() {
@@ -150,6 +155,7 @@ export default TravisRoute.extend(BuildFaviconMixin, KeyboardShortcuts, {
   },
 
   afterSignOut() {
+    this.get('featureFlags').reset();
     this.set('repositories.accessible', []);
     this.setDefault();
     if (this.get('config.enterprise')) {

--- a/app/services/auth.js
+++ b/app/services/auth.js
@@ -21,6 +21,11 @@ export default Service.extend({
   receivingEnd: `${location.protocol}//${location.host}`,
   tokenExpiredMsg: 'You\'ve been signed out, because your access token has expired.',
 
+  init() {
+    this.afterSignOutCallbacks = [];
+    return this._super(...arguments);
+  },
+
   token() {
     return this.get('sessionStorage').getItem('travis.token');
   },
@@ -36,9 +41,10 @@ export default Service.extend({
     this.get('storage').clear();
     this.set('state', 'signed-out');
     this.set('user', null);
-    this.get('store').unloadAll();
     this.set('currentUser', null);
     this.clearNonAuthFlashes();
+    this.runAfterSignOutCallbacks();
+    this.get('store').unloadAll();
   },
 
   signIn(data) {
@@ -76,6 +82,16 @@ export default Service.extend({
         }
       });
     }
+  },
+
+  afterSignOut(callback) {
+    this.afterSignOutCallbacks.push(callback);
+  },
+
+  runAfterSignOutCallbacks() {
+    this.afterSignOutCallbacks.forEach((callback) => {
+      callback();
+    });
   },
 
   userDataFrom(storage) {

--- a/tests/acceptance/auth/automatic-sign-out-test.js
+++ b/tests/acceptance/auth/automatic-sign-out-test.js
@@ -14,10 +14,11 @@ test('when token is invalid user should be signed out', function (assert) {
   window.sessionStorage.setItem('travis.token', 'wrong-token');
   window.localStorage.setItem('travis.token', 'wrong-token');
 
-  visit('/');
+  visit('/profile');
 
   andThen(function () {
     assert.equal(topPage.flashMessage.text, "You've been signed out, because your access token has expired.");
+    assert.equal(currentURL(), '/');
   });
   percySnapshot(assert);
 });


### PR DESCRIPTION
from the commit message:

```
When a Travis token expires and a user tries to open the app, we will
sign them out. The problem is that due to changes in e71862c we're no
longer running some of the sign out steps when the sign out is initiated
from the `auth` service. This commit gets back to calling the
`afterSignOut` every time a `signOut` is initiated.
```