### PR TITLE
Add filtering for triggerable branches

### DIFF
--- a/app/templates/components/trigger-custom-build.hbs
+++ b/app/templates/components/trigger-custom-build.hbs
@@ -6,7 +6,9 @@
   <label for="trigger-build-branches" class="form-label">Select a branch</label>
   {{#x-select id="trigger-build-branches" value=triggerBuildBranch on-change=(action (mut triggerBuildBranch)) as |xs|}}
     {{#each repo.branches as |branch|}}
-      {{#xs.option value=branch.name}}{{branch.name}}{{/xs.option}}
+      {{#if branch.exists_on_github}}
+        {{#xs.option value=branch.name}}{{branch.name}}{{/xs.option}}
+      {{/if}}
     {{/each}}
   {{/x-select}}
 </div>

--- a/tests/acceptance/repo/trigger-build-test.js
+++ b/tests/acceptance/repo/trigger-build-test.js
@@ -54,6 +54,14 @@ moduleForAcceptance('Acceptance | repo/trigger build', {
       sha: 'c0ffee'
     });
 
+    server.create('branch', {
+      name: 'deleted',
+      id: `/v3/repo/${repoId}/branch/deleted`,
+      default_branch: false,
+      exists_on_github: false,
+      repository: repo
+    });
+
     repo.currentBuild = latestBuild;
     repo.save();
   }
@@ -71,6 +79,9 @@ test('triggering a custom build via the dropdown', function (assert) {
 
   andThen(() => {
     assert.ok(triggerBuildPage.popupIsVisible, 'modal is visible after click');
+
+    assert.equal(triggerBuildPage.branches().count, 1, 'expected the not-on-GitHub branch to be hidden');
+    assert.equal(triggerBuildPage.branches(0).value, 'master');
   });
 
   triggerBuildPage.selectBranch('master');

--- a/tests/pages/trigger-build.js
+++ b/tests/pages/trigger-build.js
@@ -1,8 +1,10 @@
 import PageObject from 'travis/tests/page-object';
 
 let {
+  attribute,
   visitable,
   clickable,
+  collection,
   isHidden,
   isVisible,
   selectable,
@@ -15,7 +17,18 @@ export default PageObject.create({
   popupTriggerLinkIsHidden: isHidden('.option-dropdown .trigger-build-anchor'),
   openPopup: clickable('.option-dropdown .trigger-build-anchor'),
   popupIsVisible: isVisible('.trigger-build-modal'),
+
   selectBranch: selectable('#trigger-build-branches'),
+  branches: collection({
+    scope: '#trigger-build-branches',
+
+    itemScope: 'option',
+
+    item: {
+      value: attribute('value')
+    }
+  }),
+
   writeMessage: fillable('#trigger-build-message'),
   writeConfig: fillable('#trigger-build-config'),
   clickSubmit: clickable('.trigger-build-submit')


### PR DESCRIPTION
It doesn’t make sense to trigger a build on a branch that doesn’t exist on GitHub.