### PR TITLE
Use Menlo for monospace font stack

### DIFF
--- a/app/styles/app/base.sass
+++ b/app/styles/app/base.sass
@@ -91,7 +91,7 @@ span.emoji-sizer
   @include resetul
 
 .monospace
-  font-family: Monaco, monospace
+  font-family: Menlo, monospace
   font-size: 13px
   line-height: 1
 

--- a/app/styles/app/legacy/_global.scss
+++ b/app/styles/app/legacy/_global.scss
@@ -7,7 +7,7 @@
 // We use these to define default font stacks
 $font-family-sans-serif: "Source Sans Pro", Helvetica, sans-serif !default;
 $font-family-serif: $font-family-sans-serif;
-$font-family-monospace: Monaco, monospace !default;
+$font-family-monospace: Menlo, monospace !default;
 
 // We use these to define default font weights
 $font-weight-normal: normal !default;


### PR DESCRIPTION
The current monospace font stack, `Monaco, monospace`, causes issues on macOS since Monaco does not have a Bold variant, only Regular.

In Chrome, any text intended to be bolded isn't, thus bold and non-bold text have the same rendered font weight:

<img width="621" alt="chrome-before" src="https://user-images.githubusercontent.com/235875/33532172-e82373c6-d85c-11e7-8e9c-0ad226b88242.png">

Safari tries to create a bold variant on-the-fly, but this breaks the intended monospace behavior:

<img width="687" alt="safari-before" src="https://user-images.githubusercontent.com/235875/33532184-09e4c64a-d85d-11e7-856a-5bab3062bca2.png">

Menlo, on the other hand, does have a bold variant, and looks better in Chrome and Safari:

<img width="623" alt="chrome-after" src="https://user-images.githubusercontent.com/235875/33532193-1e90aa64-d85d-11e7-8248-43050852321e.png">

<img width="623" alt="safari-after" src="https://user-images.githubusercontent.com/235875/33532195-2340dff2-d85d-11e7-9c2b-a65d8201eb61.png">

This will also affect Firefox on macOS, though it renders both typefaces correctly. Other platforms should not be affected because neither typeface should be included by default (due to both being created by Apple).