### PR TITLE
Change log font to Cousine

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -11,7 +11,7 @@
     {{content-for "head"}}
 
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600" rel="stylesheet" type="text/css">
-    <link href="https://fonts.googleapis.com/css?family=Cousine" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Cousine" rel="stylesheet" type="text/css">
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/travis.css">
     <link rel="mask-icon" href="images/favicon.svg" color="black">

--- a/app/index.html
+++ b/app/index.html
@@ -11,6 +11,7 @@
     {{content-for "head"}}
 
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600" rel="stylesheet" type="text/css">
+    <link href="https://fonts.googleapis.com/css?family=Cousine" rel="stylesheet">
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/travis.css">
     <link rel="mask-icon" href="images/favicon.svg" color="black">

--- a/app/styles/app/base.sass
+++ b/app/styles/app/base.sass
@@ -91,7 +91,7 @@ span.emoji-sizer
   @include resetul
 
 .monospace
-  font-family: Monaco, monospace
+  font-family: Cousine, monospace
   font-size: 13px
   line-height: 1
 

--- a/app/styles/app/legacy/_global.scss
+++ b/app/styles/app/legacy/_global.scss
@@ -7,7 +7,7 @@
 // We use these to define default font stacks
 $font-family-sans-serif: "Source Sans Pro", Helvetica, sans-serif !default;
 $font-family-serif: $font-family-sans-serif;
-$font-family-monospace: Monaco, monospace !default;
+$font-family-monospace: Cousine, monospace !default;
 
 // We use these to define default font weights
 $font-weight-normal: normal !default;


### PR DESCRIPTION
This was formerly different across platforms.

Thanks to @jarrodldavis for #1414, which prompted us to look
into normalising on different OSes, and to @hail2u for nicely
presenting all the monospaced Google Fonts.