### PR TITLE
Remove Mousetrap Bower dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,6 @@
     "jquery-timeago": "~1.5.2",
     "pusher": "~2.2.3",
     "raven-js": "3.10.0",
-    "mousetrap": "~1.5.2",
     "js-emoji": "~3.0.2",
     "emoji-data": "~2.4.4",
     "waypoints": "4.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6557,27 +6557,14 @@
       }
     },
     "ember-keyboard-shortcuts": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/ember-keyboard-shortcuts/-/ember-keyboard-shortcuts-0.3.0.tgz",
-      "integrity": "sha1-vMLxE8wIYjdGvbogXhWqr5VA9do=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ember-keyboard-shortcuts/-/ember-keyboard-shortcuts-1.0.2.tgz",
+      "integrity": "sha512-aMifniPTzQ3eUWpjgfNIxh5Uqh1Ipha2kHxpTBFKwIu8+0Oirc6VdvP+gX8Rdsfds2dig40NfTXu7lNroW61rw==",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "5.2.4"
-      },
-      "dependencies": {
-        "ember-cli-babel": {
-          "version": "5.2.4",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz",
-          "integrity": "sha1-XOT0awjtb20h6Hhhn7aJcZ1ujhM=",
-          "dev": true,
-          "requires": {
-            "broccoli-babel-transpiler": "5.7.2",
-            "broccoli-funnel": "1.2.0",
-            "clone": "2.1.1",
-            "ember-cli-version-checker": "1.3.1",
-            "resolve": "1.4.0"
-          }
-        }
+        "ember-cli-babel": "6.8.2",
+        "fastboot-transform": "0.1.2",
+        "mousetrap": "1.6.1"
       }
     },
     "ember-load-initializers": {
@@ -8460,6 +8447,15 @@
           "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=",
           "dev": true
         }
+      }
+    },
+    "fastboot-transform": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/fastboot-transform/-/fastboot-transform-0.1.2.tgz",
+      "integrity": "sha512-SU343Ca3XeiGHxSvycVb3062ejN68Go8OXcx4QWgUUMek43XRUr/LuU4ILSxAMvvHvhamsSQivysWBEO9ux4oA==",
+      "dev": true,
+      "requires": {
+        "broccoli-stew": "1.5.0"
       }
     },
     "faye-websocket": {
@@ -12170,6 +12166,12 @@
         "on-finished": "2.3.0",
         "on-headers": "1.0.1"
       }
+    },
+    "mousetrap": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.1.tgz",
+      "integrity": "sha1-KghfXHUSlMdefoH27CVFspy/Qtk=",
+      "dev": true
     },
     "mout": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "ember-export-application-global": "2.0.0",
     "ember-feature-flags": "3.0.0",
     "ember-inflector": "^2.0.0",
-    "ember-keyboard-shortcuts": "0.3.0",
+    "ember-keyboard-shortcuts": "^1.0.2",
     "ember-load-initializers": "1.0.0",
     "ember-modal-dialog": "^2.2.0",
     "ember-one-way-controls": "^2.0.1",


### PR DESCRIPTION
This is possible thanks to the new version of ember-keyboard-shortcuts.