### PR TITLE
Update various dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -566,6 +566,13 @@
         }
       }
     },
+    "app-root-path": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.0.1.tgz",
+      "integrity": "sha1-zWLc+OT9WkF+/GZNLlsQZTxlG0Y=",
+      "dev": true,
+      "optional": true
+    },
     "aproba": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
@@ -2069,6 +2076,12 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
       "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
+      "dev": true
+    },
+    "bluebird-retry": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/bluebird-retry/-/bluebird-retry-0.11.0.tgz",
+      "integrity": "sha1-EomrIsu8OgJYe6rTVZU1HdDBwEc=",
       "dev": true
     },
     "bn.js": {
@@ -3685,6 +3698,16 @@
         "string-width": "1.0.2"
       }
     },
+    "cli-truncate": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "0.0.4",
+        "string-width": "1.0.2"
+      }
+    },
     "cli-width": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
@@ -4094,6 +4117,23 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cosmiconfig": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-1.1.0.tgz",
+      "integrity": "sha1-DeoPmATv37kp+7GxiOJVU+oFPTc=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "js-yaml": "3.9.1",
+        "minimist": "1.2.0",
+        "object-assign": "4.1.1",
+        "os-homedir": "1.0.2",
+        "parse-json": "2.2.0",
+        "pinkie-promise": "2.0.1",
+        "require-from-string": "1.2.1"
+      }
+    },
     "create-ecdh": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
@@ -4286,6 +4326,13 @@
         "mimer": "0.2.1",
         "rsvp": "3.6.2"
       }
+    },
+    "date-fns": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
+      "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
+      "dev": true,
+      "optional": true
     },
     "date-now": {
       "version": "0.1.4",
@@ -4641,6 +4688,13 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.18.tgz",
       "integrity": "sha1-PcyZ2j5rZl9qu8ccKK1Ros1zGpw=",
       "dev": true
+    },
+    "elegant-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
+      "dev": true,
+      "optional": true
     },
     "elliptic": {
       "version": "6.4.0",
@@ -7751,54 +7805,149 @@
       }
     },
     "ember-percy": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/ember-percy/-/ember-percy-1.2.13.tgz",
-      "integrity": "sha1-4OC49Og17hfKsipd63Dbbpa4tlg=",
+      "version": "1.2.22",
+      "resolved": "https://registry.npmjs.org/ember-percy/-/ember-percy-1.2.22.tgz",
+      "integrity": "sha512-OEG42NveLcgQUPWQ6f8sg/mdOYTXR/5UuDyS0Gqw+DJXzUI+khY+00l40FCizORFFadudKEsOpQpOV9Ggcwkbw==",
       "dev": true,
       "requires": {
         "body-parser": "1.17.2",
-        "ember-cli-babel": "5.2.4",
-        "es6-promise-pool": "2.4.6",
-        "percy-client": "2.1.4",
+        "ember-cli-babel": "6.10.0",
+        "es6-promise-pool": "2.5.0",
+        "percy-client": "2.5.0",
         "walk": "2.3.9"
       },
       "dependencies": {
-        "ember-cli-babel": {
-          "version": "5.2.4",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz",
-          "integrity": "sha1-XOT0awjtb20h6Hhhn7aJcZ1ujhM=",
+        "babel-core": {
+          "version": "6.26.0",
+          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
+          "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
           "dev": true,
           "requires": {
-            "broccoli-babel-transpiler": "5.7.2",
-            "broccoli-funnel": "1.2.0",
-            "clone": "2.1.1",
-            "ember-cli-version-checker": "1.3.1",
-            "resolve": "1.4.0"
-          },
-          "dependencies": {
-            "broccoli-funnel": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
-              "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
-              "dev": true,
-              "requires": {
-                "array-equal": "1.0.0",
-                "blank-object": "1.0.2",
-                "broccoli-plugin": "1.3.0",
-                "debug": "2.6.8",
-                "exists-sync": "0.0.4",
-                "fast-ordered-set": "1.0.3",
-                "fs-tree-diff": "0.5.6",
-                "heimdalljs": "0.2.5",
-                "minimatch": "3.0.4",
-                "mkdirp": "0.5.1",
-                "path-posix": "1.0.0",
-                "rimraf": "2.6.1",
-                "symlink-or-copy": "1.1.8",
-                "walk-sync": "0.3.2"
-              }
-            }
+            "babel-code-frame": "6.26.0",
+            "babel-generator": "6.26.0",
+            "babel-helpers": "6.24.1",
+            "babel-messages": "6.23.0",
+            "babel-register": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "convert-source-map": "1.5.0",
+            "debug": "2.6.8",
+            "json5": "0.5.1",
+            "lodash": "4.17.4",
+            "minimatch": "3.0.4",
+            "path-is-absolute": "1.0.1",
+            "private": "0.1.7",
+            "slash": "1.0.0",
+            "source-map": "0.5.6"
           }
+        },
+        "babylon": {
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+          "dev": true
+        },
+        "broccoli-babel-transpiler": {
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.1.2.tgz",
+          "integrity": "sha512-o1OUe5RZ5EP5+QICEmRNvWlhMvIciMisVACHu6qUPt6dE0Q0UnI5lUpWTmuXg/X+QuznqD/s1PApIpahv/QMZw==",
+          "dev": true,
+          "requires": {
+            "babel-core": "6.26.0",
+            "broccoli-funnel": "1.2.0",
+            "broccoli-merge-trees": "1.2.4",
+            "broccoli-persistent-filter": "1.4.3",
+            "clone": "2.1.1",
+            "hash-for-dep": "1.2.0",
+            "heimdalljs-logger": "0.1.9",
+            "json-stable-stringify": "1.0.1",
+            "rsvp": "3.6.2",
+            "workerpool": "2.2.2"
+          }
+        },
+        "broccoli-funnel": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+          "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+          "dev": true,
+          "requires": {
+            "array-equal": "1.0.0",
+            "blank-object": "1.0.2",
+            "broccoli-plugin": "1.3.0",
+            "debug": "2.6.8",
+            "exists-sync": "0.0.4",
+            "fast-ordered-set": "1.0.3",
+            "fs-tree-diff": "0.5.6",
+            "heimdalljs": "0.2.5",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "path-posix": "1.0.0",
+            "rimraf": "2.6.1",
+            "symlink-or-copy": "1.1.8",
+            "walk-sync": "0.3.2"
+          }
+        },
+        "broccoli-merge-trees": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
+          "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
+          "dev": true,
+          "requires": {
+            "broccoli-plugin": "1.3.0",
+            "can-symlink": "1.0.0",
+            "fast-ordered-set": "1.0.3",
+            "fs-tree-diff": "0.5.6",
+            "heimdalljs": "0.2.5",
+            "heimdalljs-logger": "0.1.9",
+            "rimraf": "2.6.1",
+            "symlink-or-copy": "1.1.8"
+          }
+        },
+        "ember-cli-babel": {
+          "version": "6.10.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.10.0.tgz",
+          "integrity": "sha512-MbgXmePweFzjkpN0l2eYFIU6XKfEKCaAx4Xk9wdL3vsPAvAm4N0DXnz4pOQ3OLezhl0bJJvutD3uLQ7Eo3sSTA==",
+          "dev": true,
+          "requires": {
+            "amd-name-resolver": "0.0.7",
+            "babel-plugin-debug-macros": "0.1.11",
+            "babel-plugin-ember-modules-api-polyfill": "2.0.1",
+            "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+            "babel-polyfill": "6.26.0",
+            "babel-preset-env": "1.6.0",
+            "broccoli-babel-transpiler": "6.1.2",
+            "broccoli-debug": "0.6.3",
+            "broccoli-funnel": "1.2.0",
+            "broccoli-source": "1.1.0",
+            "clone": "2.1.1",
+            "ember-cli-version-checker": "2.1.0",
+            "semver": "5.4.1"
+          }
+        },
+        "ember-cli-version-checker": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
+          "integrity": "sha512-ssiNyVTp+PphroFum8guHX9py4xU1PCxkRYgb25NxumgjpKTPjhkgTfpRRKXlIQe+/wVMmhf+Uv6w9vSLZKWKQ==",
+          "dev": true,
+          "requires": {
+            "resolve": "1.4.0",
+            "semver": "5.4.1"
+          }
+        },
+        "json5": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
@@ -9128,9 +9277,9 @@
       "dev": true
     },
     "es6-promise-pool": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/es6-promise-pool/-/es6-promise-pool-2.4.6.tgz",
-      "integrity": "sha1-P6TKwHImdOAkvd8S1x+cOZz8CrA=",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/es6-promise-pool/-/es6-promise-pool-2.5.0.tgz",
+      "integrity": "sha1-FHxhKza0fxBQJ/nSv1SlmKmdnMs=",
       "dev": true
     },
     "es6-promisify": {
@@ -9628,6 +9777,12 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
       "dev": true
     },
     "expand-brackets": {
@@ -11335,6 +11490,13 @@
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
       "dev": true
     },
+    "get-own-enumerable-property-symbols": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
+      "integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==",
+      "dev": true,
+      "optional": true
+    },
     "get-stdin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
@@ -12274,6 +12436,13 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "dev": true,
+      "optional": true
+    },
     "is-resolvable": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
@@ -12358,6 +12527,67 @@
         "binaryextensions": "2.0.0",
         "editions": "1.3.3",
         "textextensions": "2.1.0"
+      }
+    },
+    "jest-get-type": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
+      "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
+      "dev": true,
+      "optional": true
+    },
+    "jest-validate": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.2.1.tgz",
+      "integrity": "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "chalk": "2.3.0",
+        "jest-get-type": "21.2.0",
+        "leven": "2.1.0",
+        "pretty-format": "21.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "leven": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+          "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+          "dev": true,
+          "optional": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
       }
     },
     "jmespath": {
@@ -12673,6 +12903,289 @@
       "dev": true,
       "requires": {
         "uc.micro": "1.0.3"
+      }
+    },
+    "lint-staged": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-4.3.0.tgz",
+      "integrity": "sha512-C/Zxslg0VRbsxwmCu977iIs+QyrmW2cyRCPUV5NDFYOH/jtRFHH8ch7ua2fH0voI/nVC3Tpg7DykfgMZySliKw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "app-root-path": "2.0.1",
+        "chalk": "2.3.0",
+        "commander": "2.11.0",
+        "cosmiconfig": "1.1.0",
+        "execa": "0.8.0",
+        "is-glob": "4.0.0",
+        "jest-validate": "21.2.1",
+        "listr": "0.12.0",
+        "lodash": "4.17.4",
+        "log-symbols": "2.1.0",
+        "minimatch": "3.0.4",
+        "npm-which": "3.0.1",
+        "p-map": "1.2.0",
+        "staged-git-files": "0.0.4",
+        "stringify-object": "3.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true,
+          "optional": true
+        },
+        "is-glob": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true,
+          "optional": true
+        },
+        "log-symbols": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.1.0.tgz",
+          "integrity": "sha512-zLeLrzMA1A2vRF1e/0Mo+LNINzi6jzBylHj5WqvQ/WK/5WCZt8si9SyN4p9llr/HRYvVR1AoXHRHl4WTHyQAzQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chalk": "2.3.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "listr": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/listr/-/listr-0.12.0.tgz",
+      "integrity": "sha1-a84sD1YD+klYDqF81qAMwOX6RRo=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "figures": "1.7.0",
+        "indent-string": "2.1.0",
+        "is-promise": "2.1.0",
+        "is-stream": "1.1.0",
+        "listr-silent-renderer": "1.1.1",
+        "listr-update-renderer": "0.2.0",
+        "listr-verbose-renderer": "0.4.1",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "ora": "0.2.3",
+        "p-map": "1.2.0",
+        "rxjs": "5.5.5",
+        "stream-to-observable": "0.1.0",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "restore-cursor": "1.0.1"
+          }
+        },
+        "cli-spinners": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
+          "integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
+          "dev": true,
+          "optional": true
+        },
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
+          }
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+          "dev": true,
+          "optional": true
+        },
+        "ora": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
+          "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "cli-cursor": "1.0.2",
+            "cli-spinners": "0.1.2",
+            "object-assign": "4.1.1"
+          }
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "exit-hook": "1.1.1",
+            "onetime": "1.1.0"
+          }
+        }
+      }
+    },
+    "listr-silent-renderer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+      "dev": true,
+      "optional": true
+    },
+    "listr-update-renderer": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.2.0.tgz",
+      "integrity": "sha1-yoDhd5tOcCZoB+ju0a1qvjmFUPk=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "elegant-spinner": "1.0.1",
+        "figures": "1.7.0",
+        "indent-string": "3.2.0",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
+          }
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "listr-verbose-renderer": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
+      "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "date-fns": "1.29.0",
+        "figures": "1.7.0"
+      },
+      "dependencies": {
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "restore-cursor": "1.0.1"
+          }
+        },
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
+          }
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+          "dev": true,
+          "optional": true
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "exit-hook": "1.1.1",
+            "onetime": "1.1.0"
+          }
+        }
       }
     },
     "livereload-js": {
@@ -13221,6 +13734,49 @@
       "dev": true,
       "requires": {
         "chalk": "1.1.3"
+      }
+    },
+    "log-update": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
+      "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "cli-cursor": "1.0.2"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+          "dev": true
+        },
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "1.0.1"
+          }
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+          "dev": true
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "dev": true,
+          "requires": {
+            "exit-hook": "1.1.1",
+            "onetime": "1.1.0"
+          }
+        }
       }
     },
     "lolex": {
@@ -13894,6 +14450,16 @@
         "semver": "5.4.1"
       }
     },
+    "npm-path": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.3.tgz",
+      "integrity": "sha1-Fc/04ciaONp39W9gVbJPl137K74=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "which": "1.3.0"
+      }
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -13901,6 +14467,18 @@
       "dev": true,
       "requires": {
         "path-key": "2.0.1"
+      }
+    },
+    "npm-which": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
+      "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "commander": "2.11.0",
+        "npm-path": "2.0.3",
+        "which": "1.3.0"
       }
     },
     "npmlog": {
@@ -14130,6 +14708,12 @@
       "requires": {
         "p-limit": "1.1.0"
       }
+    },
+    "p-map": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "dev": true
     },
     "pac-proxy-agent": {
       "version": "2.0.0",
@@ -14387,51 +14971,27 @@
       }
     },
     "percy-client": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/percy-client/-/percy-client-2.1.4.tgz",
-      "integrity": "sha1-sy74Fxjac2DIhvCY/HM2EPI9IlY=",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/percy-client/-/percy-client-2.5.0.tgz",
+      "integrity": "sha512-4NoYlZuLnqgh5Cdm3SgOgNF17szCqP91rMLlCe8LSYLT15iBukIrUtoZiWmijsIpeeJZu5GRBdVfF+3mx0zwjw==",
       "dev": true,
       "requires": {
         "base64-js": "1.2.1",
+        "bluebird": "3.5.1",
+        "bluebird-retry": "0.11.0",
+        "es6-promise-pool": "2.5.0",
         "jssha": "2.3.1",
+        "lint-staged": "4.3.0",
+        "regenerator-runtime": "0.11.0",
         "request": "2.81.0",
-        "request-promise": "4.2.1"
+        "request-promise": "4.2.2"
       },
       "dependencies": {
         "bluebird": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
           "dev": true
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        },
-        "request-promise": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.1.tgz",
-          "integrity": "sha1-fuxWyJMXqCLL/qmbA5zlQ8LhX2c=",
-          "dev": true,
-          "requires": {
-            "bluebird": "3.5.0",
-            "request-promise-core": "1.1.1",
-            "stealthy-require": "1.1.1",
-            "tough-cookie": "2.3.2"
-          },
-          "dependencies": {
-            "request-promise-core": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-              "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
-              "dev": true,
-              "requires": {
-                "lodash": "4.17.4"
-              }
-            }
-          }
         }
       }
     },
@@ -14568,6 +15128,36 @@
           "resolved": "https://registry.npmjs.org/route-recognizer/-/route-recognizer-0.3.3.tgz",
           "integrity": "sha1-HTZeJ/ppleCRZ199yUCowANTvSk=",
           "dev": true
+        }
+      }
+    },
+    "pretty-format": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
+      "integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "ansi-regex": "3.0.0",
+        "ansi-styles": "3.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true,
+          "optional": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
         }
       }
     },
@@ -15169,11 +15759,64 @@
         }
       }
     },
+    "request-promise": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.2.tgz",
+      "integrity": "sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.1",
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "1.1.1",
+        "tough-cookie": "2.3.3"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+          "dev": true
+        },
+        "tough-cookie": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+          "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+          "dev": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        }
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        }
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
+    },
+    "require-from-string": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
+      "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
+      "dev": true,
+      "optional": true
     },
     "require-main-filename": {
       "version": "1.0.1",
@@ -15314,6 +15957,16 @@
       "dev": true,
       "requires": {
         "rx-lite": "4.0.8"
+      }
+    },
+    "rxjs": {
+      "version": "5.5.5",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.5.tgz",
+      "integrity": "sha512-D/MfQnPMBk8P8gfwGxvCkuaWBcG58W7dUMT//URPoYzIbDEKT0GezdirkK5whMgKFBATfCoTpxO8bJQGJ04W5A==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "symbol-observable": "1.0.1"
       }
     },
     "safe-buffer": {
@@ -16038,6 +16691,13 @@
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
       "dev": true
     },
+    "staged-git-files": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-0.0.4.tgz",
+      "integrity": "sha1-15fhtVHKemOd7AI33G60u5vhfTU=",
+      "dev": true,
+      "optional": true
+    },
     "statuses": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
@@ -16102,6 +16762,13 @@
         "readable-stream": "2.3.3"
       }
     },
+    "stream-to-observable": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.1.0.tgz",
+      "integrity": "sha1-Rb8dny19wJvtgfHDB8Qw5ouEz/4=",
+      "dev": true,
+      "optional": true
+    },
     "string-template": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
@@ -16124,6 +16791,18 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
+    },
+    "stringify-object": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.1.tgz",
+      "integrity": "sha512-jPcQYw/52HUPP8uOE4kkjxl5bB9LfHkKCTptIk3qw7ozP5XMIMlHMLjt00GGSwW6DJAf/njY5EU6Vpwl4LlBKQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "get-own-enumerable-property-symbols": "2.0.1",
+        "is-obj": "1.0.1",
+        "is-regexp": "1.0.0"
+      }
     },
     "stringmap": {
       "version": "0.2.2",
@@ -16244,6 +16923,13 @@
           }
         }
       }
+    },
+    "symbol-observable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+      "dev": true,
+      "optional": true
     },
     "symbol-tree": {
       "version": "3.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -812,28 +812,40 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "6.7.7",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
-      "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.2.tgz",
+      "integrity": "sha512-eTVoSHiGp2cDytg7RS7gtqAnfH+WFcNQMTjywGNu+hH7ViQZ/ZKsvNz2C1oVhCtd9DjMIC15iatpxmtp5Kxvpg==",
       "dev": true,
       "requires": {
-        "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000715",
+        "browserslist": "2.10.0",
+        "caniuse-lite": "1.0.30000782",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
-        "postcss": "5.2.17",
+        "postcss": "6.0.14",
         "postcss-value-parser": "3.3.0"
       },
       "dependencies": {
         "browserslist": {
-          "version": "1.7.7",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
-          "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.10.0.tgz",
+          "integrity": "sha512-WyvzSLsuAVPOjbljXnyeWl14Ae+ukAT8MUuagKVzIDvwBxl4UAwD1xqtyQs2eWYPGUKMeC3Ol62goqYuKqTTcw==",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000715",
-            "electron-to-chromium": "1.3.18"
+            "caniuse-lite": "1.0.30000782",
+            "electron-to-chromium": "1.3.28"
           }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30000782",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000782.tgz",
+          "integrity": "sha1-W4K4w4XyU0h0XEccpRMgr7G38lQ=",
+          "dev": true
+        },
+        "electron-to-chromium": {
+          "version": "1.3.28",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.28.tgz",
+          "integrity": "sha1-jdTmRYCGZE6fnwoc8y4qH53/2e4=",
+          "dev": true
         }
       }
     },
@@ -2248,15 +2260,14 @@
       }
     },
     "broccoli-autoprefixer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/broccoli-autoprefixer/-/broccoli-autoprefixer-4.1.0.tgz",
-      "integrity": "sha1-WmEu9Pzr2lH6m2RcPjXJEcgVFsI=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/broccoli-autoprefixer/-/broccoli-autoprefixer-5.0.0.tgz",
+      "integrity": "sha1-aMnzv9//nfLTnkZUW5z51EQ9ahY=",
       "dev": true,
       "requires": {
-        "autoprefixer": "6.7.7",
+        "autoprefixer": "7.2.2",
         "broccoli-persistent-filter": "1.4.3",
-        "object-assign": "4.1.1",
-        "postcss": "5.2.17"
+        "postcss": "6.0.14"
       }
     },
     "broccoli-babel-transpiler": {
@@ -3450,12 +3461,6 @@
       "requires": {
         "tmp": "0.0.28"
       }
-    },
-    "caniuse-db": {
-      "version": "1.0.30000715",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000715.tgz",
-      "integrity": "sha1-C5tceVlQ37rzAaiAa6/ofxJtqMo=",
-      "dev": true
     },
     "caniuse-lite": {
       "version": "1.0.30000726",
@@ -5039,12 +5044,12 @@
       }
     },
     "ember-cli-autoprefixer": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-autoprefixer/-/ember-cli-autoprefixer-0.7.0.tgz",
-      "integrity": "sha1-EEr3AYrChYo5acXAocIoBM0bOa4=",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-autoprefixer/-/ember-cli-autoprefixer-0.8.1.tgz",
+      "integrity": "sha1-Bx3ZV0RRBXsD3MA7cfW9nLB+8zI=",
       "dev": true,
       "requires": {
-        "broccoli-autoprefixer": "4.1.0",
+        "broccoli-autoprefixer": "5.0.0",
         "lodash": "4.17.4"
       },
       "dependencies": {
@@ -14483,30 +14488,49 @@
       }
     },
     "postcss": {
-      "version": "5.2.17",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
-      "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
+      "version": "6.0.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
+      "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "js-base64": "2.1.9",
-        "source-map": "0.5.6",
-        "supports-color": "3.2.3"
+        "chalk": "2.3.0",
+        "source-map": "0.6.1",
+        "supports-color": "4.5.0"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         },
         "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "2.0.0"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5029,13 +5029,13 @@
       }
     },
     "ember-cli-app-version": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-app-version/-/ember-cli-app-version-3.1.0.tgz",
-      "integrity": "sha1-B0sDMFgae4qwlP8H/vs04NAlS/0=",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/ember-cli-app-version/-/ember-cli-app-version-3.1.3.tgz",
+      "integrity": "sha512-Y8itgYxAZ0kBzgu8yCrrEuHvbW6sHkojZofkg3AsAC+hwc6wdJ65hQULR3JhhGB1AcId0Xs7xu6EBYIr7B06Fw==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "6.8.2",
-        "git-repo-version": "0.4.1"
+        "git-repo-version": "1.0.1"
       }
     },
     "ember-cli-autoprefixer": {
@@ -11380,20 +11380,12 @@
       "dev": true
     },
     "git-repo-version": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/git-repo-version/-/git-repo-version-0.4.1.tgz",
-      "integrity": "sha1-dfq5oKTshHB1Ww7qf9qm+dQUU78=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/git-repo-version/-/git-repo-version-1.0.1.tgz",
+      "integrity": "sha512-weKz3+5ui1zvbguI/KngiiGJhNwMYzXQa3vjTuMxTNPqvz5tHhpSIxbqfJQBQG52WHe4hqavEZLVs2SS/BbQRw==",
       "dev": true,
       "requires": {
-        "git-repo-info": "1.2.0"
-      },
-      "dependencies": {
-        "git-repo-info": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/git-repo-info/-/git-repo-info-1.2.0.tgz",
-          "integrity": "sha1-Q9hRPgSiTdRBMwovfGZVpwn9uvI=",
-          "dev": true
-        }
+        "git-repo-info": "1.4.1"
       }
     },
     "glob": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,171 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.31.tgz",
+      "integrity": "sha512-yd7CkUughvHQoEahQqcMdrZw6o/6PwUxiRkfZuVDVHCDe77mysD/suoNyk5mK6phTnRW1kyIbPHyCJgxw++LXg==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.31.tgz",
+      "integrity": "sha512-c+DAyp8LMm2nzSs2uXEuxp4LYGSUYEyHtU3fU57avFChjsnTmmpWmXj2dv0yUxHTEydgVAv5fIzA+4KJwoqWDA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "7.0.0-beta.31",
+        "@babel/template": "7.0.0-beta.31",
+        "@babel/traverse": "7.0.0-beta.31",
+        "@babel/types": "7.0.0-beta.31"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.31.tgz",
+      "integrity": "sha512-m7rVVX/dMLbbB9NCzKYRrrFb0qZxgpmQ4Wv6y7zEsB6skoJHRuXVeb/hAFze79vXBbuD63ci7AVHXzAdZSk9KQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.31"
+      }
+    },
+    "@babel/template": {
+      "version": "7.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.31.tgz",
+      "integrity": "sha512-97IRmLvoDhIDSQkqklVt3UCxJsv0LUEVb/0DzXWtc8Lgiyxj567qZkmTG9aR21CmcJVVIvq2Y/moZj4oEpl5AA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.31",
+        "@babel/types": "7.0.0-beta.31",
+        "babylon": "7.0.0-beta.31",
+        "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.31",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.31.tgz",
+          "integrity": "sha512-6lm2mV3S51yEnKmQQNnswoABL1U1H1KHoCCVwdwI3hvIv+W7ya4ki7Aw4o4KxtUHjNKkK5WpZb22rrMMOcJXJQ==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.31.tgz",
+      "integrity": "sha512-3N+VJW+KlezEjFBG7WSYeMyC5kIqVLPb/PGSzCDPFcJrnArluD1GIl7Y3xC7cjKiTq2/JohaLWHVPjJWHlo9Gg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.31",
+        "@babel/helper-function-name": "7.0.0-beta.31",
+        "@babel/types": "7.0.0-beta.31",
+        "babylon": "7.0.0-beta.31",
+        "debug": "3.1.0",
+        "globals": "10.4.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.31",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.31.tgz",
+          "integrity": "sha512-6lm2mV3S51yEnKmQQNnswoABL1U1H1KHoCCVwdwI3hvIv+W7ya4ki7Aw4o4KxtUHjNKkK5WpZb22rrMMOcJXJQ==",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "10.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-10.4.0.tgz",
+          "integrity": "sha512-uNUtxIZpGyuaq+5BqGGQHsL4wUlJAXRqOm6g3Y48/CWNGTLONgBibI0lh6lGxjR2HljFYUfszb+mk4WkgMntsA==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.31.tgz",
+      "integrity": "sha512-exAHB+NeFGxkfQ5dSUD03xl3zYGneeSk2Mw2ldTt/nTvYxuDiuSp3DlxgUBgzbdTFG4fbwPk0WtKWOoTXCmNGg==",
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "lodash": "4.17.4",
+        "to-fast-properties": "2.0.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
+        }
+      }
+    },
     "@glimmer/compiler": {
       "version": "0.25.3",
       "resolved": "https://registry.npmjs.org/@glimmer/compiler/-/compiler-0.25.3.tgz",
@@ -773,21 +938,21 @@
       }
     },
     "babel-eslint": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-7.2.3.tgz",
-      "integrity": "sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.0.3.tgz",
+      "integrity": "sha512-7D4iUpylEiKJPGbeSAlNddGcmA41PadgZ6UAb6JVyh003h3d0EbZusYFBR/+nBgqtaVJM2J2zUVa3N0hrpMH6g==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0"
+        "@babel/code-frame": "7.0.0-beta.31",
+        "@babel/traverse": "7.0.0-beta.31",
+        "@babel/types": "7.0.0-beta.31",
+        "babylon": "7.0.0-beta.31"
       },
       "dependencies": {
         "babylon": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+          "version": "7.0.0-beta.31",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.31.tgz",
+          "integrity": "sha512-6lm2mV3S51yEnKmQQNnswoABL1U1H1KHoCCVwdwI3hvIv+W7ya4ki7Aw4o4KxtUHjNKkK5WpZb22rrMMOcJXJQ==",
           "dev": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -397,6 +397,39 @@
             "clone": "2.1.1",
             "ember-cli-version-checker": "1.3.1",
             "resolve": "1.4.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+              "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+              "dev": true,
+              "requires": {
+                "array-equal": "1.0.0",
+                "blank-object": "1.0.2",
+                "broccoli-plugin": "1.3.0",
+                "debug": "2.6.8",
+                "exists-sync": "0.0.4",
+                "fast-ordered-set": "1.0.3",
+                "fs-tree-diff": "0.5.6",
+                "heimdalljs": "0.2.5",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "path-posix": "1.0.0",
+                "rimraf": "2.6.1",
+                "symlink-or-copy": "1.1.8",
+                "walk-sync": "0.3.2"
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
           }
         }
       }
@@ -2244,6 +2277,28 @@
         "workerpool": "2.2.2"
       },
       "dependencies": {
+        "broccoli-funnel": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+          "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+          "dev": true,
+          "requires": {
+            "array-equal": "1.0.0",
+            "blank-object": "1.0.2",
+            "broccoli-plugin": "1.3.0",
+            "debug": "2.6.8",
+            "exists-sync": "0.0.4",
+            "fast-ordered-set": "1.0.3",
+            "fs-tree-diff": "0.5.6",
+            "heimdalljs": "0.2.5",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "path-posix": "1.0.0",
+            "rimraf": "2.6.1",
+            "symlink-or-copy": "1.1.8",
+            "walk-sync": "0.3.2"
+          }
+        },
         "broccoli-merge-trees": {
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
@@ -2265,6 +2320,15 @@
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
           "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
           "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
         }
       }
     },
@@ -2474,16 +2538,15 @@
       }
     },
     "broccoli-funnel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
-      "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz",
+      "integrity": "sha512-C8Lnp9TVsSSiZMGEF16C0dCiNg2oJqUKwuZ1K4kVC6qRPG/2Cj/rtB5kRCC9qEbwqhX71bDbfHROx0L3J7zXQg==",
       "dev": true,
       "requires": {
         "array-equal": "1.0.0",
         "blank-object": "1.0.2",
         "broccoli-plugin": "1.3.0",
         "debug": "2.6.8",
-        "exists-sync": "0.0.4",
         "fast-ordered-set": "1.0.3",
         "fs-tree-diff": "0.5.6",
         "heimdalljs": "0.2.5",
@@ -2789,6 +2852,28 @@
         "walk-sync": "0.3.2"
       },
       "dependencies": {
+        "broccoli-funnel": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+          "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+          "dev": true,
+          "requires": {
+            "array-equal": "1.0.0",
+            "blank-object": "1.0.2",
+            "broccoli-plugin": "1.3.0",
+            "debug": "2.6.8",
+            "exists-sync": "0.0.4",
+            "fast-ordered-set": "1.0.3",
+            "fs-tree-diff": "0.5.6",
+            "heimdalljs": "0.2.5",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "path-posix": "1.0.0",
+            "rimraf": "2.6.1",
+            "symlink-or-copy": "1.1.8",
+            "walk-sync": "0.3.2"
+          }
+        },
         "broccoli-merge-trees": {
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
@@ -5042,6 +5127,28 @@
             "workerpool": "2.2.2"
           }
         },
+        "broccoli-funnel": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+          "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+          "dev": true,
+          "requires": {
+            "array-equal": "1.0.0",
+            "blank-object": "1.0.2",
+            "broccoli-plugin": "1.3.0",
+            "debug": "2.6.8",
+            "exists-sync": "0.0.4",
+            "fast-ordered-set": "1.0.3",
+            "fs-tree-diff": "0.5.6",
+            "heimdalljs": "0.2.5",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "path-posix": "1.0.0",
+            "rimraf": "2.6.1",
+            "symlink-or-copy": "1.1.8",
+            "walk-sync": "0.3.2"
+          }
+        },
         "broccoli-merge-trees": {
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
@@ -5126,6 +5233,39 @@
             "clone": "2.1.1",
             "ember-cli-version-checker": "1.3.1",
             "resolve": "1.4.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+              "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+              "dev": true,
+              "requires": {
+                "array-equal": "1.0.0",
+                "blank-object": "1.0.2",
+                "broccoli-plugin": "1.3.0",
+                "debug": "2.6.8",
+                "exists-sync": "0.0.4",
+                "fast-ordered-set": "1.0.3",
+                "fs-tree-diff": "0.5.6",
+                "heimdalljs": "0.2.5",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "path-posix": "1.0.0",
+                "rimraf": "2.6.1",
+                "symlink-or-copy": "1.1.8",
+                "walk-sync": "0.3.2"
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
           }
         }
       }
@@ -5451,6 +5591,28 @@
         "rimraf": "2.6.1"
       },
       "dependencies": {
+        "broccoli-funnel": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+          "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+          "dev": true,
+          "requires": {
+            "array-equal": "1.0.0",
+            "blank-object": "1.0.2",
+            "broccoli-plugin": "1.3.0",
+            "debug": "2.6.8",
+            "exists-sync": "0.0.4",
+            "fast-ordered-set": "1.0.3",
+            "fs-tree-diff": "0.5.6",
+            "heimdalljs": "0.2.5",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "path-posix": "1.0.0",
+            "rimraf": "2.6.1",
+            "symlink-or-copy": "1.1.8",
+            "walk-sync": "0.3.2"
+          }
+        },
         "broccoli-merge-trees": {
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
@@ -5479,6 +5641,15 @@
             "ember-cli-version-checker": "1.3.1",
             "resolve": "1.4.0"
           }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
         }
       }
     },
@@ -5502,6 +5673,39 @@
             "clone": "2.1.1",
             "ember-cli-version-checker": "1.3.1",
             "resolve": "1.4.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+              "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+              "dev": true,
+              "requires": {
+                "array-equal": "1.0.0",
+                "blank-object": "1.0.2",
+                "broccoli-plugin": "1.3.0",
+                "debug": "2.6.8",
+                "exists-sync": "0.0.4",
+                "fast-ordered-set": "1.0.3",
+                "fs-tree-diff": "0.5.6",
+                "heimdalljs": "0.2.5",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "path-posix": "1.0.0",
+                "rimraf": "2.6.1",
+                "symlink-or-copy": "1.1.8",
+                "walk-sync": "0.3.2"
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
           }
         }
       }
@@ -5771,6 +5975,36 @@
         "route-recognizer": "0.2.10"
       },
       "dependencies": {
+        "broccoli-funnel": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+          "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+          "dev": true,
+          "requires": {
+            "array-equal": "1.0.0",
+            "blank-object": "1.0.2",
+            "broccoli-plugin": "1.3.0",
+            "debug": "2.6.8",
+            "exists-sync": "0.0.4",
+            "fast-ordered-set": "1.0.3",
+            "fs-tree-diff": "0.5.6",
+            "heimdalljs": "0.2.5",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "path-posix": "1.0.0",
+            "rimraf": "2.6.1",
+            "symlink-or-copy": "1.1.8",
+            "walk-sync": "0.3.2"
+          },
+          "dependencies": {
+            "exists-sync": {
+              "version": "0.0.4",
+              "resolved": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.4.tgz",
+              "integrity": "sha1-l0TCxCjMA7AQYNtFTUsS8O88iHk=",
+              "dev": true
+            }
+          }
+        },
         "broccoli-merge-trees": {
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
@@ -5814,6 +6048,15 @@
           "resolved": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.3.tgz",
           "integrity": "sha1-uRAAC+27ETs3i4L19adjgQdiLc8=",
           "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
         }
       }
     },
@@ -5888,6 +6131,28 @@
         "resolve": "1.4.0"
       },
       "dependencies": {
+        "broccoli-funnel": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+          "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+          "dev": true,
+          "requires": {
+            "array-equal": "1.0.0",
+            "blank-object": "1.0.2",
+            "broccoli-plugin": "1.3.0",
+            "debug": "2.6.8",
+            "exists-sync": "0.0.4",
+            "fast-ordered-set": "1.0.3",
+            "fs-tree-diff": "0.5.6",
+            "heimdalljs": "0.2.5",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "path-posix": "1.0.0",
+            "rimraf": "2.6.1",
+            "symlink-or-copy": "1.1.8",
+            "walk-sync": "0.3.2"
+          }
+        },
         "broccoli-merge-trees": {
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
@@ -5909,6 +6174,15 @@
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
           "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
         }
       }
     },
@@ -5952,6 +6226,39 @@
             "clone": "2.1.1",
             "ember-cli-version-checker": "1.3.1",
             "resolve": "1.4.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+              "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+              "dev": true,
+              "requires": {
+                "array-equal": "1.0.0",
+                "blank-object": "1.0.2",
+                "broccoli-plugin": "1.3.0",
+                "debug": "2.6.8",
+                "exists-sync": "0.0.4",
+                "fast-ordered-set": "1.0.3",
+                "fs-tree-diff": "0.5.6",
+                "heimdalljs": "0.2.5",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "path-posix": "1.0.0",
+                "rimraf": "2.6.1",
+                "symlink-or-copy": "1.1.8",
+                "walk-sync": "0.3.2"
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
           }
         }
       }
@@ -5978,6 +6285,36 @@
         "silent-error": "1.1.0"
       },
       "dependencies": {
+        "broccoli-funnel": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+          "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+          "dev": true,
+          "requires": {
+            "array-equal": "1.0.0",
+            "blank-object": "1.0.2",
+            "broccoli-plugin": "1.3.0",
+            "debug": "2.6.8",
+            "exists-sync": "0.0.4",
+            "fast-ordered-set": "1.0.3",
+            "fs-tree-diff": "0.5.6",
+            "heimdalljs": "0.2.5",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "path-posix": "1.0.0",
+            "rimraf": "2.6.1",
+            "symlink-or-copy": "1.1.8",
+            "walk-sync": "0.3.2"
+          },
+          "dependencies": {
+            "exists-sync": {
+              "version": "0.0.4",
+              "resolved": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.4.tgz",
+              "integrity": "sha1-l0TCxCjMA7AQYNtFTUsS8O88iHk=",
+              "dev": true
+            }
+          }
+        },
         "broccoli-merge-trees": {
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
@@ -6005,6 +6342,15 @@
           "resolved": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.3.tgz",
           "integrity": "sha1-uRAAC+27ETs3i4L19adjgQdiLc8=",
           "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
         }
       }
     },
@@ -6024,6 +6370,39 @@
         "qunitjs": "2.4.0",
         "resolve": "1.4.0",
         "silent-error": "1.1.0"
+      },
+      "dependencies": {
+        "broccoli-funnel": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+          "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+          "dev": true,
+          "requires": {
+            "array-equal": "1.0.0",
+            "blank-object": "1.0.2",
+            "broccoli-plugin": "1.3.0",
+            "debug": "2.6.8",
+            "exists-sync": "0.0.4",
+            "fast-ordered-set": "1.0.3",
+            "fs-tree-diff": "0.5.6",
+            "heimdalljs": "0.2.5",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "path-posix": "1.0.0",
+            "rimraf": "2.6.1",
+            "symlink-or-copy": "1.1.8",
+            "walk-sync": "0.3.2"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        }
       }
     },
     "ember-cli-sass": {
@@ -6038,6 +6417,28 @@
         "ember-cli-version-checker": "1.3.1"
       },
       "dependencies": {
+        "broccoli-funnel": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+          "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+          "dev": true,
+          "requires": {
+            "array-equal": "1.0.0",
+            "blank-object": "1.0.2",
+            "broccoli-plugin": "1.3.0",
+            "debug": "2.6.8",
+            "exists-sync": "0.0.4",
+            "fast-ordered-set": "1.0.3",
+            "fs-tree-diff": "0.5.6",
+            "heimdalljs": "0.2.5",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "path-posix": "1.0.0",
+            "rimraf": "2.6.1",
+            "symlink-or-copy": "1.1.8",
+            "walk-sync": "0.3.2"
+          }
+        },
         "broccoli-merge-trees": {
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
@@ -6052,6 +6453,15 @@
             "heimdalljs-logger": "0.1.9",
             "rimraf": "2.6.1",
             "symlink-or-copy": "1.1.8"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
           }
         }
       }
@@ -6168,6 +6578,39 @@
       "requires": {
         "broccoli-funnel": "1.2.0",
         "ember-cli-babel": "6.8.2"
+      },
+      "dependencies": {
+        "broccoli-funnel": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+          "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+          "dev": true,
+          "requires": {
+            "array-equal": "1.0.0",
+            "blank-object": "1.0.2",
+            "broccoli-plugin": "1.3.0",
+            "debug": "2.6.8",
+            "exists-sync": "0.0.4",
+            "fast-ordered-set": "1.0.3",
+            "fs-tree-diff": "0.5.6",
+            "heimdalljs": "0.2.5",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "path-posix": "1.0.0",
+            "rimraf": "2.6.1",
+            "symlink-or-copy": "1.1.8",
+            "walk-sync": "0.3.2"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        }
       }
     },
     "ember-concurrency": {
@@ -6360,6 +6803,51 @@
             }
           }
         },
+        "broccoli-funnel": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+          "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+          "dev": true,
+          "requires": {
+            "array-equal": "1.0.0",
+            "blank-object": "1.0.2",
+            "broccoli-plugin": "1.3.0",
+            "debug": "2.6.8",
+            "exists-sync": "0.0.4",
+            "fast-ordered-set": "1.0.3",
+            "fs-tree-diff": "0.5.6",
+            "heimdalljs": "0.2.5",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "path-posix": "1.0.0",
+            "rimraf": "2.6.1",
+            "symlink-or-copy": "1.1.8",
+            "walk-sync": "0.3.2"
+          },
+          "dependencies": {
+            "exists-sync": {
+              "version": "0.0.4",
+              "resolved": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.4.tgz",
+              "integrity": "sha1-l0TCxCjMA7AQYNtFTUsS8O88iHk=",
+              "dev": true
+            },
+            "heimdalljs": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.5.tgz",
+              "integrity": "sha1-aqVDCO7nk7ZCz/nPlHgURfN3MKw=",
+              "dev": true,
+              "requires": {
+                "rsvp": "3.2.1"
+              }
+            },
+            "rsvp": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+              "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo=",
+              "dev": true
+            }
+          }
+        },
         "exists-sync": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.3.tgz",
@@ -6426,6 +6914,39 @@
             "clone": "2.1.1",
             "ember-cli-version-checker": "1.3.1",
             "resolve": "1.4.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+              "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+              "dev": true,
+              "requires": {
+                "array-equal": "1.0.0",
+                "blank-object": "1.0.2",
+                "broccoli-plugin": "1.3.0",
+                "debug": "2.6.8",
+                "exists-sync": "0.0.4",
+                "fast-ordered-set": "1.0.3",
+                "fs-tree-diff": "0.5.6",
+                "heimdalljs": "0.2.5",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "path-posix": "1.0.0",
+                "rimraf": "2.6.1",
+                "symlink-or-copy": "1.1.8",
+                "walk-sync": "0.3.2"
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
           }
         }
       }
@@ -6450,6 +6971,39 @@
             "clone": "2.1.1",
             "ember-cli-version-checker": "1.3.1",
             "resolve": "1.4.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+              "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+              "dev": true,
+              "requires": {
+                "array-equal": "1.0.0",
+                "blank-object": "1.0.2",
+                "broccoli-plugin": "1.3.0",
+                "debug": "2.6.8",
+                "exists-sync": "0.0.4",
+                "fast-ordered-set": "1.0.3",
+                "fs-tree-diff": "0.5.6",
+                "heimdalljs": "0.2.5",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "path-posix": "1.0.0",
+                "rimraf": "2.6.1",
+                "symlink-or-copy": "1.1.8",
+                "walk-sync": "0.3.2"
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
           }
         }
       }
@@ -6500,6 +7054,39 @@
             "clone": "2.1.1",
             "ember-cli-version-checker": "1.3.1",
             "resolve": "1.4.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+              "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+              "dev": true,
+              "requires": {
+                "array-equal": "1.0.0",
+                "blank-object": "1.0.2",
+                "broccoli-plugin": "1.3.0",
+                "debug": "2.6.8",
+                "exists-sync": "0.0.4",
+                "fast-ordered-set": "1.0.3",
+                "fs-tree-diff": "0.5.6",
+                "heimdalljs": "0.2.5",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "path-posix": "1.0.0",
+                "rimraf": "2.6.1",
+                "symlink-or-copy": "1.1.8",
+                "walk-sync": "0.3.2"
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
           }
         }
       }
@@ -6529,6 +7116,30 @@
             "clone": "2.1.1",
             "ember-cli-version-checker": "1.3.1",
             "resolve": "1.4.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+              "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+              "dev": true,
+              "requires": {
+                "array-equal": "1.0.0",
+                "blank-object": "1.0.2",
+                "broccoli-plugin": "1.3.0",
+                "debug": "2.6.8",
+                "exists-sync": "0.0.4",
+                "fast-ordered-set": "1.0.3",
+                "fs-tree-diff": "0.5.6",
+                "heimdalljs": "0.2.5",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "path-posix": "1.0.0",
+                "rimraf": "2.6.1",
+                "symlink-or-copy": "1.1.8",
+                "walk-sync": "0.3.2"
+              }
+            }
           }
         },
         "fs-extra": {
@@ -6542,6 +7153,15 @@
             "klaw": "1.3.1",
             "path-is-absolute": "1.0.1",
             "rimraf": "2.6.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
           }
         }
       }
@@ -6584,6 +7204,39 @@
             "clone": "2.1.1",
             "ember-cli-version-checker": "1.3.1",
             "resolve": "1.4.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+              "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+              "dev": true,
+              "requires": {
+                "array-equal": "1.0.0",
+                "blank-object": "1.0.2",
+                "broccoli-plugin": "1.3.0",
+                "debug": "2.6.8",
+                "exists-sync": "0.0.4",
+                "fast-ordered-set": "1.0.3",
+                "fs-tree-diff": "0.5.6",
+                "heimdalljs": "0.2.5",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "path-posix": "1.0.0",
+                "rimraf": "2.6.1",
+                "symlink-or-copy": "1.1.8",
+                "walk-sync": "0.3.2"
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
           }
         }
       }
@@ -6609,6 +7262,39 @@
             "clone": "2.1.1",
             "ember-cli-version-checker": "1.3.1",
             "resolve": "1.4.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+              "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+              "dev": true,
+              "requires": {
+                "array-equal": "1.0.0",
+                "blank-object": "1.0.2",
+                "broccoli-plugin": "1.3.0",
+                "debug": "2.6.8",
+                "exists-sync": "0.0.4",
+                "fast-ordered-set": "1.0.3",
+                "fs-tree-diff": "0.5.6",
+                "heimdalljs": "0.2.5",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "path-posix": "1.0.0",
+                "rimraf": "2.6.1",
+                "symlink-or-copy": "1.1.8",
+                "walk-sync": "0.3.2"
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
           }
         }
       }
@@ -6635,6 +7321,39 @@
             "clone": "2.1.1",
             "ember-cli-version-checker": "1.3.1",
             "resolve": "1.4.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+              "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+              "dev": true,
+              "requires": {
+                "array-equal": "1.0.0",
+                "blank-object": "1.0.2",
+                "broccoli-plugin": "1.3.0",
+                "debug": "2.6.8",
+                "exists-sync": "0.0.4",
+                "fast-ordered-set": "1.0.3",
+                "fs-tree-diff": "0.5.6",
+                "heimdalljs": "0.2.5",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "path-posix": "1.0.0",
+                "rimraf": "2.6.1",
+                "symlink-or-copy": "1.1.8",
+                "walk-sync": "0.3.2"
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
           }
         }
       }
@@ -6660,6 +7379,39 @@
             "clone": "2.1.1",
             "ember-cli-version-checker": "1.3.1",
             "resolve": "1.4.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+              "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+              "dev": true,
+              "requires": {
+                "array-equal": "1.0.0",
+                "blank-object": "1.0.2",
+                "broccoli-plugin": "1.3.0",
+                "debug": "2.6.8",
+                "exists-sync": "0.0.4",
+                "fast-ordered-set": "1.0.3",
+                "fs-tree-diff": "0.5.6",
+                "heimdalljs": "0.2.5",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "path-posix": "1.0.0",
+                "rimraf": "2.6.1",
+                "symlink-or-copy": "1.1.8",
+                "walk-sync": "0.3.2"
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
           }
         }
       }
@@ -6684,6 +7436,39 @@
             "clone": "2.1.1",
             "ember-cli-version-checker": "1.3.1",
             "resolve": "1.4.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+              "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+              "dev": true,
+              "requires": {
+                "array-equal": "1.0.0",
+                "blank-object": "1.0.2",
+                "broccoli-plugin": "1.3.0",
+                "debug": "2.6.8",
+                "exists-sync": "0.0.4",
+                "fast-ordered-set": "1.0.3",
+                "fs-tree-diff": "0.5.6",
+                "heimdalljs": "0.2.5",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "path-posix": "1.0.0",
+                "rimraf": "2.6.1",
+                "symlink-or-copy": "1.1.8",
+                "walk-sync": "0.3.2"
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
           }
         }
       }
@@ -6717,6 +7502,39 @@
             "clone": "2.1.1",
             "ember-cli-version-checker": "1.3.1",
             "resolve": "1.4.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+              "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+              "dev": true,
+              "requires": {
+                "array-equal": "1.0.0",
+                "blank-object": "1.0.2",
+                "broccoli-plugin": "1.3.0",
+                "debug": "2.6.8",
+                "exists-sync": "0.0.4",
+                "fast-ordered-set": "1.0.3",
+                "fs-tree-diff": "0.5.6",
+                "heimdalljs": "0.2.5",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "path-posix": "1.0.0",
+                "rimraf": "2.6.1",
+                "symlink-or-copy": "1.1.8",
+                "walk-sync": "0.3.2"
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
           }
         }
       }
@@ -6753,6 +7571,39 @@
         "broccoli-string-replace": "0.1.2",
         "ember-cli-babel": "6.8.2",
         "lodash-es": "4.17.4"
+      },
+      "dependencies": {
+        "broccoli-funnel": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+          "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+          "dev": true,
+          "requires": {
+            "array-equal": "1.0.0",
+            "blank-object": "1.0.2",
+            "broccoli-plugin": "1.3.0",
+            "debug": "2.6.8",
+            "exists-sync": "0.0.4",
+            "fast-ordered-set": "1.0.3",
+            "fs-tree-diff": "0.5.6",
+            "heimdalljs": "0.2.5",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "path-posix": "1.0.0",
+            "rimraf": "2.6.1",
+            "symlink-or-copy": "1.1.8",
+            "walk-sync": "0.3.2"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        }
       }
     },
     "ember-macro-helpers": {
@@ -6779,6 +7630,28 @@
         "regenerator-runtime": "0.9.6"
       },
       "dependencies": {
+        "broccoli-funnel": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+          "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+          "dev": true,
+          "requires": {
+            "array-equal": "1.0.0",
+            "blank-object": "1.0.2",
+            "broccoli-plugin": "1.3.0",
+            "debug": "2.6.8",
+            "exists-sync": "0.0.4",
+            "fast-ordered-set": "1.0.3",
+            "fs-tree-diff": "0.5.6",
+            "heimdalljs": "0.2.5",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "path-posix": "1.0.0",
+            "rimraf": "2.6.1",
+            "symlink-or-copy": "1.1.8",
+            "walk-sync": "0.3.2"
+          }
+        },
         "broccoli-merge-trees": {
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
@@ -6793,6 +7666,15 @@
             "heimdalljs-logger": "0.1.9",
             "rimraf": "2.6.1",
             "symlink-or-copy": "1.1.8"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
           }
         },
         "regenerator-runtime": {
@@ -6887,6 +7769,39 @@
             "clone": "2.1.1",
             "ember-cli-version-checker": "1.3.1",
             "resolve": "1.4.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+              "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+              "dev": true,
+              "requires": {
+                "array-equal": "1.0.0",
+                "blank-object": "1.0.2",
+                "broccoli-plugin": "1.3.0",
+                "debug": "2.6.8",
+                "exists-sync": "0.0.4",
+                "fast-ordered-set": "1.0.3",
+                "fs-tree-diff": "0.5.6",
+                "heimdalljs": "0.2.5",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "path-posix": "1.0.0",
+                "rimraf": "2.6.1",
+                "symlink-or-copy": "1.1.8",
+                "walk-sync": "0.3.2"
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
           }
         }
       }
@@ -6944,6 +7859,30 @@
             "debug": "2.6.8",
             "lodash": "4.17.4",
             "resolve": "1.4.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+              "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+              "dev": true,
+              "requires": {
+                "array-equal": "1.0.0",
+                "blank-object": "1.0.2",
+                "broccoli-plugin": "1.3.0",
+                "debug": "2.6.8",
+                "exists-sync": "0.0.4",
+                "fast-ordered-set": "1.0.3",
+                "fs-tree-diff": "0.5.6",
+                "heimdalljs": "0.2.5",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "path-posix": "1.0.0",
+                "rimraf": "2.6.1",
+                "symlink-or-copy": "1.1.8",
+                "walk-sync": "0.3.2"
+              }
+            }
           }
         },
         "lodash": {
@@ -6951,6 +7890,15 @@
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
           "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
         }
       }
     },
@@ -6974,6 +7922,39 @@
             "clone": "2.1.1",
             "ember-cli-version-checker": "1.3.1",
             "resolve": "1.4.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+              "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+              "dev": true,
+              "requires": {
+                "array-equal": "1.0.0",
+                "blank-object": "1.0.2",
+                "broccoli-plugin": "1.3.0",
+                "debug": "2.6.8",
+                "exists-sync": "0.0.4",
+                "fast-ordered-set": "1.0.3",
+                "fs-tree-diff": "0.5.6",
+                "heimdalljs": "0.2.5",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "path-posix": "1.0.0",
+                "rimraf": "2.6.1",
+                "symlink-or-copy": "1.1.8",
+                "walk-sync": "0.3.2"
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
           }
         }
       }
@@ -7043,6 +8024,30 @@
             "clone": "2.1.1",
             "ember-cli-version-checker": "1.3.1",
             "resolve": "1.4.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+              "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+              "dev": true,
+              "requires": {
+                "array-equal": "1.0.0",
+                "blank-object": "1.0.2",
+                "broccoli-plugin": "1.3.0",
+                "debug": "2.6.8",
+                "exists-sync": "0.0.4",
+                "fast-ordered-set": "1.0.3",
+                "fs-tree-diff": "0.5.6",
+                "heimdalljs": "0.2.5",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "path-posix": "1.0.0",
+                "rimraf": "2.6.1",
+                "symlink-or-copy": "1.1.8",
+                "walk-sync": "0.3.2"
+              }
+            }
           }
         },
         "esprima": {
@@ -7099,6 +8104,39 @@
         "ember-cli-babel": "6.8.2",
         "ember-cli-version-checker": "1.3.1",
         "resolve": "1.4.0"
+      },
+      "dependencies": {
+        "broccoli-funnel": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+          "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+          "dev": true,
+          "requires": {
+            "array-equal": "1.0.0",
+            "blank-object": "1.0.2",
+            "broccoli-plugin": "1.3.0",
+            "debug": "2.6.8",
+            "exists-sync": "0.0.4",
+            "fast-ordered-set": "1.0.3",
+            "fs-tree-diff": "0.5.6",
+            "heimdalljs": "0.2.5",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "path-posix": "1.0.0",
+            "rimraf": "2.6.1",
+            "symlink-or-copy": "1.1.8",
+            "walk-sync": "0.3.2"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        }
       }
     },
     "ember-rfc176-data": {
@@ -7239,6 +8277,39 @@
         "rsvp": "3.6.2",
         "simple-dom": "0.3.2",
         "simple-html-tokenizer": "0.4.3"
+      },
+      "dependencies": {
+        "broccoli-funnel": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+          "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+          "dev": true,
+          "requires": {
+            "array-equal": "1.0.0",
+            "blank-object": "1.0.2",
+            "broccoli-plugin": "1.3.0",
+            "debug": "2.6.8",
+            "exists-sync": "0.0.4",
+            "fast-ordered-set": "1.0.3",
+            "fs-tree-diff": "0.5.6",
+            "heimdalljs": "0.2.5",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "path-posix": "1.0.0",
+            "rimraf": "2.6.1",
+            "symlink-or-copy": "1.1.8",
+            "walk-sync": "0.3.2"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        }
       }
     },
     "ember-svg-jar": {
@@ -7271,6 +8342,61 @@
             "rimraf": "2.6.1",
             "rsvp": "3.6.2",
             "walk-sync": "0.2.7"
+          }
+        },
+        "broccoli-funnel": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+          "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+          "dev": true,
+          "requires": {
+            "array-equal": "1.0.0",
+            "blank-object": "1.0.2",
+            "broccoli-plugin": "1.3.0",
+            "debug": "2.6.8",
+            "exists-sync": "0.0.4",
+            "fast-ordered-set": "1.0.3",
+            "fs-tree-diff": "0.5.6",
+            "heimdalljs": "0.2.5",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "path-posix": "1.0.0",
+            "rimraf": "2.6.1",
+            "symlink-or-copy": "1.1.8",
+            "walk-sync": "0.3.2"
+          },
+          "dependencies": {
+            "broccoli-plugin": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz",
+              "integrity": "sha1-vucEqOQtoIy1jlE6qkNu+38O8e4=",
+              "dev": true,
+              "requires": {
+                "promise-map-series": "0.2.3",
+                "quick-temp": "0.1.8",
+                "rimraf": "2.6.1",
+                "symlink-or-copy": "1.1.8"
+              }
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+              "dev": true,
+              "requires": {
+                "brace-expansion": "1.1.8"
+              }
+            },
+            "walk-sync": {
+              "version": "0.3.2",
+              "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.2.tgz",
+              "integrity": "sha512-FMB5VqpLqOCcqrzA9okZFc0wq0Qbmdm396qJxvQZhDpyu0W95G9JCmp74tx7iyYnyOcBtUuKJsgIKAqjozvmmQ==",
+              "dev": true,
+              "requires": {
+                "ensure-posix-path": "1.0.2",
+                "matcher-collection": "1.0.4"
+              }
+            }
           }
         },
         "broccoli-kitchen-sink-helpers": {
@@ -7366,6 +8492,28 @@
         "ember-cli-babel": "5.2.4"
       },
       "dependencies": {
+        "broccoli-funnel": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+          "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+          "dev": true,
+          "requires": {
+            "array-equal": "1.0.0",
+            "blank-object": "1.0.2",
+            "broccoli-plugin": "1.3.0",
+            "debug": "2.6.8",
+            "exists-sync": "0.0.4",
+            "fast-ordered-set": "1.0.3",
+            "fs-tree-diff": "0.5.6",
+            "heimdalljs": "0.2.5",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "path-posix": "1.0.0",
+            "rimraf": "2.6.1",
+            "symlink-or-copy": "1.1.8",
+            "walk-sync": "0.3.2"
+          }
+        },
         "ember-cli-babel": {
           "version": "5.2.4",
           "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz",
@@ -7377,6 +8525,15 @@
             "clone": "2.1.1",
             "ember-cli-version-checker": "1.3.1",
             "resolve": "1.4.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
           }
         }
       }
@@ -7425,6 +8582,30 @@
             "clone": "2.1.1",
             "ember-cli-version-checker": "1.3.1",
             "resolve": "1.4.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+              "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+              "dev": true,
+              "requires": {
+                "array-equal": "1.0.0",
+                "blank-object": "1.0.2",
+                "broccoli-plugin": "1.3.0",
+                "debug": "2.6.8",
+                "exists-sync": "0.0.4",
+                "fast-ordered-set": "1.0.3",
+                "fs-tree-diff": "0.5.6",
+                "heimdalljs": "0.2.5",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "path-posix": "1.0.0",
+                "rimraf": "2.6.1",
+                "symlink-or-copy": "1.1.8",
+                "walk-sync": "0.3.2"
+              }
+            }
           }
         },
         "ember-cli-node-assets": {
@@ -7439,6 +8620,30 @@
             "debug": "2.6.8",
             "lodash": "4.17.4",
             "resolve": "1.4.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+              "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+              "dev": true,
+              "requires": {
+                "array-equal": "1.0.0",
+                "blank-object": "1.0.2",
+                "broccoli-plugin": "1.3.0",
+                "debug": "2.6.8",
+                "exists-sync": "0.0.4",
+                "fast-ordered-set": "1.0.3",
+                "fs-tree-diff": "0.5.6",
+                "heimdalljs": "0.2.5",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "path-posix": "1.0.0",
+                "rimraf": "2.6.1",
+                "symlink-or-copy": "1.1.8",
+                "walk-sync": "0.3.2"
+              }
+            }
           }
         },
         "lodash": {
@@ -7446,6 +8651,15 @@
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
           "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
         }
       }
     },
@@ -7497,8 +8711,41 @@
                 "clone": "2.1.1",
                 "ember-cli-version-checker": "1.3.1",
                 "resolve": "1.4.0"
+              },
+              "dependencies": {
+                "broccoli-funnel": {
+                  "version": "1.2.0",
+                  "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+                  "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+                  "dev": true,
+                  "requires": {
+                    "array-equal": "1.0.0",
+                    "blank-object": "1.0.2",
+                    "broccoli-plugin": "1.3.0",
+                    "debug": "2.6.8",
+                    "exists-sync": "0.0.4",
+                    "fast-ordered-set": "1.0.3",
+                    "fs-tree-diff": "0.5.6",
+                    "heimdalljs": "0.2.5",
+                    "minimatch": "3.0.4",
+                    "mkdirp": "0.5.1",
+                    "path-posix": "1.0.0",
+                    "rimraf": "2.6.1",
+                    "symlink-or-copy": "1.1.8",
+                    "walk-sync": "0.3.2"
+                  }
+                }
               }
             }
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
           }
         }
       }
@@ -7579,6 +8826,39 @@
             "clone": "2.1.1",
             "ember-cli-version-checker": "1.3.1",
             "resolve": "1.4.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+              "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+              "dev": true,
+              "requires": {
+                "array-equal": "1.0.0",
+                "blank-object": "1.0.2",
+                "broccoli-plugin": "1.3.0",
+                "debug": "2.6.8",
+                "exists-sync": "0.0.4",
+                "fast-ordered-set": "1.0.3",
+                "fs-tree-diff": "0.5.6",
+                "heimdalljs": "0.2.5",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "path-posix": "1.0.0",
+                "rimraf": "2.6.1",
+                "symlink-or-copy": "1.1.8",
+                "walk-sync": "0.3.2"
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "broccoli-asset-rev": "^2.4.5",
-    "broccoli-funnel": "^1.0.7",
+    "broccoli-funnel": "^2.0.1",
     "broccoli-merge-trees": "^2.0.0",
     "ember-ajax": "3.0.0",
     "ember-browserify": "^1.1.13",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "active-model-adapter": "2.1.1",
     "ansiparse": "0.1.0",
-    "babel-eslint": "^7.1.1",
+    "babel-eslint": "^8.0.3",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "broccoli-asset-rev": "^2.4.5",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "ember-modal-dialog": "^2.2.0",
     "ember-moment": "^7.4.1",
     "ember-one-way-controls": "^2.0.1",
-    "ember-percy": "1.2.13",
+    "ember-percy": "^1.2.22",
     "ember-prism": "0.1.1",
     "ember-promise-helpers": "^1.0.3",
     "ember-qunit-nice-errors": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ember-browserify": "^1.1.13",
     "ember-cli": "~2.16.2",
     "ember-cli-app-version": "^3.0.0",
-    "ember-cli-autoprefixer": "^0.7.0",
+    "ember-cli-autoprefixer": "^0.8.1",
     "ember-cli-babel": "6.8.2",
     "ember-cli-content-security-policy": "0.6.1",
     "ember-cli-dependency-checker": "^2.0.0",


### PR DESCRIPTION
We haven’t restored Greenkeeper, so I’m manually updating some packages.
I realised after starting that I might as well update Ember and Ember CLI
to get those known updates out of the way, so I’ll come back to doing this
(in a new PR) after that.