### PR TITLE
Move fuzzysort into devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11173,7 +11173,8 @@
     "fuzzysort": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-1.0.2.tgz",
-      "integrity": "sha512-atTlYyCB0YD6+NPSoZf8VWBM44IhNMRFwYpWu2ivUrFMZU2anyE3bZoeqK1JFB2cpR+pAiKfo2062RZesi4Xpg=="
+      "integrity": "sha512-atTlYyCB0YD6+NPSoZf8VWBM44IhNMRFwYpWu2ivUrFMZU2anyE3bZoeqK1JFB2cpR+pAiKfo2062RZesi4Xpg==",
+      "dev": true
     },
     "gauge": {
       "version": "2.7.4",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "emberx-select": "~3.1.0",
     "emoji-datasource-apple": "^4.0.0",
     "emoji-js": "^3.4.0",
+    "fuzzysort": "^1.0.1",
     "glob": "^7.1.2",
     "loader.js": "^4.2.3",
     "lodash.intersection": "4.4.0",
@@ -92,8 +93,5 @@
   "engines": {
     "node": "8.5.0",
     "npm": "5.4.2"
-  },
-  "dependencies": {
-    "fuzzysort": "^1.0.1"
   }
 }


### PR DESCRIPTION
I’m not sure about this being necessary BUT it follows the
existing pattern!