### PR TITLE
Introduce an api service for API V3

### DIFF
--- a/app/components/dashboard-row.js
+++ b/app/components/dashboard-row.js
@@ -7,7 +7,7 @@ import { alias } from 'ember-decorators/object/computed';
 export default Component.extend({
   @service('permissions') permissionsService: null,
   @service externalLinks: null,
-  @service ajax: null,
+  @service api: null,
   @service flashes: null,
 
   tagName: 'li',
@@ -40,7 +40,7 @@ export default Component.extend({
     let data = {};
     data.request = `{ 'branch': '${this.get('repo.defaultBranch.name')}' }`;
 
-    this.get('ajax').postV3(`/repo/${this.get('repo.id')}/requests`, data)
+    this.get('api').post(`/repo/${this.get('repo.id')}/requests`, { data: data })
       .then(() => {
         self.set('isTriggering', false);
         self.get('flashes')

--- a/app/components/repository-layout.js
+++ b/app/components/repository-layout.js
@@ -5,7 +5,6 @@ import { service } from 'ember-decorators/service';
 export default Component.extend({
   @service statusImages: null,
   @service externalLinks: null,
-  @service ajax: null,
 
   isShowingTriggerBuildModal: false,
   isShowingStatusBadgeModal: false,

--- a/app/components/repository-sidebar.js
+++ b/app/components/repository-sidebar.js
@@ -11,7 +11,6 @@ import { service } from 'ember-decorators/service';
 export default Component.extend({
   @service tabStates: null,
   @service jobState: null,
-  @service ajax: null,
   @service('updateTimes') updateTimesService: null,
   @service repositories: null,
   @service store: null,

--- a/app/components/trigger-custom-build.js
+++ b/app/components/trigger-custom-build.js
@@ -6,7 +6,7 @@ import { service } from 'ember-decorators/service';
 import { filterBy, notEmpty } from 'ember-decorators/object/computed';
 
 export default Component.extend({
-  @service ajax: null,
+  @service api: null,
   @service flashes: null,
   @service router: null,
 
@@ -26,7 +26,7 @@ export default Component.extend({
   createBuild: task(function* () {
     try {
       const body = this.buildTriggerRequestBody();
-      return yield this.get('ajax').postV3(`/repo/${this.get('repo.id')}/requests`, body);
+      return yield this.get('api').post(`/repo/${this.get('repo.id')}/requests`, { data: body });
     } catch (e) {
       this.displayError(e);
     }
@@ -48,10 +48,7 @@ export default Component.extend({
   fetchBuildStatus: task(function* (repoId, requestId) {
     try {
       const url = `/repo/${repoId}/request/${requestId}`;
-      const headers = {
-        'Travis-API-Version': '3'
-      };
-      return yield this.get('ajax').ajax(url, 'GET', { headers });
+      return yield this.get('api').request(url);
     } catch (e) {
       this.displayError(e);
     }

--- a/app/components/trigger-custom-build.js
+++ b/app/components/trigger-custom-build.js
@@ -48,7 +48,7 @@ export default Component.extend({
   fetchBuildStatus: task(function* (repoId, requestId) {
     try {
       const url = `/repo/${repoId}/request/${requestId}`;
-      return yield this.get('api').request(url);
+      return yield this.get('api').get(url);
     } catch (e) {
       this.displayError(e);
     }

--- a/app/controllers/dashboard/repositories.js
+++ b/app/controllers/dashboard/repositories.js
@@ -10,7 +10,7 @@ export default Controller.extend({
   offset: 0,
 
   @service flashes: null,
-  @service ajax: null,
+  @service api: null,
 
   starring: taskGroup().drop(),
 
@@ -25,7 +25,7 @@ export default Controller.extend({
   star: task(function* (repo) {
     repo.set('starred', true);
     try {
-      yield this.get('ajax').postV3(`/repo/${repo.get('id')}/star`);
+      yield this.get('api').post(`/repo/${repo.get('id')}/star`);
     } catch (e) {
       repo.set('starred', false);
       this.get('flashes')
@@ -37,7 +37,7 @@ export default Controller.extend({
   unstar: task(function* (repo) {
     repo.set('starred', false);
     try {
-      yield this.get('ajax').postV3(`/repo/${repo.get('id')}/unstar`);
+      yield this.get('api').post(`/repo/${repo.get('id')}/unstar`);
     } catch (e) {
       repo.set('starred', true);
       this.get('flashes')

--- a/app/models/build.js
+++ b/app/models/build.js
@@ -15,7 +15,7 @@ import { alias } from 'ember-decorators/object/computed';
 import moment from 'moment';
 
 export default Model.extend(DurationCalculations, {
-  @service ajax: null,
+  @service api: null,
 
   @alias('branch.name') branchName: null,
 
@@ -127,12 +127,12 @@ export default Model.extend(DurationCalculations, {
 
   cancel() {
     const url = `/build/${this.get('id')}/cancel`;
-    return this.get('ajax').postV3(url);
+    return this.get('api').post(url);
   },
 
   restart() {
     const url = `/build/${this.get('id')}/restart`;
-    return this.get('ajax').postV3(url);
+    return this.get('api').post(url);
   },
 
   @computed('jobs.[]')

--- a/app/models/job.js
+++ b/app/models/job.js
@@ -18,6 +18,7 @@ import { service } from 'ember-decorators/service';
 import moment from 'moment';
 
 export default Model.extend(DurationCalculations, DurationAttributes, {
+  @service api: null,
   @service ajax: null,
   @service jobConfigFetcher: null,
 
@@ -52,7 +53,7 @@ export default Model.extend(DurationCalculations, DurationAttributes, {
     this.set('isLogAccessed', true);
     return Log.create({
       job: this,
-      ajax: this.get('ajax'),
+      api: this.get('api'),
       container: getOwner(this)
     });
   },
@@ -109,7 +110,7 @@ export default Model.extend(DurationCalculations, DurationAttributes, {
 
   cancel() {
     const url = `/job/${this.get('id')}/cancel`;
-    return this.get('ajax').postV3(url);
+    return this.get('api').post(url);
   },
 
   removeLog() {
@@ -124,12 +125,12 @@ export default Model.extend(DurationCalculations, DurationAttributes, {
 
   restart() {
     const url = `/job/${this.get('id')}/restart`;
-    return this.get('ajax').postV3(url);
+    return this.get('api').post(url);
   },
 
   debug() {
     const url = `/job/${this.get('id')}/debug`;
-    return this.get('ajax').postV3(url, { quiet: true });
+    return this.get('api').post(url, { data: { quiet: true } });
   },
 
   appendLog(part) {

--- a/app/models/repo.js
+++ b/app/models/repo.js
@@ -1,7 +1,5 @@
-import ArrayProxy from '@ember/array/proxy';
 import {
   Promise as EmberPromise,
-  allSettled
 } from 'rsvp';
 import $ from 'jquery';
 import { A } from '@ember/array';
@@ -195,7 +193,6 @@ Repo.reopenClass({
   },
 
   search(store, query) {
-    let promise, queryString, result;
     return store.query('repo', {
       slug_filter: query,
       sort_by: 'slug_filter:desc',

--- a/app/models/repo.js
+++ b/app/models/repo.js
@@ -134,7 +134,7 @@ const Repo = Model.extend({
 
   fetchSettings() {
     const url = `/repo/${this.get('id')}/settings`;
-    return this.get('api').request(url, 'get').
+    return this.get('api').get(url).
       then(data => this._convertV3SettingsToV2(data['settings']));
   },
 

--- a/app/routes/settings.js
+++ b/app/routes/settings.js
@@ -6,7 +6,7 @@ import config from 'travis/config/environment';
 import { service } from 'ember-decorators/service';
 
 export default TravisRoute.extend({
-  @service ajax: null,
+  @service api: null,
 
   needsAuth: true,
 
@@ -63,7 +63,7 @@ export default TravisRoute.extend({
     if (config.endpoints.sshKey) {
       const repo = this.modelFor('repo');
       const url = `/repos/${repo.get('id')}/key`;
-      return this.get('ajax').get(url, (data) => {
+      return this.get('api').get(url, (data) => {
         const fingerprint = EmberObject.create({
           fingerprint: data.fingerprint
         });

--- a/app/routes/settings.js
+++ b/app/routes/settings.js
@@ -63,7 +63,7 @@ export default TravisRoute.extend({
     if (config.endpoints.sshKey) {
       const repo = this.modelFor('repo');
       const url = `/repos/${repo.get('id')}/key`;
-      return this.get('api').get(url, (data) => {
+      return this.get('api').request(url, 'GET', (data) => {
         const fingerprint = EmberObject.create({
           fingerprint: data.fingerprint
         });

--- a/app/routes/settings.js
+++ b/app/routes/settings.js
@@ -1,11 +1,11 @@
 import { hash } from 'rsvp';
-import $ from 'jquery';
 import EmberObject from '@ember/object';
 import TravisRoute from 'travis/routes/basic';
 import config from 'travis/config/environment';
 import { service } from 'ember-decorators/service';
 
 export default TravisRoute.extend({
+  @service ajax: null,
   @service api: null,
 
   needsAuth: true,
@@ -63,7 +63,7 @@ export default TravisRoute.extend({
     if (config.endpoints.sshKey) {
       const repo = this.modelFor('repo');
       const url = `/repos/${repo.get('id')}/key`;
-      return this.get('api').request(url, 'GET', (data) => {
+      return this.get('ajax').get(url, (data) => {
         const fingerprint = EmberObject.create({
           fingerprint: data.fingerprint
         });
@@ -74,13 +74,7 @@ export default TravisRoute.extend({
 
   fetchRepositoryActiveFlag() {
     const repoId = this.modelFor('repo').get('id');
-    const url = `${config.apiEndpoint}/repo/${repoId}`;
-    return $.ajax(url, {
-      headers: {
-        Authorization: `token ${this.auth.token()}`,
-        'Travis-API-Version': '3'
-      }
-    }).then(response => response.active);
+    return this.get('api').get(`/repo/${repoId}`).then(response => response.active);
   },
 
   hasPushAccess() {

--- a/app/services/api.js
+++ b/app/services/api.js
@@ -1,0 +1,59 @@
+/* global jQuery */
+import { isNone } from '@ember/utils';
+
+import { Promise as EmberPromise } from 'rsvp';
+import $ from 'jquery';
+import { get } from '@ember/object';
+import Service from '@ember/service';
+import config from 'travis/config/environment';
+import { service } from 'ember-decorators/service';
+
+jQuery.support.cors = true;
+
+export default Service.extend({
+  @service auth: null,
+  @service features: null,
+
+  post(url, options = {}) {
+    return this.request(url, 'POST', options);
+  },
+
+  patch(url, options = {}) {
+    return this.request(url, 'PATCH', options);
+  },
+
+  put(url, options = {}) {
+    return this.request(url, 'PUT', options);
+  },
+
+  delete(url, options = {}) {
+    return this.request(url, 'DELETE', options);
+  },
+
+  request(url, method = 'GET', options = {}) {
+    let endpoint = config.apiEndpoint || '';
+    let token = this.get('auth').token();
+
+    options.headers = options.headers || {};
+    options.headers['Travis-API-Version'] = '3';
+
+    if (token) {
+      if (!options.headers['Authorization']) {
+        options.headers['Authorization'] = `token ${token}`;
+      }
+    }
+    options.url = url = `${endpoint}${url}`;
+    options.method = method;
+    options.dataType = options.dataType || 'json';
+    let errorCallback = options.error || (() => {});
+    options.error = (data, status, xhr) => {
+      if (this.get('features.debugLogging')) {
+        // eslint-disable-next-line
+        console.log(`[ERROR] API responded with an error (${status}): ${JSON.stringify(data)}`);
+      }
+      return errorCallback.call(this, data, status, xhr);
+    };
+
+    return jQuery.ajax(url, options);
+  }
+});

--- a/app/services/api.js
+++ b/app/services/api.js
@@ -4,10 +4,15 @@ import config from 'travis/config/environment';
 import { service } from 'ember-decorators/service';
 import { Promise as EmberPromise } from 'rsvp';
 import { run } from '@ember/runloop';
+import { get } from '@ember/object';
 
 export default Service.extend({
   @service auth: null,
   @service features: null,
+
+  get(url, options = {}) {
+    return this.request(url, 'GET', options);
+  },
 
   post(url, options = {}) {
     return this.request(url, 'POST', options);
@@ -27,7 +32,7 @@ export default Service.extend({
 
   request(url, method = 'GET', options = {}) {
     let endpoint = config.apiEndpoint || '';
-    let token = this.get('auth').token();
+    let token = get(this, 'auth').token();
 
     options.headers = options.headers || {};
     options.headers['Travis-API-Version'] = '3';
@@ -51,7 +56,7 @@ export default Service.extend({
 
     return new EmberPromise((resolve, reject) => {
       options.error = (jqXHR, textStatus, errorThrown) => {
-        if (this.get('features.debugLogging')) {
+        if (get(this, 'features.debugLogging')) {
           // eslint-disable-next-line
           console.log(`[ERROR] API responded with an error (${status}): ${JSON.stringify(data)}`);
         }

--- a/app/services/api.js
+++ b/app/services/api.js
@@ -1,14 +1,7 @@
-/* global jQuery */
-import { isNone } from '@ember/utils';
-
-import { Promise as EmberPromise } from 'rsvp';
 import $ from 'jquery';
-import { get } from '@ember/object';
 import Service from '@ember/service';
 import config from 'travis/config/environment';
 import { service } from 'ember-decorators/service';
-
-jQuery.support.cors = true;
 
 export default Service.extend({
   @service auth: null,
@@ -63,6 +56,6 @@ export default Service.extend({
       return errorCallback.call(this, data, status, xhr);
     };
 
-    return jQuery.ajax(url, options);
+    return $.ajax(url, options);
   }
 });

--- a/app/services/api.js
+++ b/app/services/api.js
@@ -48,7 +48,12 @@ export default Service.extend({
     options.url = url = `${endpoint}${url}`;
     options.method = method;
     options.dataType = options.dataType || 'json';
-    options.contentType = 'json';
+    options.contentType = 'application/json';
+
+    if (options.data) {
+      options.data = JSON.stringify(options.data);
+    }
+
     let errorCallback = options.error || (() => {});
     options.error = (data, status, xhr) => {
       if (this.get('features.debugLogging')) {

--- a/app/services/api.js
+++ b/app/services/api.js
@@ -36,6 +36,9 @@ export default Service.extend({
 
     options.headers = options.headers || {};
     options.headers['Travis-API-Version'] = '3';
+    if (!options.headers['Accept']) {
+      options.headers['Accept'] = 'application/json';
+    }
 
     if (token) {
       if (!options.headers['Authorization']) {
@@ -45,6 +48,7 @@ export default Service.extend({
     options.url = url = `${endpoint}${url}`;
     options.method = method;
     options.dataType = options.dataType || 'json';
+    options.contentType = 'json';
     let errorCallback = options.error || (() => {});
     options.error = (data, status, xhr) => {
       if (this.get('features.debugLogging')) {

--- a/app/services/repositories.js
+++ b/app/services/repositories.js
@@ -11,7 +11,7 @@ export default Service.extend({
   @service auth: null,
   @service store: null,
   @service tabStates: null,
-  @service ajax: null,
+  @service api: null,
   @service router: null,
 
   @computed('requestOwnedRepositories', 'performSearchRequest', 'showSearchResults')
@@ -30,13 +30,12 @@ export default Service.extend({
 
   performSearchRequest: task(function* () {
     const store = this.get('store');
-    const ajax = this.get('ajax');
     const query = this.get('searchQuery');
 
     const urlQuery = this.get('router._router.currentURL').split('/')[2];
 
     if (!this.get('_searchResults.length') || urlQuery !== query) {
-      const searchResults = yield Repo.search(store, ajax, query);
+      const searchResults = yield Repo.search(store, query);
       this.set('_searchResults', searchResults);
     }
   }).drop(),

--- a/config/deprecation-workflow.js
+++ b/config/deprecation-workflow.js
@@ -1,6 +1,7 @@
 window.deprecationWorkflow = window.deprecationWorkflow || {};
 window.deprecationWorkflow.config = {
   workflow: [
-    { handler: 'silence', matchId: 'ember-router.router' }
+    { handler: 'silence', matchId: 'ember-router.router' },
+    { handler: 'silence', matchId: 'macro-computed-deprecated' },
   ]
 };

--- a/tests/acceptance/builds/pull-requests-test.js
+++ b/tests/acceptance/builds/pull-requests-test.js
@@ -88,6 +88,7 @@ test('view and cancel pull requests', function (assert) {
 
   page.builds(0).cancelButton.click();
 
+  andThen(() => {});
   andThen(() => {
     assert.equal(topPage.flashMessage.text, 'Build has been successfully cancelled.');
   });

--- a/tests/integration/components/dashboard-row-test.js
+++ b/tests/integration/components/dashboard-row-test.js
@@ -13,8 +13,8 @@ const ajaxStub = Service.extend({
 moduleForComponent('dashboard-row', 'Integration | Component | dashboard row', {
   integration: true,
   beforeEach() {
-    this.register('service:ajax', ajaxStub);
-    this.inject.service('ajax', { as: 'ajax' });
+    this.register('service:api', ajaxStub);
+    this.inject.service('api', { as: 'api' });
   }
 });
 

--- a/tests/unit/models/job-test.js
+++ b/tests/unit/models/job-test.js
@@ -5,7 +5,7 @@ import { moduleForModel, test } from 'ember-qunit';
 moduleForModel('job', 'Unit | Model | job', {
   needs: ['model:repo', 'model:build', 'model:commit', 'model:stage', 'service:ajax',
     'service:jobConfigFetcher', 'service:auth', 'service:features', 'service:flashes',
-    'service:storage', 'service:sessionStorage']
+    'service:storage', 'service:sessionStorage', 'service:api']
 });
 
 test('config is fetched if it\'s not available', function (assert) {

--- a/tests/unit/services/store/record-version-test.js
+++ b/tests/unit/services/store/record-version-test.js
@@ -2,7 +2,7 @@ import { run } from '@ember/runloop';
 import { moduleForModel, test } from 'ember-qunit';
 
 moduleForModel('build', 'Unit | Store | record version management', {
-  needs: ['model:build', 'model:job', 'service:store', 'service:auth', 'service:ajax',
+  needs: ['model:build', 'model:job', 'service:store', 'service:auth', 'service:api',
     'service:jobConfigFetcher']
 });
 

--- a/tests/unit/services/store/record-version-test.js
+++ b/tests/unit/services/store/record-version-test.js
@@ -2,8 +2,8 @@ import { run } from '@ember/runloop';
 import { moduleForModel, test } from 'ember-qunit';
 
 moduleForModel('build', 'Unit | Store | record version management', {
-  needs: ['model:build', 'model:job', 'service:store', 'service:auth', 'service:api',
-    'service:jobConfigFetcher']
+  needs: ['model:build', 'model:job', 'service:store', 'service:auth', 'service:ajax',
+    'service:jobConfigFetcher', 'service:api']
 });
 
 test('it does not allow to push an older record to the store', function (assert) {

--- a/tests/unit/store-filter-test.js
+++ b/tests/unit/store-filter-test.js
@@ -3,7 +3,7 @@ import { resolve, all } from 'rsvp';
 import { moduleForModel, test } from 'ember-qunit';
 
 moduleForModel('repo', 'Unit | store.filter', {
-  needs: ['model:repo', 'service:ajax', 'service:auth', 'service:store']
+  needs: ['model:repo', 'service:api', 'service:auth', 'service:store']
 });
 
 test('it does not run query if query params are not passed', function (assert) {

--- a/tests/unit/store-paginated-test.js
+++ b/tests/unit/store-paginated-test.js
@@ -4,7 +4,7 @@ import { run } from '@ember/runloop';
 import { moduleForModel, test } from 'ember-qunit';
 
 moduleForModel('repo', 'Unit | store.paginated', {
-  needs: ['model:repo', 'service:ajax', 'service:auth', 'service:store']
+  needs: ['model:repo', 'service:api', 'service:auth', 'service:store']
 });
 
 test('it adds records already in the store to paginated collection', function (assert) {


### PR DESCRIPTION
This commit introduces a new service named `api` that can be used to
request data from the V3 API. Before we were using the `ajax` service
for API operetions, but we want to remove it in the future (ie. as soon
as we drop V2).