### PR TITLE
Use divs instead of paragraphs for log lines

### DIFF
--- a/app/components/log-content.js
+++ b/app/components/log-content.js
@@ -29,7 +29,7 @@ Log.Scroll.prototype = $.extend(new Log.Listener(), {
   },
   tryScroll() {
     let ref;
-    let element = $('#log p:visible.highlight:first');
+    let element = $('#log .log-line:visible.highlight:first');
     if (element) {
       if (this.beforeScroll) {
         this.beforeScroll();

--- a/app/styles/app/layouts/log.sass
+++ b/app/styles/app/layouts/log.sass
@@ -148,7 +148,7 @@
   .cut
     padding: 20px 15px 0 55px
 
-  p
+  .log-line
     position: relative
     padding: 0 15px 0 62px
     margin: 0
@@ -181,16 +181,16 @@
     &.open
       height: auto
 
-    p:first-of-type
+    .log-line:first-of-type
       padding-right: 190px
 
     // &.active
-    p:first-of-type
+    .log-line:first-of-type
       background: darken($color-bg-log-hover, 10) inline-image('ui/log.fold.open.2.svg') no-repeat 8px 3px
       &.highlight
         background-color: $color-bg-log-fold-highlight
 
-    &:not(.open) p:first-of-type
+    &:not(.open) .log-line:first-of-type
       visibility: visible
       height: auto
       min-height: 16px

--- a/app/utils/lines-selector.js
+++ b/app/utils/lines-selector.js
@@ -38,7 +38,7 @@ export default (function () {
     this.element.on('click', 'a', (function (_this) {
       return function (event) {
         let element;
-        element = $(event.target).parent('p');
+        element = $(event.target).parent('.log-line');
         _this.loadLineNumbers(element, event.shiftKey);
         event.preventDefault();
         return false;
@@ -60,7 +60,7 @@ export default (function () {
     this.removeAllHighlights();
     let lines = this.getSelectedLines();
     if (lines) {
-      let elements = this.element.find('p:visible').slice(lines.first - 1, lines.last);
+      let elements = this.element.find('.log-line:visible').slice(lines.first - 1, lines.last);
       if (elements.length) {
         elements.addClass('highlight');
       } else if (tries < 4) {
@@ -83,7 +83,7 @@ export default (function () {
       results = [];
       for (index in lines) {
         l = lines[index];
-        line = this.element.find('p:visible').slice(l - 1, l);
+        line = this.element.find('.log-line:visible').slice(l - 1, l);
         results.push(this.folder.unfold(line));
       }
       return results;
@@ -105,13 +105,13 @@ export default (function () {
 
   LinesSelector.prototype.getLineNumberFromElement = function (element) {
     if (this && this.element) {
-      return this.element.find('p:visible').index(element) + 1;
+      return this.element.find('.log-line:visible').index(element) + 1;
     }
   };
 
   LinesSelector.prototype.removeAllHighlights = function () {
     if (this && this.element) {
-      return this.element.find('p.highlight').removeClass('highlight');
+      return this.element.find('.log-line.highlight').removeClass('highlight');
     }
   };
 

--- a/app/utils/log.js
+++ b/app/utils/log.js
@@ -1060,7 +1060,10 @@ Log.extend(Log.Renderer.prototype, {
   },
   createParagraph: function () {
     let para;
-    para = document.createElement('p');
+    // TODO: I know that now naming doesn't make sense, but the code already has
+    // `createSpan` function and I'm not into biggger refactoring at the moment
+    para = document.createElement('div');
+    para.classList.add('log-line');
     para.appendChild(document.createElement('a'));
     return para;
   },

--- a/tests/acceptance/builds/cancel-test.js
+++ b/tests/acceptance/builds/cancel-test.js
@@ -30,6 +30,7 @@ test('cancelling build', function (assert) {
     .visit({ slug: 'travis-ci/travis-web', build_id: build.id })
     .cancelBuild();
 
+  andThen(() => {});
   andThen(function () {
     assert.equal(topPage.flashMessage.text, 'Build has been successfully cancelled.', 'cancelled build notification should be displayed');
     assert.equal($('head link[rel=icon]').attr('href'), getFaviconUri('yellow'), 'expected the favicon data URI to match the one for running');

--- a/tests/acceptance/job/basic-layout-test.js
+++ b/tests/acceptance/job/basic-layout-test.js
@@ -27,7 +27,7 @@ test('visiting job-view', function (assert) {
   server.create('log', { id: job.id });
 
   visit('/travis-ci/travis-web/jobs/' + job.id);
-  waitForElement('#log > p');
+  waitForElement('#log > .log-line');
 
   andThen(() => {
     assert.equal(document.title, 'Job #1234.1 - travis-ci/travis-web - Travis CI');

--- a/tests/pages/job.js
+++ b/tests/pages/job.js
@@ -28,7 +28,7 @@ export default PageObject.create({
   logLines: collection({
     scope: 'pre#log',
 
-    itemScope: 'p span:first-of-type',
+    itemScope: '.log-line span:first-of-type',
 
     item: {
       text: text(),
@@ -66,7 +66,7 @@ export default PageObject.create({
 
     item: {
       name: text('span.fold-name'),
-      toggle: clickable('p:first-of-type'),
+      toggle: clickable('.log-line:first-of-type'),
       isOpen: hasClass('open')
     }
   }),


### PR DESCRIPTION
When using paragraphs Firefox inserts a new line after each line if you
copy the log output. 