### PR TITLE
Redirect to job page when selecting a line.

### DIFF
--- a/app/components/log-content.js
+++ b/app/components/log-content.js
@@ -6,6 +6,7 @@ import $ from 'jquery';
 import LinesSelector from 'travis/utils/lines-selector';
 import Log from 'travis/utils/log';
 import LogFolder from 'travis/utils/log-folder';
+import { Promise as EmberPromise } from 'rsvp';
 
 import config from 'travis/config/environment';
 
@@ -71,6 +72,7 @@ export default Component.extend({
   @service auth: null,
   @service permissions: null,
   @service externalLinks: null,
+  @service router: null,
 
   classNameBindings: ['logIsVisible:is-open'],
   logIsVisible: false,
@@ -145,7 +147,18 @@ export default Component.extend({
       });
       this.engine.limit = this.limit;
       this.logFolder = new LogFolder(this.$('#log'));
-      this.lineSelector = new LinesSelector(this.$('#log'), this.scroll, this.logFolder);
+      let onLogLineClick = () => {
+        let router = this.get('router'),
+          currentRouteName = router.get('currentRouteName');
+        if (currentRouteName === 'build.index' || currentRouteName === 'job.index') {
+          return EmberPromise.resolve();
+        } else {
+          return router.transitionTo('job', log.get('job.repo'), log.get('job'));
+        }
+      };
+      this.lineSelector = new LinesSelector(
+        this.$('#log'), this.scroll, this.logFolder, null, onLogLineClick
+      );
       this.observeParts(log);
     }
   },

--- a/app/utils/lines-selector.js
+++ b/app/utils/lines-selector.js
@@ -25,7 +25,7 @@ export default (function () {
 
   LinesSelector.prototype.last_selected_line = null;
 
-  function LinesSelector(element1, scroll, folder, location) {
+  function LinesSelector(element1, scroll, folder, location, onLogLineClick) {
     this.element = element1;
     this.scroll = scroll;
     this.folder = folder;
@@ -35,15 +35,20 @@ export default (function () {
       this.last_selected_line = (ref = this.getSelectedLines()) != null ? ref.first : void 0;
       return this.highlightLines();
     });
-    this.element.on('click', 'a', (function (_this) {
-      return function (event) {
-        let element;
-        element = $(event.target).parent('.log-line');
-        _this.loadLineNumbers(element, event.shiftKey);
-        event.preventDefault();
-        return false;
+    this.element.on('click', 'a', (event) => {
+      let callback = () => {
+        let element = $(event.target).parent('.log-line');
+        this.loadLineNumbers(element, event.shiftKey);
       };
-    })(this));
+
+      if (onLogLineClick) {
+        onLogLineClick().then(callback);
+      } else {
+        callback();
+      }
+      event.preventDefault();
+      return false;
+    });
   }
 
   LinesSelector.prototype.willDestroy = function () {


### PR DESCRIPTION
When you select a line in the rendered log it doesn't really make sense
to do it with a repo url, because if you link to a repo URL the
displayed job will likely change in the future.