### PR TITLE
Redirect to a previous URL after signing in from auth page

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -218,7 +218,7 @@ module.exports = {
     'no-whitespace-before-property': 2,
 
     // require padding inside curly braces
-    'object-curly-spacing': [2, 'always'],
+    'object-curly-spacing': 0,
 
     // enforce line breaks between braces
     // http://eslint.org/docs/rules/object-curly-newline

--- a/app/.eslintrc.js
+++ b/app/.eslintrc.js
@@ -215,7 +215,7 @@ module.exports = {
     'no-whitespace-before-property': 2,
 
     // require padding inside curly braces
-    'object-curly-spacing': [2, 'always'],
+    'object-curly-spacing': 0,
 
     // enforce line breaks between braces
     // http://eslint.org/docs/rules/object-curly-newline

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -104,7 +104,8 @@ export default TravisRoute.extend(BuildFaviconMixin, KeyboardShortcuts, {
 
   actions: {
     signIn() {
-      this.get('auth').signIn();
+      let authParams = this.modelFor('auth');
+      this.get('auth').signIn(null, authParams);
       this.afterSignIn();
     },
 
@@ -123,7 +124,10 @@ export default TravisRoute.extend(BuildFaviconMixin, KeyboardShortcuts, {
     error(error) {
       if (error === 'needs-auth') {
         this.set('auth.redirected', true);
-        return this.transitionTo('auth');
+        let currentURL = new URL(window.location.href),
+          routerURL = `${currentURL.origin}${this.get('router.url')}`;
+
+        return this.transitionTo('auth', { queryParams: { redirectUri: routerURL }});
       } else {
         return true;
       }

--- a/app/routes/auth.js
+++ b/app/routes/auth.js
@@ -5,7 +5,19 @@ import { service } from 'ember-decorators/service';
 export default TravisRoute.extend({
   @service auth: null,
 
+  queryParams: {
+    redirectUri: {
+      refreshModel: true
+    }
+  },
+
   needsAuth: false,
+
+  model(params) {
+    if (params.redirectUri) {
+      return { redirectUri: params.redirectUri };
+    }
+  },
 
   renderTemplate() {
     $('body').attr('id', 'auth');

--- a/app/services/auth.js
+++ b/app/services/auth.js
@@ -47,13 +47,14 @@ export default Service.extend({
     this.get('store').unloadAll();
   },
 
-  signIn(data) {
+  signIn(data, options = {}) {
     if (data) {
       this.autoSignIn(data);
     } else {
       this.set('state', 'signing-in');
 
-      let url = new URL(window.location.href);
+      let uri = options.redirectUri || window.location.href,
+        url = new URL(uri);
 
       if (url.pathname === '/plans') {
         url.pathname = '/';

--- a/app/templates/components/repo-not-found.hbs
+++ b/app/templates/components/repo-not-found.hbs
@@ -6,7 +6,7 @@
   <h2 class="page-title">We couldn't find the repository <br><span class="h2--red">{{slug}}</span></h2>
   {{#if features.proVersion}}
     {{#unless auth.signedIn}}
-      <p class="page-notice">This repository may not exist or you may need to {{#link-to "auth" class="auth-button--white m-l-s" action="singI"}}Sign in with GitHub{{/link-to}}</p>
+      <p class="page-notice">This repository may not exist or you may need to <button class="auth-button--white m-l-s" {{action "signIn"}}>Sign in with GitHub</button></p>
     {{/unless}}
   {{/if}}
 </div>

--- a/tests/acceptance/feature-flags/user-sets-flags-test.js
+++ b/tests/acceptance/feature-flags/user-sets-flags-test.js
@@ -8,7 +8,7 @@ test('visiting /features directly as guest', function (assert) {
   featurePage.visit();
 
   andThen(function () {
-    assert.equal(currentURL(), '/auth');
+    assert.ok(currentURL().match(/\?redirectUri=.*%2Ffeatures/));
   });
 });
 


### PR DESCRIPTION
When a user opens a URL that needs a redirect to the auth page, the
information about previous URL is lost. That's why whenever we
automatically redirect to the auth page we need to preserve the redirec
uri and pass it to the API.