### PR TITLE
A fix to travis-ci/travis-ci#8986

### DIFF
--- a/app/components/branch-row.js
+++ b/app/components/branch-row.js
@@ -37,7 +37,7 @@ export default Component.extend({
     } else {
       apiEndpoint = config.apiEndpoint;
       repoId = this.get('branch.repository.id');
-      branchName = this.get('branch.name');
+      branchName = encodeURIComponent(this.get('branch.name'));
       options = {
         headers: {
           'Travis-API-Version': '3'
@@ -51,12 +51,12 @@ export default Component.extend({
       let url = `${path}${params}`;
 
       $.ajax(url, options).then(response => {
-        let array, i, ref;
+        let array, i, trueLength;
         array = response.builds.map(build => EmberObject.create(build));
-        // TODO: Clean this up, all we want to do is have 5 elements no matter
-        // what. This code doesn't express that very well.
+        // We need exactly 5 elements in array
         if (array.length < 5) {
-          for (i = 1, ref = 5 - array.length; i <= ref; i += 1) {
+          trueLength = array.length;
+          for (i = trueLength; i < 5; i++) {
             array.push({});
           }
         }

--- a/tests/acceptance/repo/branches-test.js
+++ b/tests/acceptance/repo/branches-test.js
@@ -32,8 +32,8 @@ moduleForAcceptance('Acceptance | repo branches', {
     const repoId = parseInt(repository.id);
 
     const primaryBranch = server.create('branch', {
-      name: 'primary',
-      id: `/v3/repo/${repoId}/branch/primary`,
+      name: 'primary#yes',
+      id: `/v3/repo/${repoId}/branch/primary#yes`,
       default_branch: true,
       repository,
     });
@@ -166,7 +166,7 @@ test('view branches', function (assert) {
   });
 
   andThen(() => {
-    assert.equal(branchesPage.defaultBranch.name, 'primary');
+    assert.equal(branchesPage.defaultBranch.name, 'primary#yes');
     assert.ok(branchesPage.defaultBranch.passed, 'expected default branch last build to have passed');
     assert.equal(branchesPage.defaultBranch.buildCount, '3 builds');
     assert.equal(branchesPage.defaultBranch.request, '1919 passed');


### PR DESCRIPTION
![untitled](https://user-images.githubusercontent.com/8774516/34667228-25e2e172-f48e-11e7-80c2-6ad6d92c64fa.png)

Screenshot confirms travis-ci/travis-ci#8986 completely. The URL is not formed completely post the "#" sign. The attempted fix simply encloses the branch name in encodeURIComponent. 

Further, tried to pursue the TODO mentioned just below. 