### PR TITLE
Change PR titles to commit messages

### DIFF
--- a/app/templates/components/builds-item.hbs
+++ b/app/templates/components/builds-item.hbs
@@ -18,15 +18,11 @@
         {{/if}}
       {{/if}}
     </h2>
-    {{#if build.isPullRequest}}
-      <div class="row-message">
-        {{{format-message build.pullRequestTitle short="true" repo=build.repo}}}
-      </div>
-    {{else}}
-      <div class="row-message">
-        {{{format-message build.commit.message short="true" repo=build.repo eventType=build.eventType}}}
-      </div>
-    {{/if}}
+    
+    <div class="row-message">
+      {{{format-message build.commit.message short="true" repo=build.repo eventType=build.eventType}}}
+    </div>
+  
   </div>
   <div class="row-item row-committer">
     {{user-avatar url=build.commit.authorAvatarUrl name=build.commit.authorName small=true size=18}}


### PR DESCRIPTION
When you view a PRs list you only see the PR title and no commit
message, which might be confusing as to what changes were made in the
commit.