### PR TITLE
Remove xcode8 image from the list of deprecated images

### DIFF
--- a/app/components/job-infrastructure-notification.js
+++ b/app/components/job-infrastructure-notification.js
@@ -44,16 +44,14 @@ export default Component.extend({
 
   @alias('jobConfig.osx_image') macOSImage: null,
 
-  deprecatedXcodeImages: ['xcode8', 'xcode8.1', 'xcode8.2'],
+  deprecatedXcodeImages: ['xcode8.1', 'xcode8.2'],
 
   imageToRetirementDate: {
-    'xcode8': NOVEMBER_2017_RETIREMENT,
     'xcode8.1': NOVEMBER_2017_RETIREMENT,
     'xcode8.2': NOVEMBER_2017_RETIREMENT
   },
 
   imageToNewImage: {
-    'xcode8': 'xcode8.3',
     'xcode8.1': 'xcode8.3',
     'xcode8.2': 'xcode8.3'
   },


### PR DESCRIPTION
We are keeping it for now.