### PR TITLE
Remove extra white space on trigger build button

### DIFF
--- a/app/styles/app/modules/dropdown.sass
+++ b/app/styles/app/modules/dropdown.sass
@@ -89,6 +89,7 @@ $dropdown-button-margin: -9px
   button
     display: block
     width: 100%
+    margin-bottom: 0px
     padding: .5em 1em
     font-size: 14px
     color: $oxide-blue


### PR DESCRIPTION
#### What does this PR do?
- Removes extra white-space from the bottom of the trigger build button in Safari browser

#### Issue

[2484](https://github.com/travis-pro/team-teal/issues/2484)

#### Where should I start?

`app/styles/app/modules/dropdown.sass`

#### Screenshots
<img width="142" alt="screen shot 2018-01-11 at 10 28 18 am" src="https://user-images.githubusercontent.com/529465/34818110-2b0891a0-f6ba-11e7-865e-2741a7ecfb04.png">


#### How this PR makes you feel?
![fix_it](https://user-images.githubusercontent.com/529465/34725398-153fb58e-f551-11e7-83ba-b902f58142d1.gif)
