### PR TITLE
Change the active and focus state outline on build button

### DIFF
--- a/app/styles/app/modules/buttons.sass
+++ b/app/styles/app/modules/buttons.sass
@@ -99,6 +99,9 @@
   border-radius: 14px
   cursor: pointer
   white-space: nowrap
+  &:active,
+  &:focus
+    outline: thin dotted
   &:hover,
   &:active
     +colorSVG($oxide-blue)


### PR DESCRIPTION
#### What does this PR do?
- Changes the outline border to `thin dotted` when the build button is active and/or focused

#### Issue

[2333](https://github.com/travis-pro/team-teal/issues/2333)

#### Where should I start?

`app/styles/app/modules/buttons.sass`

#### Screenshots
##### Focus
<img width="155" alt="screen shot 2018-01-12 at 9 41 18 am" src="https://user-images.githubusercontent.com/529465/34867211-9c6a049e-f77f-11e7-9243-e64680b51c87.png">

##### Active
<img width="174" alt="screen shot 2018-01-12 at 9 40 51 am" src="https://user-images.githubusercontent.com/529465/34867218-a3725106-f77f-11e7-90be-678afb6521fc.png">
