### PR TITLE
Add VS Code JavaScript config file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ public/scripts
 .node_modules.ember-try/
 bower.json.ember-try
 package.json.ember-try
+
+# vs code JavaScript config file
+jsconfig.json


### PR DESCRIPTION
Global .gitignore doesn't seem to take on Windows, so adding the JS Config file for VS Code to project gitignore to save time.