### PR TITLE
Add help links and rename build branch and pr buttons

### DIFF
--- a/app/templates/settings.hbs
+++ b/app/templates/settings.hbs
@@ -2,14 +2,22 @@
 
   <section class="settings-section">
     <h2 class="small-title">General</h2>
-
     <ul class="settings-list--columns">
       <li>{{settings-switch active=model.settings.builds_only_with_travis_yml repo=repo description="Build only if .travis.yml is present" key="builds_only_with_travis_yml"}}</li>
-      <li>{{settings-switch active=model.settings.build_pushes repo=repo description="Build branch updates" key="build_pushes"}}</li>
+      <li>{{settings-switch active=model.settings.build_pushes repo=repo description="Build pushed branches" key="build_pushes"}}
+        <a href="https://docs.travis-ci.com/user/customizing-the-build/#Building-only-the-latest-commit"
+           title="about branch updates">
+           {{tooltip-on-element text='Read more about branch updates'}}
+           {{svg-jar 'icon-help' class="icon-help"}}</a>
+      </li>
       <li>{{limit-concurrent-builds value=model.settings.maximum_number_of_builds enabled=concurrentBuildsLimit repo=repo}}</li>
-      <li>{{settings-switch active=model.settings.build_pull_requests repo=repo description="Build pull request updates" key="build_pull_requests"}}</li>
+      <li>{{settings-switch active=model.settings.build_pull_requests repo=repo description="Build pushed pull requests" key="build_pull_requests"}}
+        <a href="https://docs.travis-ci.com/user/customizing-the-build/#Building-only-the-latest-commit"
+           title="about the pull request updates">
+           {{tooltip-on-element text='Read more about pull request updates'}}
+           {{svg-jar 'icon-help' class="icon-help"}}</a>
+      </li>
     </ul>
-
   </section>
 
   {{#if showAutoCancellationSwitches}}


### PR DESCRIPTION
#### What does this PR do?
- Add help links to the build branches and PR buttons
- Update text of the build branches and PR buttons

#### Issue

[2214](https://github.com/travis-pro/team-teal/issues/2214)

#### Screenshots
<img width="342" alt="screen shot 2018-01-18 at 10 50 47 am" src="https://user-images.githubusercontent.com/529465/35094219-ec7399b8-fc44-11e7-82cf-5de53c6828d8.png">

#### Where should I start?

`app/templates/settings.hbs`