### PR TITLE
Remove server.logging statements from acceptance tests

### DIFF
--- a/tests/acceptance/auth/first-sync-test.js
+++ b/tests/acceptance/auth/first-sync-test.js
@@ -11,7 +11,6 @@ moduleForAcceptance('Acceptance | auth/first sync', {
 });
 
 test('first sync shows up and redirects to profile page after the sync is finished', function (assert) {
-  server.logging = true;
   visit('/');
   andThen(() => {
     assert.equal(page.heading, 'One more thing');

--- a/tests/acceptance/builds/build-stages-test.js
+++ b/tests/acceptance/builds/build-stages-test.js
@@ -11,7 +11,6 @@ function futureTime(secondsAhead) {
 }
 
 test('visiting build with one stage', function (assert) {
-  server.logging = true;
   let repo =  server.create('repository', { slug: 'travis-ci/travis-web' });
 
   let branch = server.create('branch', { name: 'acceptance-tests' });

--- a/tests/acceptance/builds/current-tab-test.js
+++ b/tests/acceptance/builds/current-tab-test.js
@@ -25,7 +25,6 @@ test('renders most recent repository without builds', function (assert) {
 });
 
 test('renders most recent repository and most recent build when builds present, single-job build shows job status instead', function (assert) {
-  server.logging = true;
   let repository =  server.create('repository', { slug: 'travis-ci/travis-web' });
 
   const branch = server.create('branch', { name: 'acceptance-tests' });
@@ -65,7 +64,6 @@ test('renders most recent repository and most recent build when builds present, 
 });
 
 test('renders the repository and subscribes to private log channel for a private repository', function (assert) {
-  server.logging = true;
   let repository =  server.create('repository', { slug: 'travis-ci/travis-web', private: true });
 
   const branch = server.create('branch', { name: 'acceptance-tests' });

--- a/tests/acceptance/builds/pull-requests-test.js
+++ b/tests/acceptance/builds/pull-requests-test.js
@@ -25,7 +25,6 @@ test('renders no pull requests messaging when none present', function (assert) {
 });
 
 test('view and cancel pull requests', function (assert) {
-  server.logging = true;
   const repository = server.create('repository');
 
   const pullRequestBuild = server.create('build', {

--- a/tests/acceptance/repo/show-test.js
+++ b/tests/acceptance/repo/show-test.js
@@ -24,7 +24,6 @@ moduleForAcceptance('Acceptance | show repo page', {
 });
 
 test('loading branches doesnt update the default branch on the repo', function (assert) {
-  server.logging = true;
   page.visit({ organization: 'killjoys', repo: 'living-a-feminist-life' });
   page.openStatusImagePopup();
 


### PR DESCRIPTION
I assume that this was used for debugging purposes at some point, but it currently just adds noise to the test suite.