### PR TITLE
Make GitHub icon open link in new tab

### DIFF
--- a/app/templates/components/repository-layout.hbs
+++ b/app/templates/components/repository-layout.hbs
@@ -1,8 +1,9 @@
 <article class="repo-header">
   <header>
     <h1 class="repo-title">{{#link-to "owner" repo.owner.login}}{{repo.owner.login}}{{/link-to}} / {{#link-to "repo" repo}}{{repo.name}}{{/link-to}}</h1>
-      <a href="{{urlGithub}}" title="{{repo.name}} on GitHub" class="repo-gh">
-        {{svg-jar 'icon-repooctocat'}}</a>
+      {{#external-link-to href=urlGithub class="repo-gh" title=(concat repo.name " on GitHub")}}
+        {{svg-jar 'icon-repooctocat'}}
+      {{/external-link-to}}
       <div class="repo-badge">
         <a href="#" id="status-image-popup" title="Latest push build on default branch: {{repo.defaultBranch.lastBuild.state}}" name="status-images" class="open-popup" {{action "toggleStatusBadgeModal"}}>
           <img src={{statusImageUrl}} alt="build:{{repo.defaultBranch.lastBuild.state}}"/>


### PR DESCRIPTION
This makes it more consistent with the other GitHub links within the app.