### PR TITLE
Fix Erroneous Title Values

### DIFF
--- a/app/templates/components/build-header.hbs
+++ b/app/templates/components/build-header.hbs
@@ -124,7 +124,7 @@
         </span>
       </li>
     {{else}}
-      <li title="Started {{pretty-date item.startedAt}}" class="commit-stopwatch">
+      <li title="{{if elapsedTime (concat "Started " (pretty-date item.startedAt))}}" class="commit-stopwatch">
         {{svg-jar 'icon-stopwatch' class="icon--m"}}
         <span class="label-align">
           {{if item.isFinished 'Ran for' 'Running for'}} <time datetime="PT{{elapsedTime}}S">{{format-duration elapsedTime}}</time>

--- a/app/templates/components/builds-item.hbs
+++ b/app/templates/components/builds-item.hbs
@@ -65,7 +65,7 @@
     </div>
   </div>
   <div class="row-item row-calendar">
-    <div title="Finished {{pretty-date build.formattedFinishedAt}}">
+    <div title="{{if build.finishedAt (concat "Finished " (pretty-date build.formattedFinishedAt))}}">
       {{svg-jar 'icon-calendar' class="icon"}}
       <time class="label-align" datetime={{build.finishedAt}}>{{format-time build.finishedAt}}</time>
     </div>

--- a/app/templates/components/repos-list-item.hbs
+++ b/app/templates/components/repos-list-item.hbs
@@ -22,7 +22,8 @@
   <p>
     {{svg-jar 'icon-clock' class="icon"}}
     <span class="label-align">Duration:
-       <time class="duration" datetime="PT{{repo.currentBuild.duration}}S" title="Started {{pretty-date repo.currentBuild.startedAt}}">{{format-duration repo.currentBuild.duration}}</time>
+       <time class="duration" datetime="PT{{repo.currentBuild.duration}}S"
+       title="{{if repo.currentBuild.duration (concat "Started " (pretty-date repo.currentBuild.startedAt))}}">{{format-duration repo.currentBuild.duration}}</time>
     </span>
   </p>
 

--- a/app/templates/components/repos-list-item.hbs
+++ b/app/templates/components/repos-list-item.hbs
@@ -22,8 +22,7 @@
   <p>
     {{svg-jar 'icon-clock' class="icon"}}
     <span class="label-align">Duration:
-       <time class="duration" datetime="PT{{repo.currentBuild.duration}}S"
-       title="{{if repo.currentBuild.duration (concat "Started " (pretty-date repo.currentBuild.startedAt))}}">{{format-duration repo.currentBuild.duration}}</time>
+       <time class="duration" datetime="PT{{repo.currentBuild.duration}}S" title="{{if repo.currentBuild.duration (concat "Started " (pretty-date repo.currentBuild.startedAt))}}">{{format-duration repo.currentBuild.duration}}</time>
     </span>
   </p>
 


### PR DESCRIPTION
This PR aims to fix following errors,

- Title attribute shows "January 1, 1970" if user hovers over the job/build duration before it starts


![35292757-9c2e1bb2-0082-11e8-9448-b02f6250ae12](https://user-images.githubusercontent.com/6593585/35447846-c43c551c-02c9-11e8-810b-2a23ae4e3924.jpg)

![wrongstartdate](https://user-images.githubusercontent.com/6593585/35448044-466d19f4-02ca-11e8-941c-f50d9bc330d6.jpg)


- Title attribute shows "Invalid Date" if user hovers over the job/build completion date before it completes on Build History tab

![finished_invalid_date](https://user-images.githubusercontent.com/6593585/35447948-008d1920-02ca-11e8-9e38-f602c88be49f.jpg)

