### PR TITLE
Fix status icons

### DIFF
--- a/app/styles/app/modules/build-tile.sass
+++ b/app/styles/app/modules/build-tile.sass
@@ -19,8 +19,6 @@
       right: 0
       bottom: 0
       left: 0
-      width: 18px
-      height: 18px
       margin: auto !important
       background-color: transparent
       transition: top 200ms ease

--- a/app/templates/components/dashboard-row.hbs
+++ b/app/templates/components/dashboard-row.hbs
@@ -74,7 +74,7 @@
           </button>
           <ul class="dropup-list">
             <li><button title="Trigger a build on the default branch" {{action 'triggerBuild'}}>
-                {{svg-jar 'icon-restart' class="icon"}}
+                {{svg-jar 'icon-restart' class="icon" width="15px" height="15px" viewBox="0 0 15 15" preserveAspectRatio="none"}}
                 <span class="label-align">Trigger a build</span></button></li>
             <li>
               {{#link-to 'settings' repo title="Settings for this repository"}}

--- a/app/templates/components/repo-actions.hbs
+++ b/app/templates/components/repo-actions.hbs
@@ -17,7 +17,7 @@
     <div class='action-button-container'>
       <button {{action (perform restart)}} class="action-button--restart" aria-label="Restart {{type}}" type="button">
         {{#if labelless}}{{#tooltip-on-element}}Restart {{type}}{{/tooltip-on-element}}{{/if}}
-        {{svg-jar 'icon-restart' class="icon"}}
+        {{svg-jar 'icon-restart' class="icon" width="15px" height="15px" viewBox="0 0 15 15" preserveAspectRatio="none"}}
         <span class="label-align">Restart {{type}}</span>
       </button>
     </div>

--- a/app/templates/components/status-icon.hbs
+++ b/app/templates/components/status-icon.hbs
@@ -1,23 +1,23 @@
 {{#if isEmpty}}
-  {{svg-jar 'icon-nobuilds'}}
+  {{svg-jar 'icon-nobuilds' width="15px" height="15px" viewBox="0 0 18 18" preserveAspectRatio="none"}}
 {{else}}
   {{#if hasPassed}}
-    {{svg-jar 'icon-passed'}}
+    {{svg-jar 'icon-passed' width="15px" height="15px" viewBox="0 0 18 18" preserveAspectRatio="none"}}
   {{/if}}
 
   {{#if hasFailed}}
-    {{svg-jar 'icon-failed'}}
+    {{svg-jar 'icon-failed' width="15px" height="15px" viewBox="0 0 18 18" preserveAspectRatio="none"}}
   {{/if}}
 
   {{#if wasCanceled}}
-    {{svg-jar 'icon-canceled'}}
+    {{svg-jar 'icon-canceled' width="15px" height="15px" viewBox="-1 -1 18 18" preserveAspectRatio="none"}}
   {{/if}}
 
   {{#if hasErrored}}
-    {{svg-jar 'icon-errored'}}
+    {{svg-jar 'icon-errored' width="15px" height="15px" viewBox="0 0 18 18" preserveAspectRatio="none"}}
   {{/if}}
 
   {{#if isRunning}}
-    {{svg-jar 'icon-running'}}
+    {{svg-jar 'icon-running' width="15px" height="15px" viewBox="0 0 18 18" preserveAspectRatio="none"}}
   {{/if}}
 {{/if}}


### PR DESCRIPTION
#### What does this PR do?
- Updates `viewBox`, `width`, and `height` values for status icon SVG's so they don't clip

#### Screenshots
![screenshot-2018-1-26 travis ci 1](https://user-images.githubusercontent.com/529465/35466674-2d371fe0-02c3-11e8-83de-e4a5264fbff7.png)
![screenshot-2018-1-26 travis-ci dpl - travis ci 1](https://user-images.githubusercontent.com/529465/35466675-369077e4-02c3-11e8-8100-6df7211ead9f.png)
![screenshot-2018-1-26 travis-ci dpl - travis ci](https://user-images.githubusercontent.com/529465/35466685-505bfb6c-02c3-11e8-9958-08c48b5696a0.png)
![screenshot-2018-1-26 travis ci](https://user-images.githubusercontent.com/529465/35466686-534ea98c-02c3-11e8-8b7f-277619580bdb.png)

#### Where should I start?
`app/templates/components/status-icon.hbs`

#### How does this PR make you feel?
![fix_it](https://user-images.githubusercontent.com/529465/35466718-a9833a3e-02c3-11e8-8050-c75e59d141b4.gif)
