### PR TITLE
Fix status icon clipping

### DIFF
--- a/app/styles/app/modules/status-icon.sass
+++ b/app/styles/app/modules/status-icon.sass
@@ -5,6 +5,7 @@
     stroke-linecap: round
     stroke-linejoin: round
     stroke-miterlimit: 10
+    overflow: visible
 
 .status-icon
   @extend %icon


### PR DESCRIPTION
This fixes https://github.com/travis-pro/team-teal/issues/2524 by making the SVG overflow property visible to prevent rectangle shaped path clipping over the icons.