### PR TITLE
Fix broken pagination links containing decimals

### DIFF
--- a/app/components/pagination-navigation.js
+++ b/app/components/pagination-navigation.js
@@ -77,7 +77,7 @@ export default Component.extend({
         }
       }
 
-      // ... devider unit
+      // ... divider unit
       if (lowerInnerBoundary - pageArray.length > outerWindow) {
         pageArray.push({});
       }

--- a/app/components/pagination-navigation.js
+++ b/app/components/pagination-navigation.js
@@ -9,7 +9,6 @@ export default Component.extend({
 
   @computed('pagination.{currentPage,isFirst}')
   prevPageNumber(page, isFirst) {
-    console.log({page});
     if (!isFirst) {
       return page - 1;
     }

--- a/app/components/pagination-navigation.js
+++ b/app/components/pagination-navigation.js
@@ -7,6 +7,23 @@ export default Component.extend({
   classNames: ['pagination-navigation'],
   @alias('collection.pagination') pagination: null,
 
+  @computed('pagination.{currentPage,isFirst}')
+  prevPageNumber(page, isFirst) {
+    console.log({page});
+    if (!isFirst) {
+      return page - 1;
+    }
+    return undefined;
+  },
+
+  @computed('pagination.{currentPage,isLast}')
+  nextPageNumber(page, isLast) {
+    if (!isLast) {
+      return page + 1;
+    }
+    return undefined;
+  },
+
   @computed('outer')
   outerWindow(outer) {
     return outer || 1;

--- a/app/controllers/account/repositories.js
+++ b/app/controllers/account/repositories.js
@@ -2,7 +2,7 @@ import { computed, action } from 'ember-decorators/object';
 import Controller from '@ember/controller';
 
 export default Controller.extend({
-  offset: 0,
+  page: 1,
 
   @computed('model')
   sortedRepositories(repos) {

--- a/app/controllers/dashboard/repositories.js
+++ b/app/controllers/dashboard/repositories.js
@@ -6,8 +6,7 @@ import { computed } from 'ember-decorators/object';
 import dashboardRepositoriesSort from 'travis/utils/dashboard-repositories-sort';
 
 export default Controller.extend({
-  queryParams: ['account', 'offset'],
-  offset: 0,
+  page: 1,
 
   @service flashes: null,
   @service api: null,

--- a/app/routes/account/repositories.js
+++ b/app/routes/account/repositories.js
@@ -1,8 +1,10 @@
 import TravisRoute from 'travis/routes/basic';
 
 export default TravisRoute.extend({
+  recordsPerPage: 25,
+
   queryParams: {
-    offset: {
+    page: {
       refreshModel: true
     }
   },
@@ -11,10 +13,12 @@ export default TravisRoute.extend({
     const account = this.modelFor('account');
     // account is an Ember-Data model
     if (!account.error) {
+      // TODO: Make perPage property configurable
+      const offset = (params.page - 1) * this.get('recordsPerPage');
       return this.store.paginated(
         'repo',
         {
-          offset: params.offset,
+          offset,
           sort_by: 'name',
           limit: 25,
           custom: {

--- a/app/routes/account/repositories.js
+++ b/app/routes/account/repositories.js
@@ -1,4 +1,5 @@
 import TravisRoute from 'travis/routes/basic';
+// eslint-disable-next-line
 import config from 'travis/config/environment';
 import { alias } from 'ember-decorators/object/computed';
 

--- a/app/routes/account/repositories.js
+++ b/app/routes/account/repositories.js
@@ -1,13 +1,15 @@
 import TravisRoute from 'travis/routes/basic';
+import config from 'travis/config/environment';
+import { alias } from 'ember-decorators/object/computed';
 
 export default TravisRoute.extend({
-  recordsPerPage: 25,
-
   queryParams: {
     page: {
       refreshModel: true
     }
   },
+
+  @alias('config.pagination.profileReposPerPage') recordsPerPage: null,
 
   model(params) {
     const account = this.modelFor('account');
@@ -20,7 +22,7 @@ export default TravisRoute.extend({
         {
           offset,
           sort_by: 'name',
-          limit: 25,
+          limit: this.get('recordsPerPage'),
           custom: {
             owner: account.get('login'),
             type: 'byOwner',

--- a/app/routes/dashboard/repositories.js
+++ b/app/routes/dashboard/repositories.js
@@ -3,11 +3,13 @@ import TravisRoute from 'travis/routes/basic';
 import dashboardRepositoriesSort from 'travis/utils/dashboard-repositories-sort';
 
 export default TravisRoute.extend({
+  recordsPerPage: 25,
+
   queryParams: {
     filter: {
       replace: true
     },
-    offset: {
+    page: {
       refreshModel: true
     }
   },
@@ -19,6 +21,7 @@ export default TravisRoute.extend({
   },
 
   model(params) {
+    const offset = (params.page - 1) * this.get('recordsPerPage');
     return hash({
       starredRepos: this.store.filter('repo', {
         active: true,
@@ -28,7 +31,7 @@ export default TravisRoute.extend({
       repos: this.store.paginated('repo', {
         active: true,
         sort_by: 'current_build:desc',
-        offset: params.offset
+        offset,
       }, {
         filter: (repo) => repo.get('active') && repo.get('isCurrentUserACollaborator'),
         sort: dashboardRepositoriesSort,

--- a/app/routes/dashboard/repositories.js
+++ b/app/routes/dashboard/repositories.js
@@ -3,7 +3,7 @@ import TravisRoute from 'travis/routes/basic';
 import dashboardRepositoriesSort from 'travis/utils/dashboard-repositories-sort';
 
 export default TravisRoute.extend({
-  recordsPerPage: 25,
+  recordsPerPage: 100,
 
   queryParams: {
     filter: {
@@ -32,6 +32,7 @@ export default TravisRoute.extend({
         active: true,
         sort_by: 'current_build:desc',
         offset,
+        limit: this.get('recordsPerPage'),
       }, {
         filter: (repo) => repo.get('active') && repo.get('isCurrentUserACollaborator'),
         sort: dashboardRepositoriesSort,

--- a/app/routes/dashboard/repositories.js
+++ b/app/routes/dashboard/repositories.js
@@ -1,6 +1,7 @@
 import { hash } from 'rsvp';
 import TravisRoute from 'travis/routes/basic';
 import dashboardRepositoriesSort from 'travis/utils/dashboard-repositories-sort';
+// eslint-disable-next-line
 import config from 'travis/config/environment';
 import { alias } from 'ember-decorators/object/computed';
 

--- a/app/routes/dashboard/repositories.js
+++ b/app/routes/dashboard/repositories.js
@@ -1,10 +1,10 @@
 import { hash } from 'rsvp';
 import TravisRoute from 'travis/routes/basic';
 import dashboardRepositoriesSort from 'travis/utils/dashboard-repositories-sort';
+import config from 'travis/config/environment';
+import { alias } from 'ember-decorators/object/computed';
 
 export default TravisRoute.extend({
-  recordsPerPage: 100,
-
   queryParams: {
     filter: {
       replace: true
@@ -19,6 +19,8 @@ export default TravisRoute.extend({
       return this.transitionTo('index');
     }
   },
+
+  @alias('config.pagination.dashboardReposPerPage') recordsPerPage: null,
 
   model(params) {
     const offset = (params.page - 1) * this.get('recordsPerPage');

--- a/app/templates/components/pagination-navigation.hbs
+++ b/app/templates/components/pagination-navigation.hbs
@@ -1,8 +1,8 @@
 {{#if showPagination}}
   <ul role="navigation">
-    {{#unless pagination.isFirst}}
-      <li>{{#link-to route (query-params page=pagination.prev.num) rel="prev" class="pagination-button" title="Go to previous page"}}prev{{/link-to}}</li>
-    {{/unless}}
+    {{#if prevPageNumber}}
+      <li>{{#link-to route (query-params page=prevPageNumber) rel="prev" class="pagination-button" title="Go to previous page"}}prev{{/link-to}}</li>
+    {{/if}}
 
     {{#each pages as |page|}}
       <li>
@@ -14,8 +14,8 @@
       </li>
     {{/each}}
 
-    {{#unless pagination.isLast}}
-      <li>{{#link-to route (query-params page=pagination.next.num) rel="next" class="pagination-button" title="Go to next page"}}next{{/link-to}}</li>
-    {{/unless}}
+    {{#if nextPageNumber}}
+      <li>{{#link-to route (query-params page=nextPageNumber) rel="next" class="pagination-button" title="Go to next page"}}next{{/link-to}}</li>
+    {{/if}}
   </ul>
 {{/if}}

--- a/app/templates/components/pagination-navigation.hbs
+++ b/app/templates/components/pagination-navigation.hbs
@@ -1,13 +1,13 @@
 {{#if showPagination}}
   <ul role="navigation">
     {{#unless pagination.isFirst}}
-      <li>{{#link-to route (query-params offset=pagination.prev.offset) rel="prev" class="pagination-button" title="Go to previous page"}}prev{{/link-to}}</li>
+      <li>{{#link-to route (query-params page=pagination.prev.num) rel="prev" class="pagination-button" title="Go to previous page"}}prev{{/link-to}}</li>
     {{/unless}}
 
     {{#each pages as |page|}}
       <li>
         {{#if page.num}}
-          {{#link-to route (query-params offset=page.offset) class="pagination-link" title=(concat "Go to page number " page.num)}}{{page.num}}{{/link-to}}
+          {{#link-to route (query-params page=page.num) class="pagination-link" title=(concat "Go to page number " page.num)}}{{page.num}}{{/link-to}}
         {{else}}
           ...
         {{/if}}
@@ -15,7 +15,7 @@
     {{/each}}
 
     {{#unless pagination.isLast}}
-      <li>{{#link-to route (query-params offset=pagination.next.offset) rel="next" class="pagination-button" title="Go to next page"}}next{{/link-to}}</li>
+      <li>{{#link-to route (query-params page=pagination.next.num) rel="next" class="pagination-button" title="Go to next page"}}next{{/link-to}}</li>
     {{/unless}}
   </ul>
 {{/if}}

--- a/config/environment.js
+++ b/config/environment.js
@@ -152,6 +152,8 @@ module.exports = function (environment) {
     ENV.intervals.syncingPolling = 10;
     ENV.timing.syncingPageRedirectionTime = 30;
 
+    ENV.pagination.dashboardReposPerPage = 10;
+
     ENV.APP.rootElement = '#ember-testing';
     ENV.APP.autoboot = false;
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -72,6 +72,11 @@ module.exports = function (environment) {
     'enterprise-version': !!process.env.TRAVIS_ENTERPRISE || false
   };
 
+  ENV.pagination = {
+    dashboardReposPerPage: 100,
+    profileReposPerPage: 25,
+  };
+
   ENV.sentry = {
     dsn: 'https://e775f26d043843bdb7ae391dc0f2487a@app.getsentry.com/75334',
     whitelistUrls: [


### PR DESCRIPTION
Users were able to manually specify the offset in the URL, which led to rounding errors in the rendered pagination links.

This makes it simpler to use from a user's perspective and also avoids exposing something the user should not be able to influence (yet). We can always re-evaluate this later if users would find it useful, as API still supports it.