### PR TITLE
[Bugfix]: Ensure tab is set as `builds` regardless of auth status

### DIFF
--- a/app/routes/builds.js
+++ b/app/routes/builds.js
@@ -9,8 +9,8 @@ export default TravisRoute.extend({
 
     if (this.get('auth.signedIn')) {
       this.set('tabStates.sidebarTab', 'owned');
-      this.set('tabStates.mainTab', 'builds');
     }
+    this.set('tabStates.mainTab', 'builds');
   },
 
   titleToken() {


### PR DESCRIPTION
This should address https://github.com/travis-pro/team-teal/issues/2520, where builds for a public repo were not being loaded when clicking "Show more." 