### PR TITLE
SVG padding fix

### DIFF
--- a/app/styles/app/modules/status-icon.sass
+++ b/app/styles/app/modules/status-icon.sass
@@ -6,6 +6,7 @@
     stroke-linejoin: round
     stroke-miterlimit: 10
     overflow: visible
+    padding: 1px
 
 .status-icon
   @extend %icon


### PR DESCRIPTION
Adding 1px padding to status icons to make sure overflow is visible even on hover