### PR TITLE
Update some imports for deprecation warnings

### DIFF
--- a/app/helpers/fuzzy-highlight.js
+++ b/app/helpers/fuzzy-highlight.js
@@ -1,10 +1,10 @@
-import Ember from 'ember';
 import fuzzyMatch from 'travis/utils/fuzzy-match';
 import { htmlSafe } from '@ember/string';
+import { helper } from '@ember/component/helper';
 
 export function fuzzyHighlight([slug, query]) {
   const highlighted =  fuzzyMatch(slug, query);
   return new htmlSafe(highlighted);
 }
 
-export default Ember.Helper.helper(fuzzyHighlight);
+export default helper(fuzzyHighlight);

--- a/app/helpers/github-commit-link.js
+++ b/app/helpers/github-commit-link.js
@@ -1,10 +1,12 @@
 import { htmlSafe } from '@ember/string';
-import Helper from '@ember/component/helper';
+import { helper } from '@ember/component/helper';
 import formatCommit from 'travis/utils/format-commit';
-import Ember from 'ember';
 import { service } from 'ember-decorators/service';
 
-export default Helper.extend({
+import Ember from 'ember';
+const { escapeExpression: escape } = Ember.Handlebars.Utils;
+
+export default helper.extend({
   @service externalLinks: null,
 
   compute([slug, commitSha]) {
@@ -12,14 +14,14 @@ export default Helper.extend({
       return '';
     }
 
-    const sha = Ember.Handlebars.Utils.escapeExpression(formatCommit(commitSha));
+    const sha = escape(formatCommit(commitSha));
 
     if (!slug) {
       return sha;
     }
 
     const commitUrl = this.get('externalLinks').githubCommit(slug, sha);
-    const url = Ember.Handlebars.Utils.escapeExpression(commitUrl);
+    const url = escape(commitUrl);
     const string = `<a class="github-link only-on-hover" href="${url}">${sha}</a>`;
     return new htmlSafe(string);
   }

--- a/app/helpers/github-commit-link.js
+++ b/app/helpers/github-commit-link.js
@@ -1,12 +1,12 @@
 import { htmlSafe } from '@ember/string';
-import { helper } from '@ember/component/helper';
+import Helper from '@ember/component/helper';
 import formatCommit from 'travis/utils/format-commit';
 import { service } from 'ember-decorators/service';
 
 import Ember from 'ember';
 const { escapeExpression: escape } = Ember.Handlebars.Utils;
 
-export default helper.extend({
+export default Helper.extend({
   @service externalLinks: null,
 
   compute([slug, commitSha]) {


### PR DESCRIPTION
There’s one more but maybe it’s from ember-svg-jar and
I can’t figure out how it could be addressed.