### PR TITLE
[Reliability]: App boots without feature-flags

### DIFF
--- a/app/services/feature-flags.js
+++ b/app/services/feature-flags.js
@@ -16,26 +16,34 @@ export default Service.extend({
    * transition, this is a decent interim solution. */
 
   fetchTask: task(function* () {
-    const featureSet = yield this.get('store').findAll('beta-feature');
-    this.set('serverFlags', featureSet);
-    let featuresService = this.get('features');
-    featureSet.map((feature) => {
-      // this means that non-single-word feature names will turn
-      // 'comic sans' into 'comic-sans'. This may/may not work as expected.
-      // TODO: Confirm that this won't break if we add a feature name with
-      // spaces.
-      let featureName = feature.get('dasherizedName');
-      if (feature.get('enabled')) {
-        featuresService.enable(featureName);
-      } else {
-        featuresService.disable(featureName);
-      }
-    });
+    try {
+      const featureSet = yield this.get('store').findAll('beta-feature');
+      this.set('serverFlags', featureSet);
+      let featuresService = this.get('features');
+      featureSet.map(feature => {
+        // this means that non-single-word feature names will turn
+        // 'comic sans' into 'comic-sans'. This may/may not work as expected.
+        // TODO: Confirm that this won't break if we add a feature name with
+        // spaces.
+        let featureName = feature.get('dasherizedName');
+        if (feature.get('enabled')) {
+          featuresService.enable(featureName);
+        } else {
+          featuresService.disable(featureName);
+        }
+      });
+    // We purposely left the catch block blank because:
+    // 1) We don't want to add any state here
+    // 2) We are still thinking about how to handle this from a UX perspective.
+    //    For instance the exception might be logged to Sentry
+    //    or we might want to show the user a flash message etc.
+    //    But this will be done at a later date.
+    } catch (e) {}
   }).drop(),
 
   reset() {
     this.get('serverFlags').map(flag => {
       this.get('features').disable(flag.get('name').dasherize());
     });
-  },
+  }
 });

--- a/tests/acceptance/feature-flags/app-boots-test.js
+++ b/tests/acceptance/feature-flags/app-boots-test.js
@@ -1,0 +1,27 @@
+import { test } from 'qunit';
+import moduleForAcceptance from 'travis/tests/helpers/module-for-acceptance';
+import { Response } from 'ember-cli-mirage';
+
+
+moduleForAcceptance('Acceptance | feature flags/app boots');
+
+test('visiting /feature-flags/app-boots', function (assert) {
+  server.get('/user/:user_id/beta_features', function (schema) {
+    return new Response(500, {}, {});
+  });
+
+  const currentUser = server.create('user');
+  signInUser(currentUser);
+
+  server.create('repository', {
+    owner: {
+      login: currentUser.login
+    },
+  });
+
+  visit('/');
+
+  andThen(function () {
+    assert.equal(currentURL(), '/');
+  });
+});


### PR DESCRIPTION
Currently in production, if a feature-flag call fails, ember-data throws an exception that halts loading on the page.

This change catches that exception to ensure the app still boots, just with the default flags.

Co-authored-by: Curtis Ekstrom <curtis@travis-ci.org>
Co-authored-by: Berrak Nil Boya <berraknil@gmail.com>