### PR TITLE
[Reliability] Remove broken offset parameter from links

### DIFF
--- a/app/templates/components/not-active.hbs
+++ b/app/templates/components/not-active.hbs
@@ -6,7 +6,7 @@
   <h2 class="page-title">This is not an active repository</h2>
 
   {{#if canActivate}}
-    <p class="page-notice">You can activate the repository on {{#link-to "account" repo.owner.login (query-params offset=0)}}your profile{{/link-to}},<br/>
+    <p class="page-notice">You can activate the repository on {{#link-to "account" repo.owner.login}}your profile{{/link-to}},<br/>
     or by clicking the button below</p>
 
     <button {{action (perform activate)}} class="button button--blue">Activate repository</button>

--- a/app/templates/components/org-item.hbs
+++ b/app/templates/components/org-item.hbs
@@ -1,4 +1,4 @@
-{{#link-to "account" account.login (query-params offset=0) class="org-info"}} 
+{{#link-to "account" account.login class="org-info"}}
   <span class="account-avatar">
     {{user-avatar url=account.avatarUrl name=name size=36}}
   </span>
@@ -8,10 +8,10 @@
       <p class="account-repo-count">{{pluralize account.reposCount 'repository'}}</p>
     {{else}}
       No repositories
-    {{/if}} 
+    {{/if}}
     {{#if isUser}}
       <p class="account-token">
-        Token: 
+        Token:
         {{#if tokenIsVisible}}
           <strong>{{auth.currentUser.token}}</strong>
         {{/if}}
@@ -22,7 +22,7 @@
           {{else}}
             show token
           {{/if}}
-          {{/tooltip-on-element}} 
+          {{/tooltip-on-element}}
           {{svg-jar 'icon-seemore' class="icon icon-seemore"}}
         </a>
       </p>

--- a/app/templates/components/repos-list-tabs.hbs
+++ b/app/templates/components/repos-list-tabs.hbs
@@ -10,7 +10,7 @@
   {{/if}}
 
   <li id="tab_new" class={{classNew}}>
-    {{#link-to "account" currentUser.login (query-params offset=0) trackEvent="add-repository-from-list" title="Add New Repository"}}
+    {{#link-to "account" currentUser.login trackEvent="add-repository-from-list" title="Add New Repository"}}
     <span class="icon icon--plus"></span>
     {{/link-to}}
   </li>

--- a/app/templates/components/top-bar.hbs
+++ b/app/templates/components/top-bar.hbs
@@ -85,7 +85,7 @@
             </button>
         {{/if}}
         {{#if auth.signedIn}}
-          {{#link-to "account" user.login (query-params offset=0) class="navigation-anchor signed-in"}}
+          {{#link-to "account" user.login class="navigation-anchor signed-in"}}
             {{userName}}
             {{user-avatar url=user.avatarUrl name=user.fullName size=40}}
           {{/link-to}}
@@ -96,7 +96,7 @@
         {{#if auth.signedIn}}
           <ul class="navigation-nested">
             <li>
-              {{#link-to "account" user.login (query-params offset=0) class="signed-in" title="See your Travis profile"}}Profile{{/link-to}}
+              {{#link-to "account" user.login class="signed-in" title="See your Travis profile"}}Profile{{/link-to}}
             </li>
             {{#if config.billingEndpoint}}
               {{#unless features.enterpriseVersion}}


### PR DESCRIPTION
Since we changed the pagination from offset to page, we don't need to send an _offset=0_ to **link-to** components on templates. It breaks active org/user state for highlighting as we don't use the offset at all anymore.