### PR TITLE
[Reliability]: Ensure feature flags exception logged to Sentry

### DIFF
--- a/app/services/feature-flags.js
+++ b/app/services/feature-flags.js
@@ -5,6 +5,7 @@ import { service } from 'ember-decorators/service';
 export default Service.extend({
   @service store: null,
   @service features: null,
+  @service raven: null,
 
   serverFlags: [],
 
@@ -32,13 +33,12 @@ export default Service.extend({
           featuresService.disable(featureName);
         }
       });
-    // We purposely left the catch block blank because:
-    // 1) We don't want to add any state here
-    // 2) We are still thinking about how to handle this from a UX perspective.
-    //    For instance the exception might be logged to Sentry
-    //    or we might want to show the user a flash message etc.
-    //    But this will be done at a later date.
-    } catch (e) {}
+      // TODO:
+      // We are still thinking about how to handle a failure from a UX perspective.
+      // For instance, we might want to show the user a flash message etc.
+    } catch (e) {
+      this.get('raven').logException(e);
+    }
   }).drop(),
 
   reset() {

--- a/tests/acceptance/feature-flags/app-boots-test.js
+++ b/tests/acceptance/feature-flags/app-boots-test.js
@@ -1,6 +1,7 @@
 import { test } from 'qunit';
 import moduleForAcceptance from 'travis/tests/helpers/module-for-acceptance';
 import { Response } from 'ember-cli-mirage';
+import Service from '@ember/service';
 
 moduleForAcceptance('Acceptance | feature flags/app boots');
 
@@ -14,7 +15,7 @@ test('app boots even if call to `/beta_features` fails', function (assert) {
   const currentUser = server.create('user');
   signInUser(currentUser);
 
-  const mockSentry = Ember.Service.extend({
+  const mockSentry = Service.extend({
     logException(error) {
       assert.ok(true);
     },

--- a/tests/acceptance/feature-flags/app-boots-test.js
+++ b/tests/acceptance/feature-flags/app-boots-test.js
@@ -2,16 +2,27 @@ import { test } from 'qunit';
 import moduleForAcceptance from 'travis/tests/helpers/module-for-acceptance';
 import { Response } from 'ember-cli-mirage';
 
-
 moduleForAcceptance('Acceptance | feature flags/app boots');
 
-test('visiting /feature-flags/app-boots', function (assert) {
+test('app boots even if call to `/beta_features` fails', function (assert) {
+  assert.expect(2);
+
   server.get('/user/:user_id/beta_features', function (schema) {
     return new Response(500, {}, {});
   });
 
   const currentUser = server.create('user');
   signInUser(currentUser);
+
+  const mockSentry = Ember.Service.extend({
+    logException(error) {
+      assert.ok(true);
+    },
+  });
+
+  const instance = this.application.__deprecatedInstance__;
+  const registry = instance.register ? instance : instance.registry;
+  registry.register('service:raven', mockSentry);
 
   server.create('repository', {
     owner: {


### PR DESCRIPTION
The test is a bit noisier now, but it feels worth the tradeoff. Also, fix the test name as it was still the generated boilerplate.