### PR TITLE
[Reliability] Add padding to build status icons

### DIFF
--- a/app/styles/app/modules/build-tile.sass
+++ b/app/styles/app/modules/build-tile.sass
@@ -14,6 +14,7 @@
     &:last-of-type
       border-right: none
     .status-icon
+      padding: 1px
       position: absolute
       top: 0
       right: 0

--- a/app/styles/app/modules/status-icon.sass
+++ b/app/styles/app/modules/status-icon.sass
@@ -6,7 +6,6 @@
     stroke-linejoin: round
     stroke-miterlimit: 10
     overflow: visible
-    padding: 1px
 
 .status-icon
   @extend %icon

--- a/app/styles/app/modules/status-icon.sass
+++ b/app/styles/app/modules/status-icon.sass
@@ -6,6 +6,7 @@
     stroke-linejoin: round
     stroke-miterlimit: 10
     overflow: visible
+    padding: 1px
 
 .status-icon
   @extend %icon


### PR DESCRIPTION
Build status icons are clipped on hover as documented [here](https://github.com/travis-pro/team-teal/issues/2539). This 1px padding forces them outside of their bounding box and makes them completely visible.

This commit also removes the previously applied global padding to all status icons as it is unnecessary and breaks the flow of the layout.