### PR TITLE
Bump Ember-CLI to 2.18.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4011,7 +4011,7 @@
         "chalk": "2.3.0",
         "inquirer": "2.0.0",
         "json-stable-stringify": "1.0.1",
-        "ora": "1.3.0",
+        "ora": "1.4.0",
         "through": "2.3.8",
         "user-info": "1.0.0"
       },
@@ -4803,16 +4803,16 @@
       }
     },
     "ember-cli": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/ember-cli/-/ember-cli-2.18.1.tgz",
-      "integrity": "sha1-qGUNy5zktstHSbk4eMKnrSlx5fs=",
+      "version": "2.18.2",
+      "resolved": "https://registry.npmjs.org/ember-cli/-/ember-cli-2.18.2.tgz",
+      "integrity": "sha1-uxUxOhUTmoUkiobSA2Q/kYukD1c=",
       "dev": true,
       "requires": {
         "amd-name-resolver": "1.0.0",
         "babel-plugin-transform-es2015-modules-amd": "6.24.1",
         "bower-config": "1.4.1",
         "bower-endpoint-parser": "0.2.2",
-        "broccoli-babel-transpiler": "6.1.2",
+        "broccoli-babel-transpiler": "6.1.4",
         "broccoli-brocfile-loader": "0.18.0",
         "broccoli-builder": "0.18.11",
         "broccoli-concat": "3.2.2",
@@ -4848,7 +4848,7 @@
         "exists-sync": "0.0.4",
         "exit": "0.1.2",
         "express": "4.16.2",
-        "filesize": "3.5.11",
+        "filesize": "3.6.0",
         "find-up": "2.1.0",
         "fs-extra": "4.0.3",
         "fs-tree-diff": "0.5.6",
@@ -4878,14 +4878,14 @@
         "promise-map-series": "0.2.3",
         "quick-temp": "0.1.8",
         "resolve": "1.4.0",
-        "rsvp": "4.8.0",
+        "rsvp": "4.8.1",
         "sane": "2.3.0",
         "semver": "5.4.1",
         "silent-error": "1.1.0",
         "sort-package-json": "1.7.1",
         "symlink-or-copy": "1.1.8",
         "temp": "0.8.3",
-        "testem": "1.18.4",
+        "testem": "2.0.0",
         "tiny-lr": "1.1.0",
         "tree-sync": "1.2.2",
         "uuid": "3.1.0",
@@ -4931,7 +4931,7 @@
             "convert-source-map": "1.5.0",
             "debug": "2.6.8",
             "json5": "0.5.1",
-            "lodash": "4.17.4",
+            "lodash": "4.17.5",
             "minimatch": "3.0.4",
             "path-is-absolute": "1.0.1",
             "private": "0.1.7",
@@ -4946,9 +4946,9 @@
           "dev": true
         },
         "broccoli-babel-transpiler": {
-          "version": "6.1.2",
-          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.1.2.tgz",
-          "integrity": "sha512-o1OUe5RZ5EP5+QICEmRNvWlhMvIciMisVACHu6qUPt6dE0Q0UnI5lUpWTmuXg/X+QuznqD/s1PApIpahv/QMZw==",
+          "version": "6.1.4",
+          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.1.4.tgz",
+          "integrity": "sha512-h63g7iOBWdxj0GuZw8kNsyaD1T9weKsY3I+gp3rOefozbHwUesJ43vzLy0jj3t/rbiP2czcJAlyHS48EcRil8Q==",
           "dev": true,
           "requires": {
             "babel-core": "6.26.0",
@@ -4960,7 +4960,7 @@
             "heimdalljs-logger": "0.1.9",
             "json-stable-stringify": "1.0.1",
             "rsvp": "3.6.2",
-            "workerpool": "2.2.2"
+            "workerpool": "2.3.0"
           },
           "dependencies": {
             "broccoli-funnel": {
@@ -5059,9 +5059,9 @@
           "dev": true
         },
         "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
           "dev": true
         },
         "minimatch": {
@@ -5074,9 +5074,9 @@
           }
         },
         "rsvp": {
-          "version": "4.8.0",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.0.tgz",
-          "integrity": "sha512-a3a52vA+LoPu4n9t10O+a5aFaEcB1zacD5DggJZw7XZmSWVJ0A46LgInfve+LL8QuiSZSp280B0boXSqvNYfnw==",
+          "version": "4.8.1",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.1.tgz",
+          "integrity": "sha512-c9tShmZbQ5nLVVVl3Fuhk1NExJlXfAMIEz7a8GC570X8XhNQNZPFAdjOeMmJEN3SLYOOb2OprS576P/QO4QouA==",
           "dev": true
         },
         "supports-color": {
@@ -5086,6 +5086,15 @@
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
+          }
+        },
+        "workerpool": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.0.tgz",
+          "integrity": "sha512-JP5DpviEV84zDmz13QnD4FfRjZBjnTOYY2O4pGgxtlqLh47WOzQFHm8o17TE5OSfcDoKC6vHSrN4yPju93DW0Q==",
+          "dev": true,
+          "requires": {
+            "object-assign": "4.1.1"
           }
         }
       }
@@ -5979,7 +5988,7 @@
         "exists-sync": "0.0.3",
         "fs-extra": "4.0.3",
         "inflection": "1.12.0",
-        "rsvp": "4.8.0",
+        "rsvp": "4.8.1",
         "silent-error": "1.1.0"
       },
       "dependencies": {
@@ -6020,9 +6029,9 @@
           "dev": true
         },
         "rsvp": {
-          "version": "4.8.0",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.0.tgz",
-          "integrity": "sha512-a3a52vA+LoPu4n9t10O+a5aFaEcB1zacD5DggJZw7XZmSWVJ0A46LgInfve+LL8QuiSZSp280B0boXSqvNYfnw==",
+          "version": "4.8.1",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.1.tgz",
+          "integrity": "sha512-c9tShmZbQ5nLVVVl3Fuhk1NExJlXfAMIEz7a8GC570X8XhNQNZPFAdjOeMmJEN3SLYOOb2OprS576P/QO4QouA==",
           "dev": true
         },
         "supports-color": {
@@ -8846,16 +8855,16 @@
       "integrity": "sha1-a+CvbHGUmBPgKseTVk/dv4M2uAc=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "node-fetch": "1.7.3",
         "rsvp": "3.6.2",
         "semver": "5.4.1"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
           "dev": true
         }
       }
@@ -10040,9 +10049,9 @@
       "dev": true
     },
     "filesize": {
-      "version": "3.5.11",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.5.11.tgz",
-      "integrity": "sha512-ZH7loueKBoDb7yG9esn1U+fgq7BzlzW6NRi5/rMdxIZ05dj7GFD/Xc5rq2CDt5Yq86CyfSYVyx4242QQNZbx1g==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.0.tgz",
+      "integrity": "sha512-g5OWtoZWcPI56js1DFhIEqyG9tnu/7sG3foHwgS9KGYFMfsYguI3E+PRVCmtmE96VajQIEMRU2OhN+ME589Gdw==",
       "dev": true
     },
     "fill-range": {
@@ -11795,9 +11804,9 @@
       }
     },
     "http-parser-js": {
-      "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.9.tgz",
-      "integrity": "sha1-6hoE+2St/wJC6ZdPKX3Uw8rSceE=",
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
+      "integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q=",
       "dev": true
     },
     "http-proxy": {
@@ -12009,7 +12018,7 @@
         "cli-width": "2.2.0",
         "external-editor": "1.1.1",
         "figures": "2.0.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "mute-stream": "0.0.6",
         "pinkie-promise": "2.0.1",
         "run-async": "2.3.0",
@@ -12032,9 +12041,9 @@
           "dev": true
         },
         "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
           "dev": true
         },
         "string-width": {
@@ -12749,7 +12758,7 @@
       "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08=",
       "dev": true,
       "requires": {
-        "uc.micro": "1.0.3"
+        "uc.micro": "1.0.5"
       }
     },
     "lint-staged": {
@@ -13348,6 +13357,12 @@
         "lodash._slice": "2.3.0"
       }
     },
+    "lodash.castarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "integrity": "sha1-wCUTUV4wna3dTCTGDP3c9ZdtkRU=",
+      "dev": true
+    },
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -13741,7 +13756,7 @@
         "entities": "1.1.1",
         "linkify-it": "2.0.3",
         "mdurl": "1.0.1",
-        "uc.micro": "1.0.3"
+        "uc.micro": "1.0.5"
       }
     },
     "markdown-it-terminal": {
@@ -14586,17 +14601,37 @@
       "dev": true
     },
     "ora": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-1.3.0.tgz",
-      "integrity": "sha1-gAeN0rkqk0r2ajrXKluRBpTt5Ro=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-1.4.0.tgz",
+      "integrity": "sha512-iMK1DOQxzzh2MBlVsU42G80mnrvUhqsMh74phHtDlrcTZPK0pH6o7l7DRshK+0YsxDyEuaOkziVdvM3T0QTzpw==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
+        "chalk": "2.3.0",
         "cli-cursor": "2.1.0",
         "cli-spinners": "1.1.0",
-        "log-symbols": "1.0.2"
+        "log-symbols": "2.2.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
         "cli-cursor": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -14604,6 +14639,15 @@
           "dev": true,
           "requires": {
             "restore-cursor": "2.0.0"
+          }
+        },
+        "log-symbols": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+          "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.0"
           }
         },
         "onetime": {
@@ -14623,6 +14667,15 @@
           "requires": {
             "onetime": "2.0.1",
             "signal-exit": "3.0.2"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
           }
         }
       }
@@ -17116,9 +17169,9 @@
       }
     },
     "testem": {
-      "version": "1.18.4",
-      "resolved": "https://registry.npmjs.org/testem/-/testem-1.18.4.tgz",
-      "integrity": "sha1-5F/tkivsL1SmFsQ/EZIlmKyX60E=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/testem/-/testem-2.0.0.tgz",
+      "integrity": "sha1-sFyWIAx6yYuumY1xyUwMU0WQfRM=",
       "dev": true,
       "requires": {
         "backbone": "1.3.3",
@@ -17126,13 +17179,14 @@
         "charm": "1.0.2",
         "commander": "2.11.0",
         "consolidate": "0.14.5",
-        "cross-spawn": "5.1.0",
+        "execa": "0.9.0",
         "express": "4.16.2",
         "fireworm": "0.7.1",
         "glob": "7.1.2",
         "http-proxy": "1.16.2",
         "js-yaml": "3.9.1",
         "lodash.assignin": "4.2.0",
+        "lodash.castarray": "4.4.0",
         "lodash.clonedeep": "4.5.0",
         "lodash.find": "4.6.0",
         "lodash.uniqby": "4.7.0",
@@ -17154,6 +17208,21 @@
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
           "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
           "dev": true
+        },
+        "execa": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.9.0.tgz",
+          "integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
         }
       }
     },
@@ -17436,9 +17505,9 @@
       "dev": true
     },
     "uc.micro": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.3.tgz",
-      "integrity": "sha1-ftUNXg+an7ClczeSWfKndFjVAZI=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.5.tgz",
+      "integrity": "sha512-JoLI4g5zv5qNyT09f4YAvEZIIV1oOjqnewYg5D38dkQljIzpPT296dbIGvKro3digYI1bkb7W6EP1y4uDlmzLg==",
       "dev": true
     },
     "uglify-js": {
@@ -17737,7 +17806,7 @@
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "dev": true,
       "requires": {
-        "http-parser-js": "0.4.9",
+        "http-parser-js": "0.4.10",
         "websocket-extensions": "0.1.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "broccoli-merge-trees": "^2.0.0",
     "ember-ajax": "3.0.0",
     "ember-browserify": "^1.1.13",
-    "ember-cli": "~2.18.0",
+    "ember-cli": "^2.18.2",
     "ember-cli-app-version": "^3.0.0",
     "ember-cli-autoprefixer": "^0.8.1",
     "ember-cli-babel": "^6.10.0",


### PR DESCRIPTION
This changes the semver range for `ember-cli` to use the `^` operator instead of `~`. The only reason for this is that it [will allow minor/patch version updates](https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004) as opposed to [patch-only updates when the patch version is specified](https://docs.npmjs.com/misc/semver#tilde-ranges-123-12-1).

Given we now have a `package-lock.json` file, I'm not sure an `npm install` will do anything weird in either case, but the version definition may affect how Greenkeeper works (meaning less PR's for versions we'd legitimately want automatically tested).

So, in our case, `~` would allow an update to 2.19.0, while `^` would only allow updates to higher 2.18.x versions.