### PR TITLE
Improve overall token UX on profile page

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -339,6 +339,8 @@ module.exports = {
       },
       globals: {
         server: true,
+        triggerCopySuccess: true,
+        triggerCopyError: true,
         signInUser: true,
         withFeature: true,
         percySnapshot: true,

--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -24,7 +24,7 @@ export default ActiveModelAdapter.extend({
     hash.headers['accept'] = 'application/json; version=2';
     hash.headers['X-Client-Release'] = config.release;
 
-    let token = this.get('auth').token();
+    let token = this.get('auth.token');
     if (token) {
       if (!hash.headers['Authorization']) {
         hash.headers['Authorization'] = `token ${token}`;

--- a/app/adapters/v3.js
+++ b/app/adapters/v3.js
@@ -50,7 +50,7 @@ export default RESTAdapter.extend({
 
     hash.headers = hash.headers || {};
 
-    let token = this.get('auth').token();
+    let token = this.get('auth.token');
     if (token) {
       hash.headers['Authorization'] = `token ${token}`;
     }

--- a/app/components/branch-row.js
+++ b/app/components/branch-row.js
@@ -44,7 +44,7 @@ export default Component.extend({
         }
       };
       if (this.get('auth.signedIn')) {
-        options.headers.Authorization = `token ${this.auth.token()}`;
+        options.headers.Authorization = `token ${this.auth.token}`;
       }
       let path = `${apiEndpoint}/repo/${repoId}/builds`;
       let params = `?branch.name=${branchName}&limit=5&build.event_type=push,api,cron`;

--- a/app/components/not-active.js
+++ b/app/components/not-active.js
@@ -28,7 +28,7 @@ export default Component.extend({
     try {
       const response = yield $.ajax(`${apiEndpoint}/repo/${repoId}/activate`, {
         headers: {
-          Authorization: `token ${this.get('auth').token()}`,
+          Authorization: `token ${this.get('auth.token')}`,
           'Travis-API-Version': '3'
         },
         method: 'POST'

--- a/app/components/org-item.js
+++ b/app/components/org-item.js
@@ -8,6 +8,7 @@ export default Component.extend({
   classNameBindings: ['type', 'selected'],
 
   tokenIsVisible: false,
+  showCopySuccess: false,
 
   @alias('account.type') type: null,
   @alias('account.selected') selected: null,
@@ -29,7 +30,14 @@ export default Component.extend({
 
   actions: {
     tokenVisibility() {
+      if (this.get('showCopySuccess')) {
+        this.toggleProperty('showCopySuccess');
+      }
       this.toggleProperty('tokenIsVisible');
-    }
+    },
+
+    copyTokenSuccessful() {
+      this.toggleProperty('showCopySuccess');
+    },
   },
 });

--- a/app/components/org-item.js
+++ b/app/components/org-item.js
@@ -37,7 +37,9 @@ export default Component.extend({
     },
 
     copyTokenSuccessful() {
-      this.toggleProperty('showCopySuccess');
+      if (!this.get('showCopySuccess')) {
+        this.toggleProperty('showCopySuccess');
+      }
     },
   },
 });

--- a/app/helpers/obfuscated-chars.js
+++ b/app/helpers/obfuscated-chars.js
@@ -1,0 +1,7 @@
+import { helper } from '@ember/component/helper';
+
+export function obfuscatedChars([n]) {
+  return '•'.repeat(n);
+}
+
+export default helper(obfuscatedChars);

--- a/app/models/log.js
+++ b/app/models/log.js
@@ -34,7 +34,7 @@ export default EmberObject.extend({
 
     let id = this.get('job.id');
     const url = `${config.apiEndpoint}/job/${id}/log`;
-    const token = this.get('auth').token();
+    const token = this.get('auth.token');
     let headers = {
       'Travis-API-Version': '3'
     };

--- a/app/routes/branches.js
+++ b/app/routes/branches.js
@@ -19,7 +19,7 @@ export default TravisRoute.extend({
       }
     };
     if (this.get('auth.signedIn')) {
-      options.headers.Authorization = `token ${this.auth.token()}`;
+      options.headers.Authorization = `token ${this.auth.token}`;
     }
 
     let path = `${apiEndpoint}/repo/${repoId}/branches`;

--- a/app/routes/owner.js
+++ b/app/routes/owner.js
@@ -16,7 +16,7 @@ export default TravisRoute.extend({
       }
     };
     if (this.get('auth.signedIn')) {
-      options.headers.Authorization = `token ${this.auth.token()}`;
+      options.headers.Authorization = `token ${this.auth.token}`;
     }
     let { owner } = params;
     let { apiEndpoint } = config;

--- a/app/routes/owner/repositories.js
+++ b/app/routes/owner/repositories.js
@@ -18,7 +18,7 @@ export default TravisRoute.extend({
     };
 
     if (this.get('auth.signedIn')) {
-      options.headers.Authorization = `token ${this.auth.token()}`;
+      options.headers.Authorization = `token ${this.auth.token}`;
     }
 
     // eslint-disable-next-line

--- a/app/services/ajax.js
+++ b/app/services/ajax.js
@@ -61,7 +61,7 @@ export default Service.extend({
     method = (method || 'GET').toUpperCase();
     endpoint = config.apiEndpoint || '';
     options = options || {};
-    token = get(this, 'auth').token();
+    token = get(this, 'auth.token');
 
     options.headers = options.headers || {};
 

--- a/app/services/api.js
+++ b/app/services/api.js
@@ -32,7 +32,7 @@ export default Service.extend({
 
   request(url, method = 'GET', options = {}) {
     let endpoint = config.apiEndpoint || '';
-    let token = get(this, 'auth').token();
+    let token = get(this, 'auth.token');
 
     options.headers = options.headers || {};
     options.headers['Travis-API-Version'] = '3';

--- a/app/services/auth.js
+++ b/app/services/auth.js
@@ -28,7 +28,8 @@ export default Service.extend({
     return this._super(...arguments);
   },
 
-  token() {
+  @computed()
+  get token() {
     return this.get('sessionStorage').getItem('travis.token');
   },
 

--- a/app/services/broadcasts.js
+++ b/app/services/broadcasts.js
@@ -25,7 +25,7 @@ export default Service.extend({
       options = {};
       options.type = 'GET';
       options.headers = {
-        Authorization: `token ${this.get('auth').token()}`,
+        Authorization: `token ${this.get('auth.token')}`,
         'Travis-API-Version': '3'
       };
       seenBroadcasts = this.get('storage').getItem('travis.seen_broadcasts');

--- a/app/styles/app/layouts/profile.scss
+++ b/app/styles/app/layouts/profile.scss
@@ -227,32 +227,6 @@ $profile-breakpoint: 600px;
   }
 }
 
-.profile-token-toggle {
-  .icon-seemore {
-    vertical-align: middle;
-
-    &:hover {
-      path, ellipse {
-        stroke: $asphalt-grey;
-      }
-    }
-  }
-
-  &.is-visible {
-    .icon-seemore {
-      ellipse {
-        fill: $cement-grey;
-      }
-
-      &:hover {
-        ellipse {
-          fill: $asphalt-grey;
-        }
-      }
-    }
-  }
-}
-
 .profile-repositories-filter {
   margin-bottom: 1.5em;
 

--- a/app/styles/app/layouts/profile.scss
+++ b/app/styles/app/layouts/profile.scss
@@ -258,8 +258,18 @@ $profile-breakpoint: 600px;
   }
 }
 
-.account-token .italic {
-  font-style: italic;
+
+.account-token {
+  .token-copied-text {
+    margin-left: 8px;
+    font-size: 12px;
+    font-style: italic;
+  }
+
+  .auth-token {
+    margin-left: 8px;
+    font-size: 12px
+  }
 }
 
 .token-actions {

--- a/app/styles/app/layouts/profile.scss
+++ b/app/styles/app/layouts/profile.scss
@@ -274,7 +274,7 @@ $profile-breakpoint: 600px;
 
 .token-actions {
   margin-top: 0.5em;
-  width: 100%;
+  width: 95%;
   display: flex;
   justify-content: space-between;
 }

--- a/app/styles/app/layouts/profile.scss
+++ b/app/styles/app/layouts/profile.scss
@@ -262,6 +262,47 @@ $profile-breakpoint: 600px;
   font-style: italic;
 }
 
+.token-actions {
+  margin-top: 0.5em;
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+}
+
+.obfuscated-chars {
+  padding-left: 0.4em;
+  letter-spacing: 0.2em;
+}
+
 .token-actions button {
-  border: 1px solid $cement-grey;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  text-transform: uppercase;
+  font-weight: bold;
+  font-size: 10px;
+  background-color: transparent;
+  border-radius: 0.25em;
+  width: calc(1/2*100% - (1 - 1/2)*0.5em);
+  padding: 4px 0;
+
+  & svg {
+    margin-right: 4px;
+    height: 12px;
+  }
+
+  &.copy-button {
+    border: 0.09em solid lighten($oxide-blue, 20%);
+    box-shadow: 0 .15px 0 $oxide-blue;
+    color: $oxide-blue;
+    svg {
+      @include colorSVG($oxide-blue);
+    }
+  }
+
+  &.show-token {
+    border: 0.09em solid lighten($cement-grey, 20%);
+    box-shadow: 0 .15px 0 $cement-grey;
+    color: $cement-grey;
+  }
 }

--- a/app/styles/app/layouts/profile.scss
+++ b/app/styles/app/layouts/profile.scss
@@ -267,8 +267,9 @@ $profile-breakpoint: 600px;
   }
 
   .auth-token {
-    margin-left: 8px;
-    font-size: 12px
+    margin-left: 6px;
+    font-size: 12px;
+    font-style: italic;
   }
 }
 

--- a/app/styles/app/layouts/profile.scss
+++ b/app/styles/app/layouts/profile.scss
@@ -283,3 +283,11 @@ $profile-breakpoint: 600px;
     }
   }
 }
+
+.account-token .italic {
+  font-style: italic;
+}
+
+.token-actions button {
+  border: 1px solid $cement-grey;
+}

--- a/app/styles/app/layouts/profile.scss
+++ b/app/styles/app/layouts/profile.scss
@@ -258,7 +258,6 @@ $profile-breakpoint: 600px;
   }
 }
 
-
 .account-token {
   .token-copied-text {
     margin-left: 8px;

--- a/app/templates/components/org-item.hbs
+++ b/app/templates/components/org-item.hbs
@@ -13,13 +13,14 @@
       <p class="account-token">
         API Token:
         {{#if showCopySuccess}}
-          <span class="italic">Token copied!</span>
+          <span class="token-copied-text italic">Token copied!</span>
         {{else}}
-          <span class="italic">{{if tokenIsVisible auth.token 'hidden'}}</span>
+          <span class="auth-token italic">{{if tokenIsVisible auth.token 'hidden'}}</span>
         {{/if}}
         <div class="token-actions">
-          <button {{action 'tokenVisibility'}}>{{if tokenIsVisible 'Hide' 'Show'}}</button>
+          <button {{action 'tokenVisibility'}} class="show-token">{{if tokenIsVisible 'Hide' 'Show'}}</button>
           {{#copy-button
+            class="copy-button"
             clipboardText=auth.token
             title="Copy to clipboard"
             success=(action 'copyTokenSuccessful')}}

--- a/app/templates/components/org-item.hbs
+++ b/app/templates/components/org-item.hbs
@@ -15,7 +15,7 @@
         {{#if showCopySuccess}}
           <span class="token-copied-text italic">Token copied!</span>
         {{else}}
-          <span class="auth-token italic">{{if tokenIsVisible auth.token 'hidden'}}</span>
+          <span class="auth-token italic">{{if tokenIsVisible auth.token (obfuscated-chars 12)}}</span>
         {{/if}}
         <div class="token-actions">
           <button {{action 'tokenVisibility'}} class="show-token">{{if tokenIsVisible 'Hide' 'Show'}}</button>

--- a/app/templates/components/org-item.hbs
+++ b/app/templates/components/org-item.hbs
@@ -11,7 +11,7 @@
     {{/if}}
     {{#if isUser}}
       <p class="account-token">
-        Token:
+        API Token:
         {{#if tokenIsVisible}}
           <strong>{{auth.token}}</strong>
         {{/if}}

--- a/app/templates/components/org-item.hbs
+++ b/app/templates/components/org-item.hbs
@@ -13,7 +13,7 @@
       <p class="account-token">
         Token:
         {{#if tokenIsVisible}}
-          <strong>{{auth.currentUser.token}}</strong>
+          <strong>{{auth.token}}</strong>
         {{/if}}
         <a {{action 'tokenVisibility' prevenDefault=true}} class="profile-token-toggle {{if tokenIsVisible 'is-visible'}} dropdown">
           {{#tooltip-on-element}}

--- a/app/templates/components/org-item.hbs
+++ b/app/templates/components/org-item.hbs
@@ -11,21 +11,28 @@
     {{/if}}
     {{#if isUser}}
       <p class="account-token">
-        API Token:
+        API Token
         {{#if showCopySuccess}}
           <span class="token-copied-text italic">Token copied!</span>
         {{else}}
-          <span class="auth-token italic">{{if tokenIsVisible auth.token (obfuscated-chars 12)}}</span>
+          {{#if tokenIsVisible}}
+            <span class="auth-token">{{auth.token}}</span>
+          {{else}}
+            <span class="obfuscated-chars">{{obfuscated-chars 20}}</span>
+          {{/if}}
         {{/if}}
         <div class="token-actions">
-          <button {{action 'tokenVisibility'}} class="show-token">{{if tokenIsVisible 'Hide' 'Show'}}</button>
           {{#copy-button
             class="copy-button"
             clipboardText=auth.token
             title="Copy to clipboard"
             success=(action 'copyTokenSuccessful')}}
-            Copy
+            {{svg-jar 'icon-copy' class="icon"}} <span>Copy token</span>
           {{/copy-button}}
+          <button {{action 'tokenVisibility'}} class="show-token">
+            {{svg-jar 'icon-seemore' class="icon"}} <span>{{if tokenIsVisible
+              'Hide token' 'View token'}}</span>
+          </button>
         </div>
       </p>
     {{/if}}

--- a/app/templates/components/org-item.hbs
+++ b/app/templates/components/org-item.hbs
@@ -12,19 +12,20 @@
     {{#if isUser}}
       <p class="account-token">
         API Token:
-        {{#if tokenIsVisible}}
-          <strong>{{auth.token}}</strong>
+        {{#if showCopySuccess}}
+          <span class="italic">Token copied!</span>
+        {{else}}
+          <span class="italic">{{if tokenIsVisible auth.token 'hidden'}}</span>
         {{/if}}
-        <a {{action 'tokenVisibility' prevenDefault=true}} class="profile-token-toggle {{if tokenIsVisible 'is-visible'}} dropdown">
-          {{#tooltip-on-element}}
-          {{#if tokenIsVisible}}
-            hide token
-          {{else}}
-            show token
-          {{/if}}
-          {{/tooltip-on-element}}
-          {{svg-jar 'icon-seemore' class="icon icon-seemore"}}
-        </a>
+        <div class="token-actions">
+          <button {{action 'tokenVisibility'}}>{{if tokenIsVisible 'Hide' 'Show'}}</button>
+          {{#copy-button
+            clipboardText=auth.token
+            title="Copy to clipboard"
+            success=(action 'copyTokenSuccessful')}}
+            Copy
+          {{/copy-button}}
+        </div>
       </p>
     {{/if}}
   </span>

--- a/app/templates/components/org-item.hbs
+++ b/app/templates/components/org-item.hbs
@@ -13,7 +13,7 @@
       <p class="account-token">
         API Token
         {{#if showCopySuccess}}
-          <span class="token-copied-text italic">Token copied!</span>
+          <span class="token-copied-text">Token copied!</span>
         {{else}}
           {{#if tokenIsVisible}}
             <span class="auth-token">{{auth.token}}</span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -5346,7 +5346,7 @@
       "requires": {
         "broccoli-funnel": "1.2.0",
         "clipboard": "1.7.1",
-        "ember-cli-babel": "6.10.0",
+        "ember-cli-babel": "6.11.0",
         "ember-cli-htmlbars": "2.0.3",
         "fastboot-transform": "0.1.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3726,7 +3726,6 @@
       "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-1.7.1.tgz",
       "integrity": "sha1-Ng1taUbpmnof7zleQrqStem1oWs=",
       "dev": true,
-      "optional": true,
       "requires": {
         "good-listener": "1.2.2",
         "select": "1.1.2",
@@ -4449,8 +4448,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
       "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -5336,6 +5334,61 @@
             "minimist": "1.2.0",
             "walker": "1.0.7",
             "watch": "0.10.0"
+          }
+        }
+      }
+    },
+    "ember-cli-clipboard": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-clipboard/-/ember-cli-clipboard-0.8.1.tgz",
+      "integrity": "sha1-Wfjra6Rxp2aN/1kvzrt7BgFCQN0=",
+      "dev": true,
+      "requires": {
+        "broccoli-funnel": "1.2.0",
+        "clipboard": "1.7.1",
+        "ember-cli-babel": "6.10.0",
+        "ember-cli-htmlbars": "2.0.3",
+        "fastboot-transform": "0.1.1"
+      },
+      "dependencies": {
+        "broccoli-funnel": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+          "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+          "dev": true,
+          "requires": {
+            "array-equal": "1.0.0",
+            "blank-object": "1.0.2",
+            "broccoli-plugin": "1.3.0",
+            "debug": "2.6.8",
+            "exists-sync": "0.0.4",
+            "fast-ordered-set": "1.0.3",
+            "fs-tree-diff": "0.5.6",
+            "heimdalljs": "0.2.5",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "path-posix": "1.0.0",
+            "rimraf": "2.6.1",
+            "symlink-or-copy": "1.1.8",
+            "walk-sync": "0.3.2"
+          }
+        },
+        "fastboot-transform": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/fastboot-transform/-/fastboot-transform-0.1.1.tgz",
+          "integrity": "sha512-aY3wh4kFCYOZWZM88f2svB9OL8UNpqBtOQxV3hHxjeRncQUKLD81I2GXayIFaGEQiS8g34awXfq46WZv8uIHvQ==",
+          "dev": true,
+          "requires": {
+            "broccoli-stew": "1.5.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
           }
         }
       }
@@ -11669,7 +11722,6 @@
       "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
       "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
       "dev": true,
-      "optional": true,
       "requires": {
         "delegate": "3.2.0"
       }
@@ -16338,8 +16390,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
       "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "semver": {
       "version": "5.4.1",
@@ -17478,8 +17529,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.2.tgz",
       "integrity": "sha512-2NM0auVBGft5tee/OxP4PI3d8WItkDM+fPnaRAVo6xTDI2knbz9eC5ArWGqtGlYqiH3RU5yMpdyTTO7MguC4ow==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "tiny-lr": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "ember-cli-app-version": "^3.0.0",
     "ember-cli-autoprefixer": "^0.8.1",
     "ember-cli-babel": "6.11.0",
+    "ember-cli-clipboard": "^0.8.1",
     "ember-cli-content-security-policy": "^1.0.0",
     "ember-cli-dependency-checker": "^2.0.0",
     "ember-cli-deploy": "^1.0.2",

--- a/public/images/stroke-icons/icon-copy.svg
+++ b/public/images/stroke-icons/icon-copy.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 22.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="icon-copy_1_" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
+	 y="0px" viewBox="0 0 15 18" style="enable-background:new 0 0 15 18;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#9CA1A6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
+</style>
+<g id="icon-copy">
+	<g id="icon-invoice_1_">
+		<g>
+			<rect x="4.2" y="4" class="st0" width="9.6" height="12.2"/>
+		</g>
+	</g>
+	<polyline class="st0" points="10.8,2.5 10.8,1.2 1.3,1.2 1.3,13.3 2.6,13.3 	"/>
+</g>
+</svg>

--- a/tests/acceptance/profile/view-token-test.js
+++ b/tests/acceptance/profile/view-token-test.js
@@ -26,13 +26,28 @@ test('view token', function (assert) {
   profilePage.visit({ username: 'feministkilljoy' });
 
   andThen(() => {
-    assert.ok(profilePage.token.isHidden, 'expected token to be hidden by default');
+    assert.equal(profilePage.token.hiddenMessage, 'hidden', 'expected token to be hidden by default');
   });
 
   profilePage.token.show();
 
   andThen(function () {
     assert.equal(profilePage.token.value, 'testUserToken');
+  });
+  percySnapshot(assert);
+});
+
+test('copy token', function (assert) {
+  profilePage.visit({ username: 'feministkilljoy' });
+
+  andThen(() => {
+    assert.equal(profilePage.token.hiddenMessage, 'hidden', 'expected token to be hidden by default');
+  });
+
+  triggerCopySuccess();
+
+  andThen(function () {
+    assert.equal(profilePage.token.tokenCopiedText, 'Token copied!');
   });
   percySnapshot(assert);
 });

--- a/tests/acceptance/profile/view-token-test.js
+++ b/tests/acceptance/profile/view-token-test.js
@@ -49,5 +49,12 @@ test('copy token', function (assert) {
   andThen(function () {
     assert.equal(profilePage.token.tokenCopiedText, 'Token copied!');
   });
+
+  // ensure a second copy success does not show incorrect text/feel buggy
+  triggerCopySuccess();
+
+  andThen(function () {
+    assert.equal(profilePage.token.tokenCopiedText, 'Token copied!');
+  });
   percySnapshot(assert);
 });

--- a/tests/acceptance/profile/view-token-test.js
+++ b/tests/acceptance/profile/view-token-test.js
@@ -26,7 +26,7 @@ test('view token', function (assert) {
   profilePage.visit({ username: 'feministkilljoy' });
 
   andThen(() => {
-    assert.equal(profilePage.token.hiddenMessage, 'hidden', 'expected token to be hidden by default');
+    assert.equal(profilePage.token.obfuscatedCharacters, '••••••••••••••••••••', 'expected token to be obfuscated by default');
   });
 
   profilePage.token.show();
@@ -41,7 +41,7 @@ test('copy token', function (assert) {
   profilePage.visit({ username: 'feministkilljoy' });
 
   andThen(() => {
-    assert.equal(profilePage.token.hiddenMessage, 'hidden', 'expected token to be hidden by default');
+    assert.equal(profilePage.token.obfuscatedCharacters, '••••••••••••••••••••', 'expected token to be obfuscated by default');
   });
 
   triggerCopySuccess();

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,10 +1,13 @@
 import Application from '../../app';
 import config from '../../config/environment';
+import registerClipboardHelpers from '../helpers/ember-cli-clipboard';
 import { merge } from '@ember/polyfills';
 import { run } from '@ember/runloop';
 
 import './sign-in-user';
 import './wait-for-element';
+
+registerClipboardHelpers();
 
 export default function startApp(attrs) {
   let attributes = merge({}, config.APP);

--- a/tests/integration/helpers/obfuscated-chars-test.js
+++ b/tests/integration/helpers/obfuscated-chars-test.js
@@ -1,0 +1,14 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('obfuscated-chars', 'helper:obfuscated-chars', {
+  integration: true
+});
+
+test('it returns obfuscated chars of length passed', function (assert) {
+  this.set('inputValue', 12);
+
+  this.render(hbs`{{obfuscated-chars inputValue}}`);
+
+  assert.equal(this.$().text().trim(), '••••••••••••');
+});

--- a/tests/pages/profile.js
+++ b/tests/pages/profile.js
@@ -33,10 +33,10 @@ export default create({
   token: {
     scope: '.profile-user',
 
-    isHidden: 'strong',
-
-    show: clickable('a.profile-token-toggle'),
-    value: text('strong')
+    show: clickable('.token-actions button.show-token'),
+    value: text('.auth-token'),
+    hiddenMessage: text('.auth-token'),
+    tokenCopiedText: text('.token-copied-text'),
   },
 
   accounts: collection('.profile-aside .account', {

--- a/tests/pages/profile.js
+++ b/tests/pages/profile.js
@@ -35,7 +35,7 @@ export default create({
 
     show: clickable('.token-actions button.show-token'),
     value: text('.auth-token'),
-    hiddenMessage: text('.auth-token'),
+    obfuscatedCharacters: text('.obfuscated-chars'),
     tokenCopiedText: text('.token-copied-text'),
   },
 


### PR DESCRIPTION
This does a few things:
* Allows users to directly copy the token on the profile page (instead of merely hiding/showing), improving the flow.
* Switches the token that is shown/copied from the "Travis token" to the "API token"
* Removes the "eye" icon for a simpler button-based UI

See https://github.com/travis-pro/team-teal/issues/2559 for more details.