### PR TITLE
Upgrade ember-composable-helpers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6626,9 +6626,9 @@
       }
     },
     "ember-composable-helpers": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/ember-composable-helpers/-/ember-composable-helpers-2.0.3.tgz",
-      "integrity": "sha512-FUdhnlkC4sUBG2WO9uB496lVlBjQMvNLkepyvkUv17d6Ha0rMH9sClZRidpYBrtd5MnTnV0+UrCPArjJymGIgA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ember-composable-helpers/-/ember-composable-helpers-2.1.0.tgz",
+      "integrity": "sha512-H6KCyB/BzjR18MxQFcQQR5MDRmawCmCCZKHQTEpAwhs5wCDhnMMLUGINan+sY4NRPrStfpUlMoGg9fsksN2wJA==",
       "dev": true,
       "requires": {
         "broccoli-funnel": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^2.1.0",
     "ember-cli-uglify": "^2.0.0",
-    "ember-composable-helpers": "^2.0.3",
+    "ember-composable-helpers": "^2.1.0",
     "ember-concurrency": "0.8.14",
     "ember-data": "~2.18.0",
     "ember-data-filter": "1.13.0",


### PR DESCRIPTION
This should remove the last of the helper import deprecations.