### PR TITLE
Fix allowed failures tooltip alignment

### DIFF
--- a/app/templates/components/jobs-list.hbs
+++ b/app/templates/components/jobs-list.hbs
@@ -18,8 +18,10 @@
       </header>
     {{else}}
       <h2 class="section-title"><span class="label-align">Allowed Failures</span>
-        {{tooltip-on-element text='These are jobs you can allow to fail without failing your entire build'}}
-        {{svg-jar 'icon-help' class='icon-help'}}
+        <span>
+          {{svg-jar 'icon-help' class='icon-help'}}
+          {{tooltip-on-element text='These are jobs you can allow to fail without failing your entire build'}}
+        </span>
       </h2>
     {{/if}}
   {{/if}}


### PR DESCRIPTION
I don’t love needing this wrapper element but I also wouldn’t
love needing an ID.