### PR TITLE
Ensure test token validity

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -145,6 +145,8 @@ module.exports = function (environment) {
     // Testem prefers this...
     ENV.locationType = 'none';
 
+    ENV.validAuthToken = 'testUserToken';
+
     ENV.intervals.searchDebounceRate = 0;
     ENV.intervals.branchCreatedSyncDelay = 0;
     ENV.intervals.triggerBuildRequestDelay = 0;

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -7,6 +7,16 @@ import { merge } from '@ember/polyfills';
 const { apiEndpoint } = config;
 
 export default function () {
+  const _defaultHandler = this.pretender._handlerFor;
+
+  this.pretender._handlerFor = function (verb, path, request) {
+    const authHeader = request.requestHeaders.Authorization;
+    if (authHeader && authHeader !== 'token testUserToken') {
+      return _defaultHandler.apply(this, ['GET', '/unauthorized', request]);
+    }
+    return _defaultHandler.apply(this, arguments);
+  };
+
   this.get('https://pnpcptp8xh9k.statuspage.io/api/v2/status.json', function () {
     return {
       'page': {
@@ -20,6 +30,10 @@ export default function () {
         'description': 'AllSystems Operational'
       }
     };
+  });
+
+  this.get('/unauthorized', function () {
+    return new Mirage.Response(403, {}, {});
   });
 
   this.urlPrefix = apiEndpoint;

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -4,14 +4,14 @@ import config from 'travis/config/environment';
 import fuzzysort from 'npm:fuzzysort';
 import { merge } from '@ember/polyfills';
 
-const { apiEndpoint } = config;
+const { validAuthToken, apiEndpoint } = config;
 
 export default function () {
   const _defaultHandler = this.pretender._handlerFor;
 
   this.pretender._handlerFor = function (verb, path, request) {
     const authHeader = request.requestHeaders.Authorization;
-    if (authHeader && authHeader !== 'token testUserToken') {
+    if (authHeader && authHeader !== `token ${validAuthToken}`) {
       return _defaultHandler.apply(this, ['GET', '/unauthorized', request]);
     }
     return _defaultHandler.apply(this, arguments);

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -40,13 +40,9 @@ export default function () {
   this.namespace = '';
 
   this.get('/users', function ({ users }, request)  {
-    if (request.requestHeaders.Authorization === 'token testUserToken') {
-      let userData = JSON.parse(localStorage.getItem('travis.user')),
-        id = userData.id;
-      return this.serialize(users.find(id), 'v2');
-    } else {
-      return new Mirage.Response(403, {}, {});
-    }
+    let userData = JSON.parse(localStorage.getItem('travis.user')),
+      id = userData.id;
+    return this.serialize(users.find(id), 'v2');
   });
 
   this.get('/accounts', (schema/* , request*/) => {
@@ -57,11 +53,7 @@ export default function () {
   });
 
   this.get('/users/:id', function ({ users }, request) {
-    if (request.requestHeaders.Authorization === 'token testUserToken') {
-      return this.serialize(users.find(request.params.id), 'v2');
-    } else {
-      return new Mirage.Response(403, {}, {});
-    }
+    return this.serialize(users.find(request.params.id), 'v2');
   });
 
   this.get('/users/permissions', (schema, request) => {

--- a/tests/acceptance/profile/view-token-test.js
+++ b/tests/acceptance/profile/view-token-test.js
@@ -1,6 +1,7 @@
 import { test } from 'qunit';
 import moduleForAcceptance from 'travis/tests/helpers/module-for-acceptance';
 import profilePage from 'travis/tests/pages/profile';
+import config from 'travis/config/environment';
 
 moduleForAcceptance('Acceptance | profile/view token', {
   beforeEach() {
@@ -32,7 +33,7 @@ test('view token', function (assert) {
   profilePage.token.show();
 
   andThen(function () {
-    assert.equal(profilePage.token.value, 'testUserToken');
+    assert.equal(profilePage.token.value, config.validAuthToken);
   });
   percySnapshot(assert);
 });

--- a/tests/helpers/sign-in-user.js
+++ b/tests/helpers/sign-in-user.js
@@ -1,7 +1,8 @@
 import { registerAsyncHelper } from '@ember/test';
+import config from 'travis/config/environment';
 
 export default registerAsyncHelper('signInUser', function (app, user) {
-  const token = 'testUserToken';
+  const { validAuthToken: token }  = config;
   user.attrs.token = token;
   user.save();
 


### PR DESCRIPTION
Currently, we manually check the auth token on a per-request basis. With this change, we automatically check the auth token if one is passed, returning a 403 if it doesn't match.