### PR TITLE
Standardize mirage across test suite

### DIFF
--- a/tests/acceptance/job/delete-log-test.js
+++ b/tests/acceptance/job/delete-log-test.js
@@ -2,7 +2,7 @@ import { test } from 'qunit';
 import moduleForAcceptance from 'travis/tests/helpers/module-for-acceptance';
 import jobPage from 'travis/tests/pages/job';
 import topPage from 'travis/tests/pages/top';
-import Mirage from 'ember-cli-mirage';
+import { Response } from 'ember-cli-mirage';
 
 moduleForAcceptance('Acceptance | job/delete log', {
   beforeEach() {
@@ -48,7 +48,7 @@ test('deleting job log when successful', function (assert) {
 
 test('deleting job log when error occurs', function (assert) {
   server.patch('/jobs/:id/log', (schema, request) => {
-    return new Mirage.Response(500, {}, {});
+    return new Response(500, {}, {});
   });
 
   jobPage

--- a/tests/acceptance/repo/settings-test.js
+++ b/tests/acceptance/repo/settings-test.js
@@ -234,7 +234,7 @@ test('delete and create environment variables', function (assert) {
     } });
 
     // This will trigger a client-side error
-    server.post('/settings/env_vars', {}, 403);
+    server.post('/settings/env_vars', () => new Response(403, {}, {}));
   });
 
   settingsPage.environmentVariableForm.fillName('willFail');
@@ -245,7 +245,7 @@ test('delete and create environment variables', function (assert) {
     assert.equal(topPage.flashMessage.text, 'There was an error saving this environment variable.');
 
     // This will cause deletions to fail
-    server.delete('/settings/env_vars/:id', () => {}, 500);
+    server.delete('/settings/env_vars/:id', () => new Response(500, {}, {}));
   });
 
   settingsPage.environmentVariables[1].delete();
@@ -254,7 +254,7 @@ test('delete and create environment variables', function (assert) {
     assert.equal(settingsPage.environmentVariables.length, 2, 'expected the environment variable to remain');
     assert.equal(topPage.flashMessage.text, 'There was an error deleting this environment variable.');
 
-    server.delete('/settings/env_vars/:id', () => {}, 404);
+    server.delete('/settings/env_vars/:id', () => new Response(404, {}, {}));
   });
 
   settingsPage.environmentVariables[1].delete();

--- a/tests/acceptance/repo/settings-test.js
+++ b/tests/acceptance/repo/settings-test.js
@@ -1,5 +1,5 @@
 import { test } from 'qunit';
-import Mirage from 'ember-cli-mirage';
+import { Response } from 'ember-cli-mirage';
 
 import moduleForAcceptance from 'travis/tests/helpers/module-for-acceptance';
 import settingsPage from 'travis/tests/pages/settings';
@@ -347,7 +347,7 @@ test('add SSH key', function (assert) {
   const requestBodies = [];
 
   server.get(`/settings/ssh_key/${this.repository.id}`, function (schema, request) {
-    return new Mirage.Response(429, {}, {});
+    return new Response(429, {}, {});
   });
 
   server.patch(`/settings/ssh_key/${this.repository.id}`, (schema, request) => {

--- a/tests/acceptance/repo/trigger-build-test.js
+++ b/tests/acceptance/repo/trigger-build-test.js
@@ -2,7 +2,7 @@ import { test } from 'qunit';
 import moduleForAcceptance from 'travis/tests/helpers/module-for-acceptance';
 import triggerBuildPage from 'travis/tests/pages/trigger-build';
 import topPage from 'travis/tests/pages/top';
-import Mirage from 'ember-cli-mirage';
+import { Response } from 'ember-cli-mirage';
 
 moduleForAcceptance('Acceptance | repo/trigger build');
 
@@ -98,7 +98,7 @@ test('triggering a custom build via the dropdown', function (assert) {
 
 test('an error triggering a build is displayed', function (assert) {
   server.post('/repo/:repo_id/requests', function (schema, request) {
-    return new Mirage.Response(500, {}, {});
+    return new Response(500, {}, {});
   });
 
   triggerBuildPage.visit({ owner: 'adal', repo: 'difference-engine' });
@@ -113,7 +113,7 @@ test('an error triggering a build is displayed', function (assert) {
 
 test('a 429 shows a specific error message', function (assert) {
   server.post('/repo/:repo_id/requests', function (schema, request) {
-    return new Mirage.Response(429, {}, {});
+    return new Response(429, {}, {});
   });
 
   triggerBuildPage.visit({ owner: 'adal', repo: 'difference-engine' });

--- a/tests/integration/components/travis-status-test.js
+++ b/tests/integration/components/travis-status-test.js
@@ -3,7 +3,7 @@ import hbs from 'htmlbars-inline-precompile';
 import { startMirage } from 'travis/initializers/ember-cli-mirage';
 import config from 'travis/config/environment';
 import wait from 'ember-test-helpers/wait';
-import { Mirage } from 'ember-cli-mirage';
+import { Response } from 'ember-cli-mirage';
 
 moduleForComponent('travis-status', 'Integration | Component | travis-status', {
   integration: true,
@@ -28,7 +28,7 @@ test('shows normal status when nothing wrong', function (assert) {
 
 test('shows unknown status when statuspage returns error', function (assert) {
   this.server.get(config.statusPageStatusUrl, () => {
-    return new Mirage.Response(500, {}, {});
+    return new Response(500, {}, {});
   });
 
   this.render(hbs`{{travis-status}}`);


### PR DESCRIPTION
I came across a few idiosyncrasies in terms of imports and server route definitions. This just changes them to be in line with how we do things in the rest of the test suite.