### PR TITLE
[Bugfix]: Only display active repositories in sidebar

### DIFF
--- a/app/components/repository-sidebar.js
+++ b/app/components/repository-sidebar.js
@@ -99,10 +99,13 @@ export default Component.extend({
 
   @computed('tab', 'repositories.{searchResults.[],accessible.[]}')
   repositoryResults(tab, searchResults, accessible) {
+    let results = accessible;
+
     if (tab === 'search') {
-      return searchResults;
+      results =  searchResults;
     }
-    return accessible;
+
+    return results.filter(repo => repo.get('active'));
   },
 
   @computed('tab')


### PR DESCRIPTION
Currently in production, we incorrectly show inactive repositories in the sidebar if they are added to the repository service (which is the case when we fetch *all* repositories on the profile page).  This adds a filter to the `{{repository-sidebar}}` component to ensure only activate/activated repositories are shown.