### PR TITLE
Improve UX of Show More buttons

### DIFF
--- a/app/components/show-more-button.js
+++ b/app/components/show-more-button.js
@@ -3,5 +3,5 @@ import Component from '@ember/component';
 export default Component.extend({
   tagName: 'button',
   classNames: ['showmore-button', 'button'],
-  label: 'Show More',
+  label: 'Show more',
 });

--- a/app/components/show-more-button.js
+++ b/app/components/show-more-button.js
@@ -1,6 +1,4 @@
 import Component from '@ember/component';
-import { computed } from 'ember-decorators/object';
-import { alias } from 'ember-decorators/object/computed';
 
 export default Component.extend({
   tagName: 'button',

--- a/app/components/show-more-button.js
+++ b/app/components/show-more-button.js
@@ -5,20 +5,5 @@ import { alias } from 'ember-decorators/object/computed';
 export default Component.extend({
   tagName: 'button',
   classNames: ['showmore-button', 'button'],
-  classNameBindings: ['isLoading'],
-  attributeBindings: ['disabled'],
-
-  @alias('isLoading') disabled: null,
-
-  @computed('isLoading')
-  buttonLabel(loading) {
-    if (loading) {
-      return 'Loading';
-    }
-    return 'Show more';
-  },
-
-  click() {
-    return this.get('showMore')();
-  },
+  label: 'Show More',
 });

--- a/app/components/show-more-button.js
+++ b/app/components/show-more-button.js
@@ -19,6 +19,6 @@ export default Component.extend({
   },
 
   click() {
-    return this.attrs.showMore();
+    return this.get('showMore')();
   },
 });

--- a/app/mixins/builds/load-more.js
+++ b/app/mixins/builds/load-more.js
@@ -6,8 +6,6 @@ export default Mixin.create({
   @service tabStates: null,
 
   loadMoreBuilds: task(function* () {
-    const id = this.get('repo.id'),
-      buildsLength = this.get('builds.length');
     let number = this.get('builds.lastObject.number');
 
     const defaultBranchLastBuildNumber = this.get('repo.defaultBranch.lastBuild.number');
@@ -31,9 +29,14 @@ export default Mixin.create({
     const tabName = this.get('tabStates.mainTab');
     const singularTab = tabName.substr(0, tabName.length - 1);
     const type = tabName === 'builds' ? 'push' : singularTab;
+    const options = this._constructOptions(type);
+    yield this.store.query('build', options);
+  }).drop(),
+
+  _constructOptions(type) {
     let options = {
-      repository_id: id,
-      offset: buildsLength
+      repository_id: this.get('repo.id'),
+      offset: this.get('builds.length'),
     };
     if (type != null) {
       options.event_type = type.replace(/s$/, '');
@@ -41,6 +44,7 @@ export default Mixin.create({
         options.event_type = ['push', 'api', 'cron'];
       }
     }
-    yield this.store.query('build', options);
-  }).drop(),
+
+    return options;
+  },
 });

--- a/app/mixins/builds/load-more.js
+++ b/app/mixins/builds/load-more.js
@@ -31,7 +31,7 @@ export default Mixin.create({
     const tabName = this.get('tabStates.mainTab');
     const singularTab = tabName.substr(0, tabName.length - 1);
     const type = tabName === 'builds' ? 'push' : singularTab;
-    return this.get('loadMoreBuilds').perform(id, buildsLength, type);
+    return this.set('loadMoreTask', this.get('loadMoreBuilds').perform(id, buildsLength, type));
   },
 
   loadMoreBuilds: task(function* (id, buildsLength, type) {

--- a/app/mixins/builds/load-more.js
+++ b/app/mixins/builds/load-more.js
@@ -5,7 +5,7 @@ import { task } from 'ember-concurrency';
 export default Mixin.create({
   @service tabStates: null,
 
-  showMore() {
+  loadMoreBuilds: task(function* () {
     const id = this.get('repo.id'),
       buildsLength = this.get('builds.length');
     let number = this.get('builds.lastObject.number');
@@ -31,10 +31,6 @@ export default Mixin.create({
     const tabName = this.get('tabStates.mainTab');
     const singularTab = tabName.substr(0, tabName.length - 1);
     const type = tabName === 'builds' ? 'push' : singularTab;
-    return this.set('loadMoreTask', this.get('loadMoreBuilds').perform(id, buildsLength, type));
-  },
-
-  loadMoreBuilds: task(function* (id, buildsLength, type) {
     let options = {
       repository_id: id,
       offset: buildsLength
@@ -47,10 +43,4 @@ export default Mixin.create({
     }
     yield this.store.query('build', options);
   }).drop(),
-
-  actions: {
-    showMoreBuilds() {
-      return this.showMore();
-    }
-  }
 });

--- a/app/templates/builds.hbs
+++ b/app/templates/builds.hbs
@@ -8,10 +8,10 @@
   </ul>
   {{#if displayShowMoreButton}}
     <p>
-      {{#if loadMoreTask.isRunning}}
+      {{#if loadMoreBuilds.isRunning}}
         {{loading-indicator}}
       {{else}}
-        {{show-more-button showMore=(action 'showMoreBuilds')}}
+        {{show-more-button click=(perform loadMoreBuilds)}}
       {{/if}}
     </p>
   {{/if}}

--- a/app/templates/builds.hbs
+++ b/app/templates/builds.hbs
@@ -8,9 +8,10 @@
   </ul>
   {{#if displayShowMoreButton}}
     <p>
-      {{show-more-button isLoading=isLoading showMore=(action 'showMoreBuilds')}}
-      {{#if model.isLoading}}
+      {{#if loadMoreTask.isRunning}}
         {{loading-indicator}}
+      {{else}}
+        {{show-more-button showMore=(action 'showMoreBuilds')}}
       {{/if}}
     </p>
   {{/if}}

--- a/app/templates/components/show-more-button.hbs
+++ b/app/templates/components/show-more-button.hbs
@@ -1,2 +1,2 @@
 {{svg-jar 'icon-seemore' class="icon white"}}
-{{buttonLabel}}
+{{label}}

--- a/app/templates/pull-requests.hbs
+++ b/app/templates/pull-requests.hbs
@@ -8,10 +8,10 @@
   </ul>
   {{#if displayShowMoreButton}}
     <p>
-      {{#if loadMoreTask.isRunning}}
+      {{#if loadMoreBuilds.isRunning}}
         {{loading-indicator}}
       {{else}}
-        {{show-more-button showMore=(action 'showMoreBuilds')}}
+        {{show-more-button click=(perform loadMoreBuilds)}}
       {{/if}}
     </p>
   {{/if}}

--- a/app/templates/pull-requests.hbs
+++ b/app/templates/pull-requests.hbs
@@ -8,9 +8,10 @@
   </ul>
   {{#if displayShowMoreButton}}
     <p>
-      {{show-more-button isLoading=isLoading showMore=(action 'showMoreBuilds')}}
-      {{#if isLoading}}
+      {{#if loadMoreTask.isRunning}}
         {{loading-indicator}}
+      {{else}}
+        {{show-more-button showMore=(action 'showMoreBuilds')}}
       {{/if}}
     </p>
   {{/if}}


### PR DESCRIPTION
Currently in production, clicking on the "Show More" buttons when on the Build History/Pull Requests tab, nothing happens visually. The data loads, but the button doesn't do anything.

It appears this is a bug with the current implementation, as it expects us to change the button text to "Loading" and disable the button once it has been clicked.

Instead, this PR takes a different approach. Clicking the button will now replace the button with the loading indicator that is shown when the page loads, i.e. our normal `{{loading-indicator}}` component. This eliminates our need to disable the button. We also now use an ember-concurrency task to use derived state and the `perform` helper to radically reduce the complexity around this button.

Before:
![current](https://user-images.githubusercontent.com/366944/37213065-3d73e474-23b1-11e8-893b-01d5a10fafde.gif)

After:
![future](https://user-images.githubusercontent.com/366944/37213077-428de004-23b1-11e8-9d9a-e28c9399bbf3.gif)
