### PR TITLE
Fix missing navigation on mobile

### DIFF
--- a/app/templates/components/top-bar.hbs
+++ b/app/templates/components/top-bar.hbs
@@ -2,7 +2,7 @@
   <h1 id="logo" class="logo">{{#link-to "index"}}Travis CI{{/link-to}}</h1>
   {{header-burger-menu is-open=is-open}}
   {{header-broadcasts showBroadcasts=showBroadcasts}}
-  {{header-links}}
+  {{header-links is-open=is-open}}
 </div>
 
 {{#if features.enterpriseVersion}}


### PR DESCRIPTION
This was broken in #1564. I'm surprised this didn't break any tests/visual diffs. Will create an issue to beef up the coverage on Monday.