### PR TITLE
Add requests acceptance tests

### DIFF
--- a/app/templates/components/requests-item.hbs
+++ b/app/templates/components/requests-item.hbs
@@ -4,7 +4,7 @@
 
 <div class="row-item fade-out {{requestClass}}">
   {{request-icon event=request.event_type state=requestClass}}
-  <span class="label-align m-l-s">
+  <span class="label-align m-l-s" data-requests-item-related-model>
     {{#if request.isPullRequest}}
       <strong class="label-align">#{{request.pullRequestNumber}}</strong>
     {{/if}}
@@ -14,7 +14,7 @@
     {{#if request.commit}}
       {{github-commit-link request.repo.slug request.commit.sha}}
     {{else}}
-      <em>No commit available</em>
+      <em data-requests-item-commit-missing>No commit available</em>
     {{/if}}
   </span>
 </div>
@@ -23,11 +23,11 @@
   {{svg-jar 'icon-calendar' class="icon"}}
   <span class="label-align">{{format-time request.created_at}}</span></div>
 
-<div class="row-item fade-out">
+<div class="row-item fade-out" data-requests-item-commit-message>
   {{{format-message request.commit.message short="true" repo=request.build.repo}}}
 </div>
 
-<div class="row-item">
+<div class="row-item" data-requests-item-build>
   {{#if request.build}}
     {{svg-jar 'icon-hash' class="icon"}}
     {{#link-to "build" request.build title="Go to the build this request triggered"}}
@@ -37,6 +37,6 @@
   {{/if}}
 </div>
 
-<div class="row-item fade-out">
+<div class="row-item fade-out" data-requests-item-message>
   <span class="label-align" title="{{message}}">{{message}}</span>
 </div>

--- a/app/templates/components/requests-item.hbs
+++ b/app/templates/components/requests-item.hbs
@@ -21,7 +21,7 @@
 
 <div class="row-item fade-out" title="{{pretty-date request.created_at}}">
   {{svg-jar 'icon-calendar' class="icon"}}
-  <span class="label-align">{{format-time request.created_at}}</span></div>
+  <span class="label-align" data-requests-item-created-at>{{format-time request.created_at}}</span></div>
 
 <div class="row-item fade-out" data-requests-item-commit-message>
   {{{format-message request.commit.message short="true" repo=request.build.repo}}}

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -407,6 +407,12 @@ export default function () {
     return this.serialize(builds, 'build');
   });
 
+  this.get('/requests', function (schema, request) {
+    let requests = schema.requests.where({ repositoryId: request.queryParams.repository_id });
+
+    return requests;
+  });
+
   this.post('/repo/:repo_id/requests', function (schema, request) {
     const requestBody = JSON.parse(request.requestBody);
     const fakeRequestId = 5678;

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -39,6 +39,8 @@ export default function () {
   this.urlPrefix = apiEndpoint;
   this.namespace = '';
 
+  this.logging = true;
+
   this.get('/users', function ({ users }, request)  {
     let userData = JSON.parse(localStorage.getItem('travis.user')),
       id = userData.id;

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -39,8 +39,6 @@ export default function () {
   this.urlPrefix = apiEndpoint;
   this.namespace = '';
 
-  this.logging = true;
-
   this.get('/users', function ({ users }, request)  {
     let userData = JSON.parse(localStorage.getItem('travis.user')),
       id = userData.id;

--- a/mirage/models/commit.js
+++ b/mirage/models/commit.js
@@ -4,5 +4,6 @@ export default Model.extend({
   build: belongsTo('build', { inverseOf: 'commit' }),
   committer: belongsTo('git-user'),
   author: belongsTo('git-user'),
-  job: belongsTo('job')
+  job: belongsTo('job'),
+  request: belongsTo()
 });

--- a/mirage/models/repository.js
+++ b/mirage/models/repository.js
@@ -9,4 +9,6 @@ export default Model.extend({
   defaultBranch: belongsTo('branch', { inverse: null }),
   currentBuild: belongsTo('build', { inverse: null }),
   account: belongsTo(),
+
+  requests: hasMany(),
 });

--- a/mirage/models/request.js
+++ b/mirage/models/request.js
@@ -2,5 +2,6 @@ import { Model, belongsTo, hasMany } from 'ember-cli-mirage';
 
 export default Model.extend({
   repository: belongsTo(),
-  builds: hasMany('build')
+  builds: hasMany('build'),
+  commit: belongsTo()
 });

--- a/mirage/models/request.js
+++ b/mirage/models/request.js
@@ -1,5 +1,6 @@
-import { Model, hasMany } from 'ember-cli-mirage';
+import { Model, belongsTo, hasMany } from 'ember-cli-mirage';
 
 export default Model.extend({
+  repository: belongsTo(),
   builds: hasMany('build')
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -8920,6 +8920,29 @@
         }
       }
     },
+    "ember-test-selectors": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/ember-test-selectors/-/ember-test-selectors-0.3.8.tgz",
+      "integrity": "sha1-Horj54xkusxLv+h/mXPIWAVpnbI=",
+      "dev": true,
+      "requires": {
+        "broccoli-stew": "1.5.0",
+        "ember-cli-babel": "6.12.0",
+        "ember-cli-version-checker": "2.1.0"
+      },
+      "dependencies": {
+        "ember-cli-version-checker": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
+          "integrity": "sha512-ssiNyVTp+PphroFum8guHX9py4xU1PCxkRYgb25NxumgjpKTPjhkgTfpRRKXlIQe+/wVMmhf+Uv6w9vSLZKWKQ==",
+          "dev": true,
+          "requires": {
+            "resolve": "1.4.0",
+            "semver": "5.4.1"
+          }
+        }
+      }
+    },
     "ember-tether": {
       "version": "1.0.0-beta.0",
       "resolved": "https://registry.npmjs.org/ember-tether/-/ember-tether-1.0.0-beta.0.tgz",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "ember-source": "^2.18.2",
     "ember-svg-jar": "^0.12.0",
     "ember-test-assets": "^1.1.0",
+    "ember-test-selectors": "^0.3.8",
     "ember-tether": "^1.0.0-beta.0",
     "ember-tooltips": "^2.9.2",
     "ember-truth-helpers": "^2.0.0",

--- a/tests/acceptance/repo/requests-test.js
+++ b/tests/acceptance/repo/requests-test.js
@@ -10,7 +10,8 @@ test('list requests', function (assert) {
 
   let approvedRequest = repo.createRequest({
     result: 'approved',
-    message: 'A request message'
+    message: 'A request message',
+    created_at: new Date(new Date().getTime() - 1000 * 60 * 60 * 24 * 365)
   });
 
   let approvedCommit = server.create('commit', {
@@ -50,6 +51,9 @@ test('list requests', function (assert) {
 
       assert.equal(request.commitLink.text, 'abc123');
       assert.equal(request.commitMessage.text, 'A commit message');
+
+      assert.equal(request.createdAt.text, 'about a year ago');
+
       assert.equal(request.buildNumber.text, '1919');
       assert.equal(request.requestMessage.text, 'A request message');
     });

--- a/tests/acceptance/repo/requests-test.js
+++ b/tests/acceptance/repo/requests-test.js
@@ -11,7 +11,8 @@ test('list requests', function (assert) {
   let approvedRequest = repo.createRequest({
     result: 'approved',
     message: 'A request message',
-    created_at: new Date(new Date().getTime() - 1000 * 60 * 60 * 24 * 365)
+    created_at: new Date(new Date().getTime() - 1000 * 60 * 60 * 24 * 365),
+    event_type: 'pull_request'
   });
 
   let approvedCommit = server.create('commit', {
@@ -32,11 +33,13 @@ test('list requests', function (assert) {
   approvedRequest.save();
 
   repo.createRequest({
-    result: 'rejected'
+    result: 'rejected',
+    event_type: 'cron'
   });
 
   repo.createRequest({
-    result: 'pending'
+    result: 'pending',
+    event_type: 'api'
   });
 
   repo.save();

--- a/tests/acceptance/repo/requests-test.js
+++ b/tests/acceptance/repo/requests-test.js
@@ -8,9 +8,27 @@ moduleForAcceptance('Acceptance | repo | requests');
 test('list requests', function (assert) {
   let repo = server.create('repository', { slug: 'travis-ci/travis-web' });
 
-  repo.createRequest({
-    result: 'approved'
+  let approvedRequest = repo.createRequest({
+    result: 'approved',
+    message: 'A request message'
   });
+
+  let approvedCommit = server.create('commit', {
+    branch: 'acceptance-tests',
+    message: 'A commit message',
+    request: approvedRequest
+  });
+
+  let approvedBuild = server.create('build', {
+    repository: repo,
+    state: 'passed',
+    commit_id: approvedCommit.id,
+    commit: approvedCommit,
+    request: approvedRequest,
+    number: '1919'
+  });
+
+  approvedRequest.save();
 
   repo.createRequest({
     result: 'rejected'
@@ -25,19 +43,26 @@ test('list requests', function (assert) {
   requestsPage.visit({organization: 'travis-ci', repo: 'travis-web'});
 
   andThen(function () {
+    pauseTest();
     requestsPage.requests[0].as(request => {
       assert.ok(request.isApproved);
+      assert.equal(request.commitLink.text, 'abc123');
+      assert.equal(request.commitMessage.text, 'A commit message');
+      assert.equal(request.buildNumber.text, '1919');
+      assert.equal(request.requestMessage.text, 'A request message');
     });
 
     requestsPage.requests[1].as(request => {
       assert.ok(request.isRejected);
+      assert.ok(request.commitLink.isHidden);
+      assert.ok(request.commitMissing.text, 'missing');
+      assert.ok(request.buildNumber.isHidden);
+      assert.equal(request.requestMessage.text, 'Build created successfully');
     });
 
     requestsPage.requests[2].as(request => {
       assert.ok(request.isPending);
     });
-
-    pauseTest();
   });
 
   percySnapshot(assert);

--- a/tests/acceptance/repo/requests-test.js
+++ b/tests/acceptance/repo/requests-test.js
@@ -40,12 +40,14 @@ test('list requests', function (assert) {
 
   repo.save();
 
-  requestsPage.visit({organization: 'travis-ci', repo: 'travis-web'});
+  requestsPage.visit({organization: 'travis-ci', repo: 'travis-web', requestId: approvedRequest.id});
 
   andThen(function () {
     pauseTest();
     requestsPage.requests[0].as(request => {
       assert.ok(request.isApproved);
+      assert.ok(request.isHighlighted, 'expected the request to be highlighted because of the query param');
+
       assert.equal(request.commitLink.text, 'abc123');
       assert.equal(request.commitMessage.text, 'A commit message');
       assert.equal(request.buildNumber.text, '1919');
@@ -54,6 +56,8 @@ test('list requests', function (assert) {
 
     requestsPage.requests[1].as(request => {
       assert.ok(request.isRejected);
+      assert.notOk(request.isHighlighted);
+
       assert.ok(request.commitLink.isHidden);
       assert.ok(request.commitMissing.text, 'missing');
       assert.ok(request.buildNumber.isHidden);

--- a/tests/acceptance/repo/requests-test.js
+++ b/tests/acceptance/repo/requests-test.js
@@ -23,7 +23,7 @@ test('list requests', function (assert) {
     request: approvedRequest
   });
 
-  let approvedBuild = server.create('build', {
+  server.create('build', {
     repository: this.repo,
     state: 'passed',
     commit_id: approvedCommit.id,

--- a/tests/acceptance/repo/requests-test.js
+++ b/tests/acceptance/repo/requests-test.js
@@ -32,8 +32,6 @@ test('list requests', function (assert) {
     number: '1919'
   });
 
-  approvedRequest.save();
-
   this.repo.createRequest({
     result: 'rejected',
     event_type: 'cron'
@@ -43,8 +41,6 @@ test('list requests', function (assert) {
     result: 'pending',
     event_type: 'api'
   });
-
-  this.repo.save();
 
   requestsPage.visit({organization: 'travis-ci', repo: 'travis-web', requestId: approvedRequest.id});
 

--- a/tests/acceptance/repo/requests-test.js
+++ b/tests/acceptance/repo/requests-test.js
@@ -1,0 +1,44 @@
+import { test } from 'qunit';
+import moduleForAcceptance from 'travis/tests/helpers/module-for-acceptance';
+
+import requestsPage from 'travis/tests/pages/requests';
+
+moduleForAcceptance('Acceptance | repo | requests');
+
+test('list requests', function (assert) {
+  let repo = server.create('repository', { slug: 'travis-ci/travis-web' });
+
+  repo.createRequest({
+    result: 'approved'
+  });
+
+  repo.createRequest({
+    result: 'rejected'
+  });
+
+  repo.createRequest({
+    result: 'pending'
+  });
+
+  repo.save();
+
+  requestsPage.visit({organization: 'travis-ci', repo: 'travis-web'});
+
+  andThen(function () {
+    requestsPage.requests[0].as(request => {
+      assert.ok(request.isApproved);
+    });
+
+    requestsPage.requests[1].as(request => {
+      assert.ok(request.isRejected);
+    });
+
+    requestsPage.requests[2].as(request => {
+      assert.ok(request.isPending);
+    });
+
+    pauseTest();
+  });
+
+  percySnapshot(assert);
+});

--- a/tests/acceptance/repo/requests-test.js
+++ b/tests/acceptance/repo/requests-test.js
@@ -47,7 +47,6 @@ test('list requests', function (assert) {
   requestsPage.visit({organization: 'travis-ci', repo: 'travis-web', requestId: approvedRequest.id});
 
   andThen(function () {
-    pauseTest();
     requestsPage.requests[0].as(request => {
       assert.ok(request.isApproved);
       assert.ok(request.isHighlighted, 'expected the request to be highlighted because of the query param');

--- a/tests/pages/requests.js
+++ b/tests/pages/requests.js
@@ -17,6 +17,8 @@ export default create({
     isRejected: hasClass('rejected'),
     isPending: hasClass('pending'),
 
+    isHighlighted: hasClass('highlighted'),
+
     commitLink: {
       scope: '[data-requests-item-related-model] a'
     },

--- a/tests/pages/requests.js
+++ b/tests/pages/requests.js
@@ -15,6 +15,26 @@ export default create({
   requests: collection('.request-item', {
     isApproved: hasClass('approved'),
     isRejected: hasClass('rejected'),
-    isPending: hasClass('pending')
+    isPending: hasClass('pending'),
+
+    commitLink: {
+      scope: 'a:first-child'
+    },
+
+    commitMissing: {
+      scope: '.row-item:eq(1) em'
+    },
+
+    commitMessage: {
+      scope: '.row-item:eq(3)'
+    },
+
+    buildNumber: {
+      scope: '.row-item:eq(4) .inner-underline'
+    },
+
+    requestMessage: {
+      scope: '.row-item:eq(5)'
+    }
   })
 });

--- a/tests/pages/requests.js
+++ b/tests/pages/requests.js
@@ -1,11 +1,7 @@
 import {
   create,
-  attribute,
-  clickable,
   collection,
   hasClass,
-  isVisible,
-  text,
   visitable
 } from 'ember-cli-page-object';
 

--- a/tests/pages/requests.js
+++ b/tests/pages/requests.js
@@ -31,6 +31,10 @@ export default create({
       scope: '[data-requests-item-commit-message]'
     },
 
+    createdAt: {
+      scope: '[data-requests-item-created-at]'
+    },
+
     buildNumber: {
       scope: '[data-requests-item-build] .inner-underline'
     },

--- a/tests/pages/requests.js
+++ b/tests/pages/requests.js
@@ -1,0 +1,20 @@
+import {
+  create,
+  attribute,
+  clickable,
+  collection,
+  hasClass,
+  isVisible,
+  text,
+  visitable
+} from 'ember-cli-page-object';
+
+export default create({
+  visit: visitable(':organization/:repo/requests'),
+
+  requests: collection('.request-item', {
+    isApproved: hasClass('approved'),
+    isRejected: hasClass('rejected'),
+    isPending: hasClass('pending')
+  })
+});

--- a/tests/pages/requests.js
+++ b/tests/pages/requests.js
@@ -18,23 +18,23 @@ export default create({
     isPending: hasClass('pending'),
 
     commitLink: {
-      scope: 'a:first-child'
+      scope: '[data-requests-item-related-model] a'
     },
 
     commitMissing: {
-      scope: '.row-item:eq(1) em'
+      scope: '[data-requests-item-commit-missing]'
     },
 
     commitMessage: {
-      scope: '.row-item:eq(3)'
+      scope: '[data-requests-item-commit-message]'
     },
 
     buildNumber: {
-      scope: '.row-item:eq(4) .inner-underline'
+      scope: '[data-requests-item-build] .inner-underline'
     },
 
     requestMessage: {
-      scope: '.row-item:eq(5)'
+      scope: '[data-requests-item-message]'
     }
   })
 });

--- a/tests/pages/requests.js
+++ b/tests/pages/requests.js
@@ -42,5 +42,9 @@ export default create({
     requestMessage: {
       scope: '[data-requests-item-message]'
     }
-  })
+  }),
+
+  missingNotice: {
+    scope: '.missing-notice'
+  }
 });


### PR DESCRIPTION
I included `ember-test-selectors` here, which I remember you suggesting a while ago, @clekstro, but maybe that never happened? It just seemed weird to me to have to use `eq(3)` etc to get at the sections of a request. But I could remove it if it seems weird to have both page objects and test selectors.