### PR TITLE
Request images from API directly instead of thru waiter redirect

### DIFF
--- a/app/services/status-images.js
+++ b/app/services/status-images.js
@@ -7,27 +7,20 @@ export default Service.extend({
   @service features: null,
 
   imageUrl(repo, branch) {
-    let prefix = `${location.protocol}//${location.host}`;
-
-    // the ruby app (waiter) does an indirect, internal redirect to api on build status images
-    // but that does not work if you only run `ember serve`
-    // so in development we use the api endpoint directly
-    if (config.environment === 'development') {
-      prefix = config.apiEndpoint;
-    }
-
-    let slug = repo.get('slug');
+    const { apiEndpoint } = config;
+    const slug = repo.get('slug');
 
     if (repo.get('private')) {
       const token = this.get('auth').assetToken();
-      return `${prefix}/${slug}.svg?token=${token}${branch ? `&branch=${branch}` : ''}`;
+      return `${apiEndpoint}/${slug}.svg?token=${token}${branch ? `&branch=${branch}` : ''}`;
     } else {
-      return `${prefix}/${slug}.svg${branch ? `?branch=${encodeURIComponent(branch)}` : ''}`;
+      return `${apiEndpoint}/${slug}.svg${branch ? `?branch=${encodeURIComponent(branch)}` : ''}`;
     }
   },
 
   repositoryUrl(repo) {
-    return `https://${location.host}/${repo.get('slug')}`;
+    const { apiEndpoint } = config;
+    return `${apiEndpoint}/${repo.get('slug')}`;
   },
 
   markdownImageString(repo, branch) {

--- a/tests/unit/services/status-images-test.js
+++ b/tests/unit/services/status-images-test.js
@@ -19,9 +19,6 @@ moduleFor('service:status-images', 'Unit | Service | status images', {
   }
 });
 
-const root = `${location.protocol}//${location.host}`;
-const secureRoot = `https://${location.host}`;
-
 const branch = 'primary';
 
 const { apiEndpoint } = config;
@@ -30,98 +27,98 @@ test('it generates an image url with a token for a private repo', function (asse
   const service = this.subject();
   this.repo.set('private', true);
   const url = service.imageUrl(this.repo);
-  assert.equal(url, `${root}/travis-ci/travis-web.svg?token=token-abc-123`);
+  assert.equal(url, `${apiEndpoint}/travis-ci/travis-web.svg?token=token-abc-123`);
 });
 
 test('it generates an image url with a repo', function (assert) {
   const service = this.subject();
   const url = service.imageUrl(this.repo);
-  assert.equal(url, `${root}/travis-ci/travis-web.svg`);
+  assert.equal(url, `${apiEndpoint}/travis-ci/travis-web.svg`);
 });
 
 test('it generates an image url with a repo and a branch', function (assert) {
   const service = this.subject();
   const url = service.imageUrl(this.repo, branch);
-  assert.equal(url, `${root}/travis-ci/travis-web.svg?branch=primary`);
+  assert.equal(url, `${apiEndpoint}/travis-ci/travis-web.svg?branch=primary`);
 });
 
 test('it generates an image url with a private repo and a branc', function (assert) {
   let service = this.subject();
   this.repo.set('private', true);
   const url = service.imageUrl(this.repo, branch);
-  assert.equal(url, `${root}/travis-ci/travis-web.svg?token=token-abc-123&branch=primary`);
+  assert.equal(url, `${apiEndpoint}/travis-ci/travis-web.svg?token=token-abc-123&branch=primary`);
 });
 
 test('it generates a Markdown image string with a repo', function (assert) {
   const service = this.subject();
   const markdown = service.markdownImageString(this.repo);
-  assert.equal(markdown, `[![Build Status](${root}/travis-ci/travis-web.svg)](${secureRoot}/travis-ci/travis-web)`);
+  assert.equal(markdown, `[![Build Status](${apiEndpoint}/travis-ci/travis-web.svg)](${apiEndpoint}/travis-ci/travis-web)`);
 });
 
 test('it generates a Markdown image string with a repo and a branch', function (assert) {
   const service = this.subject();
   const markdown = service.markdownImageString(this.repo, branch);
-  assert.equal(markdown, `[![Build Status](${root}/travis-ci/travis-web.svg?branch=primary)](${secureRoot}/travis-ci/travis-web)`);
+  assert.equal(markdown, `[![Build Status](${apiEndpoint}/travis-ci/travis-web.svg?branch=primary)](${apiEndpoint}/travis-ci/travis-web)`);
 });
 
 test('it generates a Textile image string with a repo', function (assert) {
   const service = this.subject();
   const textile = service.textileImageString(this.repo);
-  assert.equal(textile, `!${root}/travis-ci/travis-web.svg!:${secureRoot}/travis-ci/travis-web`);
+  assert.equal(textile, `!${apiEndpoint}/travis-ci/travis-web.svg!:${apiEndpoint}/travis-ci/travis-web`);
 });
 
 test('it generates a Textile image string with a repo and a branch', function (assert) {
   const service = this.subject();
   const textile = service.textileImageString(this.repo, branch);
-  assert.equal(textile, `!${root}/travis-ci/travis-web.svg?branch=primary!:${secureRoot}/travis-ci/travis-web`);
+  assert.equal(textile, `!${apiEndpoint}/travis-ci/travis-web.svg?branch=primary!:${apiEndpoint}/travis-ci/travis-web`);
 });
 
 test('it generates an Rdoc image string with a repo', function (assert) {
   const service = this.subject();
   const rdoc = service.rdocImageString(this.repo);
-  assert.equal(rdoc, `{<img src="${root}/travis-ci/travis-web.svg" alt="Build Status" />}[${secureRoot}/travis-ci/travis-web]`);
+  assert.equal(rdoc, `{<img src="${apiEndpoint}/travis-ci/travis-web.svg" alt="Build Status" />}[${apiEndpoint}/travis-ci/travis-web]`);
 });
 
 test('it generates an Rdoc image string with a repo and a branch', function (assert) {
   const service = this.subject();
   const rdoc = service.rdocImageString(this.repo, branch);
-  assert.equal(rdoc, `{<img src="${root}/travis-ci/travis-web.svg?branch=primary" alt="Build Status" />}[${secureRoot}/travis-ci/travis-web]`);
+  assert.equal(rdoc, `{<img src="${apiEndpoint}/travis-ci/travis-web.svg?branch=primary" alt="Build Status" />}[${apiEndpoint}/travis-ci/travis-web]`);
 });
 
 test('it generates an Asciidoc image string with a repo', function (assert) {
   const service = this.subject();
   const asciidoc = service.asciidocImageString(this.repo);
-  assert.equal(asciidoc, `image:${root}/travis-ci/travis-web.svg["Build Status", link="${secureRoot}/travis-ci/travis-web"]`);
+  assert.equal(asciidoc, `image:${apiEndpoint}/travis-ci/travis-web.svg["Build Status", link="${apiEndpoint}/travis-ci/travis-web"]`);
 });
 
 test('it generates an Asciidoc image string with a repo and a branch', function (assert) {
   const service = this.subject();
   const asciidoc = service.asciidocImageString(this.repo, branch);
-  assert.equal(asciidoc, `image:${root}/travis-ci/travis-web.svg?branch=primary["Build Status", link="${secureRoot}/travis-ci/travis-web"]`);
+  assert.equal(asciidoc, `image:${apiEndpoint}/travis-ci/travis-web.svg?branch=primary["Build Status", link="${apiEndpoint}/travis-ci/travis-web"]`);
 });
 
 test('it generates an RST image string with a repo', function (assert) {
   const service = this.subject();
   const rst = service.rstImageString(this.repo);
-  assert.equal(rst, `.. image:: ${root}/travis-ci/travis-web.svg\n    :target: ${secureRoot}/travis-ci/travis-web`);
+  assert.equal(rst, `.. image:: ${apiEndpoint}/travis-ci/travis-web.svg\n    :target: ${apiEndpoint}/travis-ci/travis-web`);
 });
 
 test('it generates an RST image string with a repo and a branch', function (assert) {
   const service = this.subject();
   const rst = service.rstImageString(this.repo, branch);
-  assert.equal(rst, `.. image:: ${root}/travis-ci/travis-web.svg?branch=primary\n    :target: ${secureRoot}/travis-ci/travis-web`);
+  assert.equal(rst, `.. image:: ${apiEndpoint}/travis-ci/travis-web.svg?branch=primary\n    :target: ${apiEndpoint}/travis-ci/travis-web`);
 });
 
 test('it generates a Pod image string with a repo', function (assert) {
   const service = this.subject();
   const pod = service.podImageString(this.repo);
-  assert.equal(pod, `=for html <a href="${secureRoot}/travis-ci/travis-web"><img src="${root}/travis-ci/travis-web.svg"></a>`);
+  assert.equal(pod, `=for html <a href="${apiEndpoint}/travis-ci/travis-web"><img src="${apiEndpoint}/travis-ci/travis-web.svg"></a>`);
 });
 
 test('it generates a Pod image string with a repo and a branch', function (assert) {
   const service = this.subject();
   const pod = service.podImageString(this.repo, branch);
-  assert.equal(pod, `=for html <a href="${secureRoot}/travis-ci/travis-web"><img src="${root}/travis-ci/travis-web.svg?branch=primary"></a>`);
+  assert.equal(pod, `=for html <a href="${apiEndpoint}/travis-ci/travis-web"><img src="${apiEndpoint}/travis-ci/travis-web.svg?branch=primary"></a>`);
 });
 
 test('it generates CCTray url with a repo', function (assert) {


### PR DESCRIPTION
We discussed this a long, long time ago in https://github.com/travis-pro/team-teal/issues/1077. I've tested the markdown links, but would feel more comfortable testing the other image types a bit more before merging.