### PR TITLE
Don't upload error pages to S3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,23 +48,5 @@ script:
 after_script:
   - greenkeeper-lockfile-upload
 
-before_deploy:
-  - ASSETS_HOST=https://s3.amazonaws.com/travis-error-pages ember build --env production
-  # delete some of the stuff that's useless for maintenance page
-  - rm -fr dist/assets/*.js dist/images/emoji dist/index.html dist/images/sponsors
-  - cp dist/maintenance.html dist/index.html
-
-deploy:
-  - provider: s3
-    access_key_id: $MAINTENANCE_S3_ACCESS_KEY_ID
-    secret_access_key: $MAINTENANCE_S3_SECRET_ACCESS_KEY
-    bucket: travis-error-pages
-    skip_cleanup: true
-    acl: public_read
-    local_dir: dist
-    region: us-east-1
-    on:
-      branch: master
-
 after_success:
   - "test $TRAVIS_PULL_REQUEST && test $TRAVIS_PULL_REQUEST != 'false' && $TRAVIS_SECURE_ENV_VARS == 'true' && ./config/deployment/deploy-pull-request.sh"


### PR DESCRIPTION
Some errors on heroku need a link to special error pages for error pages
that don't even load the app (500 from heroku, maintenance etc). We
decided to generate those pages from travis-web, but I think that it
doesn't really make sense anymore. For some reason generating those
pages broke and maintenance page was missing styles. Instead of
debugging it I think it would be better to just keep the error pages on
S3 and modify them there if needed. It would also add a benefit of not
making travis-web's builds longer.