### PR TITLE
reduce page size on dashboard from 100 repos per page to 25

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -85,7 +85,7 @@ module.exports = function (environment) {
   }
 
   ENV.pagination = {
-    dashboardReposPerPage: 100,
+    dashboardReposPerPage: 25,
     profileReposPerPage: 25,
   };
 


### PR DESCRIPTION
this improves the initial page load speed dramatically.

refs https://github.com/travis-ci/reliability/issues/37