### PR TITLE
always lazy-load build.request

### DIFF
--- a/app/adapters/build.js
+++ b/app/adapters/build.js
@@ -1,7 +1,7 @@
 import V3Adapter from 'travis/adapters/v3';
 
 export default V3Adapter.extend({
-  includes: 'build.commit,build.branch,build.request',
+  includes: 'build.commit,build.branch',
 
   pathPrefix(modelName, id, snapshot, type, query) {
     if (type === 'query' && query.repository_id) {

--- a/app/adapters/job.js
+++ b/app/adapters/job.js
@@ -1,8 +1,6 @@
 import V3Adapter from 'travis/adapters/v3';
 
 export default V3Adapter.extend({
-  includes: 'build.request',
-
   coalesceFindRequests: true,
 
   groupRecordsForFindMany(store, snapshots) {

--- a/app/adapters/repo.js
+++ b/app/adapters/repo.js
@@ -6,7 +6,7 @@ const { apiEndpoint } = config;
 export default V3Adapter.extend({
   defaultSerializer: '-repo',
 
-  includes: 'repository.default_branch,repository.current_build,build.commit',
+  includes: 'build.branch,repository.default_branch,repository.current_build,build.commit',
 
   buildURL(modelName, id, snapshot, requestType, query) {
     if (query) {

--- a/app/adapters/repo.js
+++ b/app/adapters/repo.js
@@ -6,8 +6,7 @@ const { apiEndpoint } = config;
 export default V3Adapter.extend({
   defaultSerializer: '-repo',
 
-  includes: 'build.branch,build.request,repository.default_branch'
-    + ',repository.current_build,build.commit',
+  includes: 'repository.default_branch,repository.current_build,build.commit',
 
   buildURL(modelName, id, snapshot, requestType, query) {
     if (query) {

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -434,6 +434,16 @@ export default function () {
     });
   });
 
+  this.get('/requests/:request_id', function (schema, request) {
+    let build = schema.builds.find(9999);
+
+    return new Response(200, {}, {
+      id: request.params.request_id,
+      result: 'approved',
+      builds: [build]
+    });
+  });
+
   this.get('/repo/:repo_id/request/:request_id/messages',
     function ({ messages }, { params: { request_id: requestId }}) {
       return this.serialize(messages.where({ requestId }));


### PR DESCRIPTION
fetching build request every time we fetch a repo is quite expensive, especially on the dashboard. this should improve load times across the board.

refs https://github.com/travis-ci/reliability/issues/37