### PR TITLE
Fix log rendering issue

### DIFF
--- a/app/components/log-content.js
+++ b/app/components/log-content.js
@@ -163,18 +163,6 @@ export default Component.extend({
     }
   },
 
-  didUpdateAttrs() {
-    let oldJob = this.get('_oldJob');
-    let newJob = this.get('job');
-
-    if (oldJob && (oldJob.get('id') != newJob.get('id'))) {
-      this.teardownLog(oldJob.get('log'));
-      return this.createEngine(newJob.get('log'));
-    }
-
-    this.set('_oldJob', this.get('job'));
-  },
-
   unfoldHighlight() {
     return this.lineSelector.unfoldLines();
   },

--- a/app/models/job.js
+++ b/app/models/job.js
@@ -121,7 +121,7 @@ export default Model.extend(DurationCalculations, DurationAttributes, {
 
   reloadLog() {
     this.clearLog();
-    return this.get('log').fetch();
+    return this.get('log.fetchTask').perform();
   },
 
   restart() {

--- a/app/models/log.js
+++ b/app/models/log.js
@@ -12,7 +12,6 @@ export default EmberObject.extend({
   @service auth: null,
 
   version: 0,
-  isLoaded: false,
   length: 0,
   @gt('parts.length', 0) hasContent: null,
 
@@ -85,14 +84,12 @@ export default EmberObject.extend({
   },
 
   loadParts(parts) {
-    this.get('isLoaded', false);
     let i, len, part;
     this.debug('log model: load parts');
     for (i = 0, len = parts.length; i < len; i++) {
       part = parts[i];
       this.append(part);
     }
-    return this.set('isLoaded', true);
   },
 
   debug(message) {

--- a/app/models/log.js
+++ b/app/models/log.js
@@ -5,6 +5,7 @@ import config from 'travis/config/environment';
 import { service } from 'ember-decorators/service';
 import { computed } from 'ember-decorators/object';
 import { gt } from 'ember-decorators/object/computed';
+import { task } from 'ember-concurrency';
 
 export default EmberObject.extend({
   @service features: null,
@@ -28,11 +29,13 @@ export default EmberObject.extend({
     return parts.set('content', []);
   },
 
-  fetch() {
+
+  fetchTask: task(function* () {
     this.debug('log model: fetching log');
     this.clearParts();
 
     let id = this.get('job.id');
+
     const url = `${config.apiEndpoint}/job/${id}/log`;
     const token = this.get('auth.token');
     let headers = {
@@ -45,19 +48,18 @@ export default EmberObject.extend({
 
     // TODO: I'd like to clean API access to use fetch everywhere once we fully
     //       switch to API V3
-    return fetch(url, {
+    const response = yield fetch(url, {
       headers: new Headers(headers)
-    }).then((response) => {
-      if (response.ok) {
-        return response.json();
-      } else {
-        throw 'error';
-      }
-    }).then((json) => {
-      this.loadParts(json['log_parts']);
-      this.set('plainTextUrl', json['@raw_log_href']);
-    });
-  },
+    })
+    let json;
+    if (response.ok) {
+      json = yield response.json();
+    } else {
+      throw 'error';
+    }
+    this.loadParts(json['log_parts']);
+    this.set('plainTextUrl', json['@raw_log_href']);
+  }),
 
   clear() {
     this.clearParts();
@@ -83,6 +85,7 @@ export default EmberObject.extend({
   },
 
   loadParts(parts) {
+    this.get('isLoaded', false);
     let i, len, part;
     this.debug('log model: load parts');
     for (i = 0, len = parts.length; i < len; i++) {

--- a/app/models/log.js
+++ b/app/models/log.js
@@ -49,7 +49,7 @@ export default EmberObject.extend({
     //       switch to API V3
     const response = yield fetch(url, {
       headers: new Headers(headers)
-    })
+    });
     let json;
     if (response.ok) {
       json = yield response.json();

--- a/app/templates/components/job-log.hbs
+++ b/app/templates/components/job-log.hbs
@@ -1,9 +1,9 @@
 {{#if error}}
   <p class="notice-banner--red">There was an error while trying to fetch the log.</p>
 {{else}}
-  {{#if log.isLoaded}}
-    {{log-content job=job log=log}}
-  {{else}}
+  {{#if log.fetchTask.isRunning}}
     {{loading-indicator}}
+  {{else}}
+    {{log-content log=log job=job}}
   {{/if}}
 {{/if}}


### PR DESCRIPTION
As detailed in https://github.com/travis-pro/team-teal/issues/2607, there were circumstances under which we would render the incorrect log when clicking a sidebar link. 

This was due to the `didUpdateAttrs` hook not being fired when we expected it to be, as we were rendering a new component instance instead. I've now switched things over to use an ember-concurrency task (mainly to improve the UX around log loading which was pretty clumsy before), which just so happened to fix this issue 😎 .

I've tested this pretty thoroughly locally to make sure that log streaming is still working as expected, but will test it more extensively in our PR env to avoid a Friday surprise.