### PR TITLE
enterprise plan to on-premises product

### DIFF
--- a/app/templates/plans.hbs
+++ b/app/templates/plans.hbs
@@ -79,7 +79,7 @@
     <div>
       <h2 class="h2--teal">Travis CI Enterprise</h2>
       <p class="text-big">
-        Our Enterprise plan is perfect for companies who want to keep using the same features of Travis CI with additional on-site security needs.
+        Our on-premises product is perfect for companies who want to keep using the same features of Travis CI with additional on-site security needs.
       </p>
       <a href="https://enterprise.travis-ci.com" title="learn more about Travis CI" class="plans-button--blue">Learn more about Travis CI Enterprise</a>
     </div>


### PR DESCRIPTION
<img width="1158" alt="image 2018-04-04 at 11 50 48 am" src="https://user-images.githubusercontent.com/19433/38328482-e8a38d38-37ff-11e8-8154-b7c5c195b73f.png">

Saying that it is a plan can potentially be mistaken for it being a plan for travis-ci.com when really it's the on-premises version of Travis CI for users who want to use our product, but have it behind their firewall.