### PR TITLE
Fix services page to integrations tab

### DIFF
--- a/app/templates/getting-started.hbs
+++ b/app/templates/getting-started.hbs
@@ -37,7 +37,7 @@
               <p>To start a build, perform one of the following:</p>
               <ul>
                 <li>Commit and push something to your repository</li>
-                <li>Go to your repository's settings page, click on "Webhooks & Services" on the left menu, choose "Travis CI" in the "Services", and use the "Test service" button.</li>
+                <li>Go to your repository's settings page, click on "Integrations & services" on the left menu, choose "Travis CI" in the "Services", and use the "Test service" button.</li>
               </ul>
               <p class="note">
                 <strong>Note:</strong> You cannot trigger your first build using Test Hook button. It has to be triggered by a push to your repository.


### PR DESCRIPTION
For now services page (in repository settings) is available from a `Integrations & services` side bar's item instead of `Webhook`. So fix name of the tab.

The current documentation guide:

![screen shot 2018-04-06 at 5 06 54 pm](https://user-images.githubusercontent.com/22666467/38425612-0a87114a-39bd-11e8-9c62-ea18c1c2c300.png)

The real repository settings looks like:

![screen shot 2018-04-06 at 5 08 22 pm](https://user-images.githubusercontent.com/22666467/38425659-2c0e66c4-39bd-11e8-801a-f936dbf8dc3d.png)

Also the same not actual documentation in [there](https://github.com/travis-ci/travis-web-index/blob/a36e9610f4253d7577dd96484a22f79bd6bc6f59/app/templates/getting-started.hbs). If you accept the pull request, i will provide changes for this case too.