### PR TITLE
Turn on jobs running in the sidebar for Enterprise

### DIFF
--- a/app/instance-initializers/enterprise-environment.js
+++ b/app/instance-initializers/enterprise-environment.js
@@ -7,7 +7,7 @@ export function initialize(appInstance) {
     featureFlags['repository-filtering'] = true;
     featureFlags['debug-logging'] = false;
     featureFlags['landing-page-cta'] = false;
-    featureFlags['show-running-jobs-in-sidebar'] = false;
+    featureFlags['show-running-jobs-in-sidebar'] = true;
     featureFlags['debug-builds'] = false;
     featureFlags['broadcasts'] = false;
   }

--- a/tests/unit/instance-initializers/enterprise-environment-test.js
+++ b/tests/unit/instance-initializers/enterprise-environment-test.js
@@ -27,7 +27,7 @@ module('Unit | Instance Initializer | enterprise environment', function (hooks) 
     assert.equal(featureFlags['repository-filtering'], true);
     assert.equal(featureFlags['debug-logging'], false);
     assert.equal(featureFlags['landing-page-cta'], false);
-    assert.equal(featureFlags['show-running-jobs-in-sidebar'], false);
+    assert.equal(featureFlags['show-running-jobs-in-sidebar'], true);
     assert.equal(featureFlags['debug-builds'], false);
     assert.equal(featureFlags['broadcasts'], false);
   });


### PR DESCRIPTION
Closes https://github.com/travis-pro/travis-enterprise/issues/281 (apologies for private repo reference)

@danishkhan noticed during Enterprise 2.2 QA that jobs running in the sidebar was off and should have been on. I asked about it here https://github.com/travis-ci/travis-web/pull/1547#issuecomment-371213457 when it changed but I misunderstood the answer, thinking it was phasing out.

So this is fixing that by turning it back on!  