### PR TITLE
Add option to skip Sentry sampling

### DIFF
--- a/app/services/raven.js
+++ b/app/services/raven.js
@@ -40,8 +40,8 @@ export default RavenLogger.extend({
     return this._super(...arguments);
   },
 
-  ignoreError(error) {
-    if (!this.shouldReportError()) {
+  ignoreError(error, forceSampling = false) {
+    if (!this.shouldReportError(forceSampling)) {
       return true;
     } else {
       const message = error.message;
@@ -57,14 +57,20 @@ export default RavenLogger.extend({
     return this._super(...arguments);
   },
 
-  shouldReportError() {
+  shouldReportError(forceSampling) {
     // Sentry recommends only reporting a small subset of the actual
     // frontend errors. This can get *very* noisy otherwise.
     if (this.get('features.enterpriseVersion') || config.sentry.development) {
       return false;
+    } else if (forceSampling) {
+      return true;
     } else {
-      let sampleRate = 10;
-      return (Math.random() * 100 <= sampleRate);
+      return this.sampleError();
     }
+  },
+
+  sampleError() {
+    let sampleRate = 10;
+    return (Math.random() * 100 <= sampleRate);
   }
 });

--- a/tests/unit/services/raven-test.js
+++ b/tests/unit/services/raven-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import config from 'travis/config/environment';
 
 module('Unit | Service | raven', function (hooks) {
   setupTest(hooks);
@@ -14,5 +15,20 @@ module('Unit | Service | raven', function (hooks) {
 
     assert.ok(service.ignoreError(filteredError), 'Service should ignore benign error');
     assert.notOk(service.ignoreError(unfilteredError), 'Service should not ignore serious error');
+  });
+
+  test('it skips sampling when requested', function (assert) {
+    let service = this.owner.lookup('service:raven');
+    let sampledError = { message: 'this error should not be reported due to sampling' };
+    let forcedReportingError = { message: 'this error will be reported despite sampling' };
+
+    service.sampleError = () => false;
+
+    config.sentry.development = false;
+
+    assert.ok(service.ignoreError(sampledError), 'Service should ignore error when not sampled');
+    assert.notOk(service.ignoreError(forcedReportingError, true), 'Service should not ignore error when sampling is forced');
+
+    config.sentry.development = true;
   });
 });

--- a/tests/unit/services/raven-test.js
+++ b/tests/unit/services/raven-test.js
@@ -8,7 +8,7 @@ module('Unit | Service | raven', function (hooks) {
   test('it filters benign errors', function (assert) {
     let service = this.owner.lookup('service:raven');
     let filteredError = { message: 'foo is an error we should filter' };
-    let unfilteredError = { message: 'throw dat' };
+    let unfilteredError = { message: 'throw' };
 
     service.shouldReportError = () => true;
     service.set('benignErrors', ['foo', 'bar', 'baz']);


### PR DESCRIPTION
I have a case in billing where I want to be able to always
log an exception (apart from enterprise etc), so I’m
introducing this interface.