### PR TITLE
Fix log URL test API reference

### DIFF
--- a/tests/acceptance/job/basic-layout-test.js
+++ b/tests/acceptance/job/basic-layout-test.js
@@ -51,7 +51,7 @@ test('visiting job-view', function (assert) {
 
     assert.equal(jobPage.log, 'Hello log');
     assert.notOk(jobPage.hasTruncatedLog);
-    assert.equal(jobPage.rawLogUrl, `https://api.travis-ci.org/v3/job/${job.id}/log.txt`);
+    assert.equal(jobPage.rawLogUrl, `${config.apiEndpoint}/v3/job/${job.id}/log.txt`);
   });
 });
 


### PR DESCRIPTION
I’ve been ignoring this while running against staging but I might as well generalise it.