### PR TITLE
Change token buttons to not switch routes

### DIFF
--- a/app/styles/app/layouts/profile.scss
+++ b/app/styles/app/layouts/profile.scss
@@ -295,6 +295,7 @@ $profile-breakpoint: 600px;
   border-radius: 0.25em;
   width: calc(1/2*100% - (1 - 1/2)*0.5em);
   padding: 4px 0;
+  cursor: pointer;
 
   & svg {
     margin-right: 4px;

--- a/app/templates/components/org-item.hbs
+++ b/app/templates/components/org-item.hbs
@@ -24,7 +24,7 @@
             success=(action 'copyTokenSuccessful')}}
             {{svg-jar 'icon-copy' class="icon"}} <span>Copy token</span>
           {{/copy-button}}
-          <button {{action 'tokenVisibility'}} class="show-token">
+          <button {{action 'tokenVisibility' bubbles=false}} class="show-token">
             {{svg-jar 'icon-seemore' class="icon"}} <span>{{if tokenIsVisible
               'Hide token' 'View token'}}</span>
           </button>


### PR DESCRIPTION
It works for the view button but I don’t know how to address it for the copy button.