### PR TITLE
Update open source link to travis-ci.com on the plans page

### DIFF
--- a/app/templates/plans.hbs
+++ b/app/templates/plans.hbs
@@ -67,7 +67,7 @@
   <section class="inner section--two section--os">
     <div>
       <h2 class="h2--grey section-headline">Always <span class="em--yellow">free</span> for open source projects</h2>
-      <a href="https://travis-ci.org/signin" class="plans-button--grey" title="Open Source projects on Travis CI" {{action 'gaCta' 'plans-table'}}>Set up your open source project now</a>
+      <a href="https://travis-ci.com/signin" class="plans-button--grey" title="Open Source projects on Travis CI" {{action 'gaCta' 'plans-table'}}>Set up your open source project now</a>
     </div>
     <div>
       <h2 class="h2--grey section-headline">In need of a bigger plan?</h2>


### PR DESCRIPTION
Now that we've [announced support for open source projects on travis-ci.com](https://blog.travis-ci.com/2018-05-02-open-source-projects-on-travis-ci-com-with-github-apps) we want to encourage any new users to use travis-ci.com for their open source projects rather than travis-ci.org.