### PR TITLE
Add link to travis_migrate_to_apps gem

### DIFF
--- a/app/templates/account/repositories.hbs
+++ b/app/templates/account/repositories.hbs
@@ -95,7 +95,7 @@
         {{/external-link-to}}
         <p>
           We are only able to migrate accounts that have {{migrationRepositoryCountLimit}} or fewer repositories using the Legacy Services Integration.
-          Please <a href='https://docs.travis-ci.com/user/open-source-on-travis-ci-com/#Existing-Open-Source-Repositories-on-travis-ci.org'>refer to our documentation</a> on how to migrate your account.
+          Please <a href='https://docs.travis-ci.com/user/travis-migrate-to-apps-gem-guide/'>refer to our documentation</a> on how to migrate your account.
         </p>
       {{/if}}
     </div>


### PR DESCRIPTION
This links explains how to migrate an account with more that 50 repositories.

See action item #2 at https://travisci.slack.com/archives/C1MD4TBEV/p1525792124000033