### PR TITLE
Change staging to production on production deploys

### DIFF
--- a/config/deploy.js
+++ b/config/deploy.js
@@ -39,7 +39,6 @@ module.exports = function (deployTarget) {
   if (deployTarget === 'org-staging-pull-request') {
     ENV.s3.bucket = 'travis-web-production-next';
     ENV.redis.url = process.env.ORG_PRODUCTION_REDIS_URL;
-    ENV.redis.keyPrefix = `${process.env.CLEANED_BRANCH_SUBDOMAIN}-staging`;
   }
 
   if (deployTarget === 'com-production-pull-request' ||
@@ -52,7 +51,6 @@ module.exports = function (deployTarget) {
   if (deployTarget === 'com-staging-pull-request') {
     ENV.s3.bucket = 'travis-pro-web-production-next';
     ENV.redis.url = process.env.COM_PRODUCTION_REDIS_URL;
-    ENV.redis.keyPrefix = `${process.env.CLEANED_BRANCH_SUBDOMAIN}-staging`;
   }
 
   return ENV;

--- a/config/deployment/deploy-pull-request.sh
+++ b/config/deployment/deploy-pull-request.sh
@@ -9,6 +9,8 @@ then
 
   API_ENDPOINT=https://api-staging.travis-ci.com TRAVIS_PRO=true ember deploy com-staging-pull-request --activate
   DEPLOYMENT_EXIT_CODE=$? TLD=com ENVIRONMENT=staging ./config/deployment/update-github-status.sh
+
+  export CLEANED_BRANCH_SUBDOMAIN=`echo ${CLEANED_BRANCH_SUBDOMAIN/staging/production}`
 else
     echo "Skipping com- and org-staging PR deployments: no 'staging' in branch name."
 fi

--- a/config/deployment/update-github-status.sh
+++ b/config/deployment/update-github-status.sh
@@ -1,14 +1,7 @@
 echo env = $ENVIRONMENT and tld = $TLD
 
-if [[ "$ENVIRONMENT" = "staging" ]]
-then
-  SUFFIX="-staging"
-else
-  SUFFIX=""
-fi
-
 FULL_ENVIRONMENT=`echo $TLD`-`echo $ENVIRONMENT`
-FULL_URL=https://`echo $CLEANED_BRANCH_SUBDOMAIN``echo $SUFFIX`.test-deployments.travis-ci.`echo $TLD`
+FULL_URL=https://`echo $CLEANED_BRANCH_SUBDOMAIN`.test-deployments.travis-ci.`echo $TLD`
 
 echo deployment url: $FULL_URL
 


### PR DESCRIPTION
This should be less confusing and verbose. But I wouldn’t be
surprised if it doesn’t work the first time!

The PR deployments look for `staging` in the name of the branch
to determine whether to produce deployments for staging
environments. But the current way of handling them is to append
`-staging` to the branch name, which means staging deployment
subdomains often have a first segment ending in `-staging-staging`.
My goal here is to replace `staging` with production for the
relevant deployments.