### PR TITLE
Fix issue of localStorage getting cleared too often for the Enterprise License Banner

### DIFF
--- a/app/components/enterprise-banner.js
+++ b/app/components/enterprise-banner.js
@@ -33,12 +33,17 @@ export default Component.extend({
         isTrial: response.license_type === 'trial',
         isPaid: response.license_type !== 'trial'
       });
-      if (!this.get('expiring')) {
-        this.get('storage').removeItem(this.get('lsLicense'));
-      }
-      if (!this.get('almostExceeding') && !this.get('exceeding')) {
-        this.get('storage').removeItem(this.get('lsSeats'));
-      }
+      console.log(this.get('expiring'))
+      console.log(this.get('daysUntilExpiry'))
+
+      console.log(this.get('almostExceedingSeats'))
+      console.log(this.get('exceedingSeats'))
+      // if (this.get('daysUntilExpiry') && !this.get('expiring')) {
+      //  this.get('storage').removeItem(this.get('lsLicense'));
+      //}
+      // if (!this.get('almostExceedingSeats') && !this.get('exceedingSeats')) {
+      //   this.get('storage').removeItem(this.get('lsSeats'));
+      // }
     });
   },
 

--- a/app/components/enterprise-banner.js
+++ b/app/components/enterprise-banner.js
@@ -33,11 +33,9 @@ export default Component.extend({
         isTrial: response.license_type === 'trial',
         isPaid: response.license_type !== 'trial'
       });
-      console.log(this.get('expiring'))
-      console.log(this.get('daysUntilExpiry'))
 
-      console.log(this.get('almostExceedingSeats'))
-      console.log(this.get('exceedingSeats'))
+      // Temporary removing these until we can rework these to be more
+      // emberlike and resiliant to odd timing issues
       // if (this.get('daysUntilExpiry') && !this.get('expiring')) {
       //  this.get('storage').removeItem(this.get('lsLicense'));
       //}

--- a/app/components/enterprise-banner.js
+++ b/app/components/enterprise-banner.js
@@ -38,7 +38,7 @@ export default Component.extend({
       // emberlike and resiliant to odd timing issues
       // if (this.get('daysUntilExpiry') && !this.get('expiring')) {
       //  this.get('storage').removeItem(this.get('lsLicense'));
-      //}
+      // }
       // if (!this.get('almostExceedingSeats') && !this.get('exceedingSeats')) {
       //   this.get('storage').removeItem(this.get('lsSeats'));
       // }


### PR DESCRIPTION
Fixes https://github.com/travis-pro/travis-enterprise/issues/300 (Pardon the private issue)

Summarizing that issue, essentially the license banner comes back after a refresh even if you have dismissed it. Digging we found some bugs in one of the flows of logic where some properties got renamed: 

> Turns out it wasn't the logic that was off, but the get statements... `exceeding` and `almostExceeding` return as `undefinded`. It seems the proper properties are `exceedingSeats` and `almostExceedingSeats`? 
>
>As these are always false-y the localstorage got cleared everytime. Testing a fix to this right now. So hopefully that's the problem. 

This change has already been made in this PR. What makes this PR WIP and the feedback I need is it seems the enterprise banner component fires twice (once with the state in `destroying` and once as `inDOM`), and the `expiring` computed property comes back first `false` then `true`. So it ends up getting cleared in: https://github.com/travis-ci/travis-web/blob/master/app/components/enterprise-banner.js#L36-L38

So the local storage is getting cleared every refresh. 

My big questions are: 

1. Should this component be firing twice?
2. Why does the value of `expiring` change between it firing? Is this a promise issue or something with the API call? 
