### PR TITLE
[Enterprise Backport] When Enterprise has publicMode turned off, generate tokens for status images. (#1674)

### DIFF
--- a/app/services/status-images.js
+++ b/app/services/status-images.js
@@ -18,7 +18,9 @@ export default Service.extend({
 
     let slug = repo.get('slug');
 
-    if (repo.get('private')) {
+    // In Enterprise you can toggle public mode, where even "public" repositories are hidden
+    // in which cases we need to generate a token for all images
+    if (!config.publicMode || repo.get('private')) {
       const token = this.get('auth').assetToken();
       return `${prefix}/${slug}.svg?token=${token}${branch ? `&branch=${branch}` : ''}`;
     } else {

--- a/config/environment.js
+++ b/config/environment.js
@@ -135,7 +135,7 @@ module.exports = function (environment) {
       }
     }
 
-    if (process.env.PUBLIC_MODE !== null && (process.env.PUBLIC_MODE == false || process.env.PUBLIC_MODE == 'false')) {
+    if (process.env.PUBLIC_MODE !== null && process.env.PUBLIC_MODE == 'false') {
       ENV.publicMode = false;
     } else {
       ENV.publicMode = true;

--- a/config/environment.js
+++ b/config/environment.js
@@ -99,6 +99,12 @@ module.exports = function (environment) {
     ]
   };
 
+  if (process.env.PUBLIC_MODE) {
+    ENV.publicMode = process.env.PUBLIC_MODE;
+  } else {
+    ENV.publicMode = true;
+  }
+
   if (typeof process !== 'undefined') {
     if (ENV.featureFlags['pro-version'] && !ENV.featureFlags['enterprise-version']) {
       // set defaults for pro if it's used
@@ -133,12 +139,6 @@ module.exports = function (environment) {
       if (ENV.apiEndpoint === 'https://api-staging.travis-ci.com') {
         ENV.pusher.key = '87d0723b25c51e36def8';
       }
-    }
-
-    if (process.env.PUBLIC_MODE) {
-      ENV.publicMode = process.env.PUBLIC_MODE;
-    } else {
-      ENV.publicMode = true;
     }
 
     if (process.env.AUTH_ENDPOINT) {

--- a/config/environment.js
+++ b/config/environment.js
@@ -135,6 +135,12 @@ module.exports = function (environment) {
       }
     }
 
+    if (process.env.PUBLIC_MODE) {
+      ENV.publicMode = process.env.PUBLIC_MODE;
+    } else {
+      ENV.publicMode = true;
+    }
+
     if (process.env.AUTH_ENDPOINT) {
       ENV.authEndpoint = process.env.AUTH_ENDPOINT;
     }

--- a/config/environment.js
+++ b/config/environment.js
@@ -99,12 +99,6 @@ module.exports = function (environment) {
     ]
   };
 
-  if (process.env.PUBLIC_MODE) {
-    ENV.publicMode = process.env.PUBLIC_MODE;
-  } else {
-    ENV.publicMode = true;
-  }
-
   if (typeof process !== 'undefined') {
     if (ENV.featureFlags['pro-version'] && !ENV.featureFlags['enterprise-version']) {
       // set defaults for pro if it's used
@@ -139,6 +133,12 @@ module.exports = function (environment) {
       if (ENV.apiEndpoint === 'https://api-staging.travis-ci.com') {
         ENV.pusher.key = '87d0723b25c51e36def8';
       }
+    }
+
+    if (process.env.PUBLIC_MODE !== null && (process.env.PUBLIC_MODE == false || process.env.PUBLIC_MODE == 'false')) {
+      ENV.publicMode = false;
+    } else {
+      ENV.publicMode = true;
     }
 
     if (process.env.AUTH_ENDPOINT) {

--- a/tests/unit/services/status-images-test.js
+++ b/tests/unit/services/status-images-test.js
@@ -34,7 +34,7 @@ test('it generates an image url with a token for a private repo', function (asse
 });
 
 test('it generates an image url with a token for a repo when publicMode is false', function (assert) {
-  const service = this.owner.lookup('service:status-images');
+  const service = this.subject();
   config.publicMode = false;
   const url = service.imageUrl(this.repo);
   assert.equal(url, `${root}/travis-ci/travis-web.svg?token=token-abc-123`);

--- a/tests/unit/services/status-images-test.js
+++ b/tests/unit/services/status-images-test.js
@@ -33,6 +33,14 @@ test('it generates an image url with a token for a private repo', function (asse
   assert.equal(url, `${root}/travis-ci/travis-web.svg?token=token-abc-123`);
 });
 
+test('it generates an image url with a token for a repo when publicMode is false', function (assert) {
+  const service = this.owner.lookup('service:status-images');
+  config.publicMode = false;
+  const url = service.imageUrl(this.repo);
+  assert.equal(url, `${root}/travis-ci/travis-web.svg?token=token-abc-123`);
+  config.publicMode = true;
+});
+
 test('it generates an image url with a repo', function (assert) {
   const service = this.subject();
   const url = service.imageUrl(this.repo);

--- a/waiter/config.ru
+++ b/waiter/config.ru
@@ -51,7 +51,7 @@ end
 run Travis::Web::App.build(
   userlike:        ENV['USERLIKE'],
   environment:     ENV['RACK_ENV'] || 'development',
-  api_endpoint:    ENV['API_ENDPOINT'],
+  api_endpoint:    ENV['API_ENDPINT'],
   pages_endpoint:   ENV['PAGES_ENDPOINT'],
   billing_endpoint: ENV['BILLING_ENDPOINT'],
   source_endpoint: ENV['SOURCE_ENDPOINT'] || 'https://github.com',
@@ -68,6 +68,7 @@ run Travis::Web::App.build(
   customer_io_site_id: ENV['CUSTOMER_IO_SITE_ID'],
   pro: ENV['TRAVIS_PRO'],
   enterprise: ENV['TRAVIS_ENTERPRISE'],
+  public_mode: ENV['PUBLIC_MODE'],
   assets_host: ENV['ASSETS_HOST'],
   ajax_polling: ENV['AJAX_POLLING'],
   github_orgs_oauth_access_settings_url: ENV['GITHUB_ORGS_OAUTH_ACCESS_SETTINGS_URL']

--- a/waiter/config.ru
+++ b/waiter/config.ru
@@ -51,7 +51,7 @@ end
 run Travis::Web::App.build(
   userlike:        ENV['USERLIKE'],
   environment:     ENV['RACK_ENV'] || 'development',
-  api_endpoint:    ENV['API_ENDPINT'],
+  api_endpoint:    ENV['API_ENDPOINT'],
   pages_endpoint:   ENV['PAGES_ENDPOINT'],
   billing_endpoint: ENV['BILLING_ENDPOINT'],
   source_endpoint: ENV['SOURCE_ENDPOINT'] || 'https://github.com',

--- a/waiter/lib/travis/web/app.rb
+++ b/waiter/lib/travis/web/app.rb
@@ -196,6 +196,8 @@ class Travis::Web::App
         config['featureFlags']['enterprise-version'] = true
       end
 
+      config['publicMode'] = options[:public_mode] if options[:public_mode]
+
       if config['enterprise']
         config['pagesEndpoint'] = false
         config['billingEndpoint'] = false

--- a/waiter/lib/travis/web/app.rb
+++ b/waiter/lib/travis/web/app.rb
@@ -196,7 +196,11 @@ class Travis::Web::App
         config['featureFlags']['enterprise-version'] = true
       end
 
-      config['publicMode'] = options[:public_mode] if options[:public_mode]
+      if !options[:public_mode].nil? && (options[:public_mode] == 'false' || options[:public_mode] == false)
+        config['publicMode'] = false
+      else
+        config['publicMode'] = true
+      end
 
       if config['enterprise']
         config['pagesEndpoint'] = false


### PR DESCRIPTION
Backport of #1674 for `enterprise-2.2`

