### PR TITLE
Job names

### DIFF
--- a/app/components/build-message.js
+++ b/app/components/build-message.js
@@ -40,6 +40,10 @@ export default Component.extend({
     return `downcasing <code>${escape(args.value)}</code>`;
   },
 
+  duplicate_names(args) {
+    return `duplicate job names: <code>${escape(args.value)}</code>`;
+  },
+
   edge(args) {
     return `<code>${escape(args.given)}</code> is experimental and might be removed in the future`;
   },

--- a/app/components/jobs-item.js
+++ b/app/components/jobs-item.js
@@ -12,6 +12,13 @@ export default Component.extend({
     return jobConfigLanguage(config);
   },
 
+  @computed('job.config.content.title')
+  title(title) {
+    if (title) {
+      return title;
+    }
+  },
+
   @computed('job.config.content.{env,gemfile}')
   environment(env, gemfile) {
     if (env) {

--- a/app/components/jobs-item.js
+++ b/app/components/jobs-item.js
@@ -12,10 +12,10 @@ export default Component.extend({
     return jobConfigLanguage(config);
   },
 
-  @computed('job.config.content.title')
-  title(title) {
-    if (title) {
-      return title;
+  @computed('job.config.content.name')
+  name(name) {
+    if (name) {
+      return name;
     }
   },
 

--- a/app/styles/app/layouts/jobs.scss
+++ b/app/styles/app/layouts/jobs.scss
@@ -164,7 +164,7 @@
   overflow: hidden;
 
   @media #{$medium-up} {
-    flex: 1 0 20%;
+    flex: 1 0 40%;
     position: relative;
     padding: 0.3em 0.5em 0.5em 0.7em;
     align-self: flex-start;
@@ -233,7 +233,7 @@
 .centered {
   @media #{$xlarge-up} {
     .job-name {
-      flex: 0 0 21em;
+      flex: 0 0 42em;
     }
 
     .job-env {

--- a/app/styles/app/layouts/jobs.scss
+++ b/app/styles/app/layouts/jobs.scss
@@ -160,6 +160,26 @@
   }
 }
 
+.job-title {
+  overflow: hidden;
+
+  @media #{$medium-up} {
+    flex: 1 0 20%;
+    position: relative;
+    padding: 0.3em 0.5em 0.5em 0.7em;
+    align-self: flex-start;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    &:after {
+      @include fadeOut(right, -90deg, white);
+
+      top: -1px;
+    }
+  }
+}
+
 .job-lang {
   overflow: hidden;
 
@@ -213,6 +233,10 @@
 
 .centered {
   @media #{$xlarge-up} {
+    .job-title {
+      flex: 0 0 21em;
+    }
+
     .job-env {
       flex: 0 0 21em;
     }

--- a/app/styles/app/layouts/jobs.scss
+++ b/app/styles/app/layouts/jobs.scss
@@ -160,7 +160,7 @@
   }
 }
 
-.job-title {
+.job-name {
   overflow: hidden;
 
   @media #{$medium-up} {
@@ -232,7 +232,7 @@
 
 .centered {
   @media #{$xlarge-up} {
-    .job-title {
+    .job-name {
       flex: 0 0 21em;
     }
 

--- a/app/styles/app/layouts/jobs.scss
+++ b/app/styles/app/layouts/jobs.scss
@@ -171,6 +171,11 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+
+    &:after {
+      @include fadeOut(right, -90deg, white);
+      top: -1px;
+    }
   }
 }
 

--- a/app/styles/app/layouts/jobs.scss
+++ b/app/styles/app/layouts/jobs.scss
@@ -171,12 +171,6 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-
-    &:after {
-      @include fadeOut(right, -90deg, white);
-
-      top: -1px;
-    }
   }
 }
 

--- a/app/styles/app/mixins.scss
+++ b/app/styles/app/mixins.scss
@@ -49,7 +49,7 @@
 @mixin colorFadeOut($status, $color) {
   @media #{$medium-up} {
     &.#{$status}:hover {
-      .job-title,
+      .job-name,
       .job-lang,
       .job-env {
         &:after {
@@ -57,7 +57,7 @@
         }
       }
 
-      .job-title:hover,
+      .job-name:hover,
       .job-lang:hover,
       .job-env:hover {
         overflow: visible;

--- a/app/styles/app/mixins.scss
+++ b/app/styles/app/mixins.scss
@@ -49,6 +49,7 @@
 @mixin colorFadeOut($status, $color) {
   @media #{$medium-up} {
     &.#{$status}:hover {
+      .job-title,
       .job-lang,
       .job-env {
         &:after {
@@ -56,6 +57,7 @@
         }
       }
 
+      .job-title:hover,
       .job-lang:hover,
       .job-env:hover {
         overflow: visible;

--- a/app/templates/components/build-layout.hbs
+++ b/app/templates/components/build-layout.hbs
@@ -13,14 +13,6 @@
         {{build-messages-list repo=repo build=build}}
         {{#if jobsLoaded}}
           {{#if build.stages}}
-            <p class="notice-banner--yellow spaced">
-              <span class="label-align">
-                <strong>Beta Feature</strong> Thank you for trying Build Stages!
-              </span>
-              {{external-link-to
-                href="https://github.com/travis-ci/beta-features/issues/28"
-                content="We'd love your feedback"}}
-            </p>
             {{#each sortedBuildStages as |stage|}}
               {{jobs-list stage=stage build=build repo=repo stages=sortedBuildStages}}
             {{/each}}

--- a/app/templates/components/jobs-item.hbs
+++ b/app/templates/components/jobs-item.hbs
@@ -13,9 +13,9 @@
     {{svg-jar osIcon class='icon'}}
   </div>
 
-{{#if title}}
-  <div class="job-title">
-    <span class="label-align" aria-label="Title">{{title}}</span>
+{{#if name}}
+  <div class="job-name">
+    <span class="label-align" aria-label="Title">{{name}}</span>
   </div>
 {{else}}
   <div class="job-lang">

--- a/app/templates/components/jobs-item.hbs
+++ b/app/templates/components/jobs-item.hbs
@@ -13,10 +13,16 @@
     {{svg-jar osIcon class='icon'}}
   </div>
 
+{{#if title}}
+  <div class="job-title">
+    <span class="label-align" aria-label="Title">{{title}}</span>
+  </div>
+{{else}}
   <div class="job-lang">
     {{svg-jar 'icon-language' class="icon"}}
     <span class="label-align" aria-label="Language">{{#if languages}}{{languages}}{{else}}no language set{{/if}}</span>
   </div>
+{{/if}}
 
 {{#if environment}}
   <div class="job-env">

--- a/app/templates/components/jobs-item.hbs
+++ b/app/templates/components/jobs-item.hbs
@@ -22,7 +22,6 @@
     {{svg-jar 'icon-language' class="icon"}}
     <span class="label-align" aria-label="Language">{{#if languages}}{{languages}}{{else}}no language set{{/if}}</span>
   </div>
-{{/if}}
 
 {{#if environment}}
   <div class="job-env">
@@ -34,6 +33,7 @@
     {{svg-jar 'icon-environment' class="icon"}}
     <span class="label-align" aria-label="Environment variables">no environment variables set</span>
   </div>
+{{/if}}
 {{/if}}
 
   <div class="job-duration" title="Started {{pretty-date job.startedAt}}">

--- a/tests/integration/components/jobs-item-test.js
+++ b/tests/integration/components/jobs-item-test.js
@@ -42,6 +42,26 @@ module('Integration | Component | jobs item', function (hooks) {
     assert.dom('.job-lang').hasText(/no language set/, 'a message about no language being set should be displayed');
   });
 
+  test('when name is set it replaces both language and env', async function (assert) {
+    const job = {
+      id: 10,
+      state: 'passed',
+      number: '2',
+      config: { content: {
+        rvm: '2.1.2',
+        name: 'that name'
+      } },
+      duration: 100
+    };
+
+    this.job = job;
+    await render(hbs`{{jobs-item job=job}}`);
+
+    assert.dom('.job-name .label-align').hasText('that name', 'name should be displayed');
+    assert.dom('.job-language .label-align').doesNotExist();
+    assert.dom('.job-env .label-align').doesNotExist();
+  });
+
   test('when env is not set, gemfile is displayed in the env section', async function (assert) {
     const job = {
       id: 10,


### PR DESCRIPTION
This adds a job's name if it is present in the job's config. We are considering making this a first class attribute on jobs and add it to the api payload, but that is still to be decided. Opening this here so we can look at it.

I haven't added the name to the job view because that would need input from creative.

This replaces the "language" section with the given name:

![image](https://user-images.githubusercontent.com/2208/41286347-61985c94-6e3f-11e8-85c2-9ba44c185f8f.png)

Alternatively we can replace both "language" and "env" if a name is present:

![image](https://user-images.githubusercontent.com/2208/41355310-7a00fec0-6f21-11e8-86fc-3ccd8b90ecc1.png)

---

~Also, I think I'd need help with figuring out why in the world this fade-out thing is visible on the name:~

![image](https://user-images.githubusercontent.com/2208/41286358-699a9b5a-6e3f-11e8-9111-be5f4bbcdf31.png)

~It is not visible for a job that doesn't have a name:~

![image](https://user-images.githubusercontent.com/2208/41286465-e2a47408-6e3f-11e8-8a7b-cd1b36130fd3.png)

~I thought it's caused by the language icon (I haven't added an icon for the name), but it's not ... even if I add the icon back, the fadeout is still visible.~

Edit: @paulthegeek fixed this ❤️ 
