### PR TITLE
Remove Build only with travis yml option

### DIFF
--- a/app/templates/settings.hbs
+++ b/app/templates/settings.hbs
@@ -3,7 +3,6 @@
   <section class="settings-section">
     <h2 class="small-title">General</h2>
     <ul class="settings-list--columns">
-      <li>{{settings-switch active=model.settings.builds_only_with_travis_yml repo=repo description="Build only if .travis.yml is present" key="builds_only_with_travis_yml"}}</li>
       <li>{{settings-switch active=model.settings.build_pushes repo=repo description="Build pushed branches" key="build_pushes"}}
         <a href="https://docs.travis-ci.com/user/customizing-the-build/#Building-only-the-latest-commit"
            title="about branch updates" class="settings-tooltip">

--- a/tests/acceptance/repo/settings-test.js
+++ b/tests/acceptance/repo/settings-test.js
@@ -91,7 +91,6 @@ test('view settings', function (assert) {
   settingsPage.visit({ organization: 'org-login', repo: 'repository-name' });
 
   andThen(function () {
-    assert.ok(settingsPage.buildOnlyWithTravisYml.isActive, 'expected builds only with .travis.yml');
     assert.ok(settingsPage.buildPushes.isActive, 'expected builds for pushes');
     assert.equal(settingsPage.buildPushes.ariaChecked, 'true', 'expected the build pushes switch to have aria-checked=true');
     assert.equal(settingsPage.buildPushes.role, 'switch', 'expected the build pushes switch to be marked as such');
@@ -154,13 +153,6 @@ test('change general settings', function (assert) {
     assert.notOk(settingsPage.buildPushes.isActive, 'expected no builds for pushes');
     assert.equal(settingsPage.buildPushes.ariaChecked, 'false', 'expected the build pushes switch to have aria-checked=false');
     assert.deepEqual(settingToRequestBody.build_pushes, { 'setting.value': false });
-  });
-
-  settingsPage.buildOnlyWithTravisYml.toggle();
-
-  andThen(() => {
-    assert.notOk(settingsPage.buildOnlyWithTravisYml.isActive, 'expected builds without .travis.yml');
-    assert.deepEqual(settingToRequestBody.builds_only_with_travis_yml, { 'setting.value': false });
   });
 
   settingsPage.buildPullRequests.toggle();

--- a/tests/pages/settings.js
+++ b/tests/pages/settings.js
@@ -35,13 +35,6 @@ export default create({
     toggle: clickable()
   },
 
-  buildOnlyWithTravisYml: {
-    scope: 'section.settings-section .builds_only_with_travis_yml.switch',
-
-    isActive: hasClass('active'),
-    toggle: clickable()
-  },
-
   buildPushes: {
     scope: 'section.settings-section .build_pushes.switch',
 


### PR DESCRIPTION
### Related Issue
[2719](https://github.com/travis-pro/team-teal/issues/2719)

#### What does this PR do?
- Removes build only option from settings

#### Where should I start?
`app/templates/settings.hbs`

#### How this PR makes you feel?
![delete](https://user-images.githubusercontent.com/529465/41603427-2a655208-739a-11e8-8675-105555c13e11.gif)
