### PR TITLE
Change builds to jobs on subscription tab

### DIFF
--- a/app/templates/account/billing/index.hbs
+++ b/app/templates/account/billing/index.hbs
@@ -10,7 +10,7 @@
       <h2>Plan Overview</h2>
       <section class='plan'>
         <h3 data-test-plan-name>{{model.plan.name}}</h3>
-        <p data-test-plan-concurrency>{{pluralize model.plan.builds 'concurrent build'}}</p>
+        <p data-test-plan-concurrency>{{pluralize model.plan.builds 'concurrent job'}}</p>
         <p>Renewing on {{moment-format model.validTo 'MMMM D, YYYY'}}</p>
       </section>
     {{/unless}}

--- a/tests/acceptance/profile/billing-test.js
+++ b/tests/acceptance/profile/billing-test.js
@@ -106,7 +106,7 @@ test('view billing information with invoices', function (assert) {
     assert.ok(profilePage.billing.marketplaceButton.isHidden);
 
     assert.equal(profilePage.billing.plan.name, 'Small Business Plan');
-    assert.equal(profilePage.billing.plan.concurrency, '5 concurrent builds');
+    assert.equal(profilePage.billing.plan.concurrency, '5 concurrent jobs');
 
     assert.equal(profilePage.billing.address.text, 'User Name Travis CI GmbH Rigaerstraße 8 Address 2 Berlin, Berlin 10987 Germany VAT: 12345');
     assert.equal(profilePage.billing.source, 'This plan is paid through Stripe.');


### PR DESCRIPTION
#### What does this PR do?
- Changes the copy from `builds` to `jobs` on the subscription tab in billing.

#### Related Issue
[Issue](https://github.com/travis-pro/billing-v2/issues/128)

#### Where should I start?
`app/templates/account/billing/index.hbs`

#### How this PR makes you feel?
![jazz](https://user-images.githubusercontent.com/529465/42233145-e796c9b0-7ead-11e8-8eb3-0e6649303930.gif)


