### PR TITLE
Add visual clarity for manual subscriptions

### DIFF
--- a/app/models/subscription.js
+++ b/app/models/subscription.js
@@ -2,7 +2,7 @@ import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 import { belongsTo, hasMany } from 'ember-data/relationships';
 import { computed } from 'ember-decorators/object';
-import { and, equal, not, or } from 'ember-decorators/object/computed';
+import { and, equal, or } from 'ember-decorators/object/computed';
 import config from 'travis/config/environment';
 
 let sourceToWords = {
@@ -30,8 +30,6 @@ export default Model.extend({
   @equal('source', 'stripe') isStripe: null,
   @equal('source', 'github') isGithub: null,
   @equal('source', 'manual') isManual: null,
-
-  @not('source', 'manual') notManual: null,
 
   @and('isStripe', 'isNotSubscribed') isResubscribable: null,
 

--- a/app/models/subscription.js
+++ b/app/models/subscription.js
@@ -2,7 +2,7 @@ import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 import { belongsTo, hasMany } from 'ember-data/relationships';
 import { computed } from 'ember-decorators/object';
-import { and, equal, or } from 'ember-decorators/object/computed';
+import { and, equal, not, or } from 'ember-decorators/object/computed';
 import config from 'travis/config/environment';
 
 let sourceToWords = {
@@ -30,6 +30,8 @@ export default Model.extend({
   @equal('source', 'stripe') isStripe: null,
   @equal('source', 'github') isGithub: null,
   @equal('source', 'manual') isManual: null,
+
+  @not('source', 'manual') notManual: null,
 
   @and('isStripe', 'isNotSubscribed') isResubscribable: null,
 

--- a/app/styles/app/layouts/profile.scss
+++ b/app/styles/app/layouts/profile.scss
@@ -406,6 +406,13 @@ section.billing {
     h3 {
       margin: 20px 0 12px 0;
     }
+    .manual {
+      color: #666666;
+      font-size: 25px;
+      font-weight: 300;
+      line-height: 1.45;
+      margin-bottom: 0.2em;
+    }
 
     @media #{$medium-up} {
       h3 {

--- a/app/styles/app/layouts/profile.scss
+++ b/app/styles/app/layouts/profile.scss
@@ -406,12 +406,10 @@ section.billing {
     h3 {
       margin: 20px 0 12px 0;
     }
-    .manual {
-      color: #666666;
-      font-size: 25px;
-      font-weight: 300;
-      line-height: 1.45;
-      margin-bottom: 0.2em;
+
+    p.manual {
+      color: $brick-red;
+      font-size: 16px; 
     }
 
     @media #{$medium-up} {

--- a/app/templates/account/billing/index.hbs
+++ b/app/templates/account/billing/index.hbs
@@ -6,12 +6,12 @@
     {{manage-subscription-button subscription=model account=account}}
   {{/if}}
   {{#if model.isSubscribed}}
-      <h2>Plan Overview</h2>
-      <section class='plan'>
-        <h3 data-test-plan-name>{{model.plan.name}}</h3>
-        <p data-test-plan-concurrency>{{pluralize model.plan.builds 'concurrent job'}}</p>
-        <p>Renewing on {{moment-format model.validTo 'MMMM D, YYYY'}}</p>
-      </section>
+    <h2>Plan Overview</h2>
+    <section class='plan'>
+      <h3 data-test-plan-name>{{model.plan.name}}</h3>
+      <p data-test-plan-concurrency>{{pluralize model.plan.builds 'concurrent job'}}</p>
+      <p>Renewing on {{moment-format model.validTo 'MMMM D, YYYY'}}</p>
+    </section>
     <h2>Billing Information</h2>
     <section class='row'>
       {{#if model.isStripe}}
@@ -37,18 +37,18 @@
 </section>
 
 {{#if invoices}}
-<section class='invoices'>
-  <h2>Invoice History</h2>
-  <p>
-    {{svg-jar 'icon-help' class='icon-help' alt=''}} Having trouble with your invoices?
-    <a href='{{ config.urls.support }}' title='Email the Travis support team' {{action 'helpscoutTrigger'}}>We’re happy to help</a>.
-  </p>
-  <ul>
-    {{#each (sort-by 'createdAt:desc' invoices) as |invoice|}}
-    <li>
-      <a data-test-invoice href={{invoice.url}}>{{svg-jar 'icon-invoice' class='icon'}} {{invoice.id}} {{moment-format invoice.createdAt 'MMMM YYYY'}}</a>
-    </li>
-    {{/each}}
-  </ul>
-</section>
+  <section class='invoices'>
+    <h2>Invoice History</h2>
+    <p>
+      {{svg-jar 'icon-help' class='icon-help' alt=''}} Having trouble with your invoices?
+      <a href='{{ config.urls.support }}' title='Email the Travis support team' {{action 'helpscoutTrigger'}}>We’re happy to help</a>.
+    </p>
+    <ul>
+      {{#each (sort-by 'createdAt:desc' invoices) as |invoice|}}
+      <li>
+        <a data-test-invoice href={{invoice.url}}>{{svg-jar 'icon-invoice' class='icon'}} {{invoice.id}} {{moment-format invoice.createdAt 'MMMM YYYY'}}</a>
+      </li>
+      {{/each}}
+    </ul>
+  </section>
 {{/if}}

--- a/app/templates/account/billing/index.hbs
+++ b/app/templates/account/billing/index.hbs
@@ -23,8 +23,13 @@
         </section>
       {{/if}}
       <section class='payment'>
-        <h3>Payment details</h3>
-        {{payment-details subscription=model}}
+        {{#if model.isManual}}
+          <h3 class="manual">This is a manual subscription</h3>
+          {{payment-details subscription=model}}
+        {{else}}
+          <h3>Payment details</h3>
+          {{payment-details subscription=model}}
+        {{/if}}
       </section>
     </section>
   {{else if model}}

--- a/app/templates/account/billing/index.hbs
+++ b/app/templates/account/billing/index.hbs
@@ -1,32 +1,36 @@
 <section class='billing'>
-  {{#unless model}} {{new-subscription-button account=account}} {{/unless}} {{#if model.manageSubscription}} {{manage-subscription-button
-  subscription=model account=account}} {{/if}} {{#if model.isSubscribed}} {{#unless model.isManual}}
-  <h2>Plan Overview</h2>
-  <section class='plan'>
-    <h3 data-test-plan-name>{{model.plan.name}}</h3>
-    <p data-test-plan-concurrency>{{pluralize model.plan.builds 'concurrent job'}}</p>
-    <p>Renewing on {{moment-format model.validTo 'MMMM D, YYYY'}}</p>
-  </section>
+  {{#unless model}}
+    {{new-subscription-button account=account}}
   {{/unless}}
-  <h2>Billing Information</h2>
-  <section class='row'>
-    {{#if model.isStripe}}
-    <section class='contact'>
-      <h3>Billing Contact</h3>
-      {{billing-address billingInfo=model.billingInfo}}
+  {{#if model.manageSubscription}}
+    {{manage-subscription-button subscription=model account=account}}
+  {{/if}}
+  {{#if model.isSubscribed}}
+      <h2>Plan Overview</h2>
+      <section class='plan'>
+        <h3 data-test-plan-name>{{model.plan.name}}</h3>
+        <p data-test-plan-concurrency>{{pluralize model.plan.builds 'concurrent job'}}</p>
+        <p>Renewing on {{moment-format model.validTo 'MMMM D, YYYY'}}</p>
+      </section>
+    <h2>Billing Information</h2>
+    <section class='row'>
+      {{#if model.isStripe}}
+      <section class='contact'>
+        <h3>Billing Contact</h3>
+        {{billing-address billingInfo=model.billingInfo}}
+      </section>
+      {{/if}}
+      <section class='payment'>
+        <h3>Payment details</h3>
+        {{payment-details subscription=model}}
+      </section>
     </section>
-    {{/if}}
-    <section class='payment'>
-      <h3>Payment details</h3>
-      {{payment-details subscription=model}}
-    </section>
-  </section>
   {{else if model}}
-  <span data-test-expiry-message>
+  <div data-test-expiry-message>
     {{#if model.isExpired}} You had a {{model.sourceWords}} subscription that expired on {{moment-format model.validTo 'MMMM
     D, YYYY'}}. {{else}} This subscription has been canceled by you and is valid through {{moment-format model.validTo 'MMMM
     D, YYYY'}}. {{/if}} {{#if model.isManual}} {{manual-subscription-help}} {{/if}}
-  </span>
+  </div>
   {{#if model.isResubscribable}} {{resubscribe-button subscription=model account=account}} {{/if}} {{#if model.isGithub}}
   <a href={{config.marketplaceEndpoint}} class='button--blue marketplace-button'>Manage on GitHub Marketplace</a>
   {{/if}} {{/if}}

--- a/app/templates/account/billing/index.hbs
+++ b/app/templates/account/billing/index.hbs
@@ -1,69 +1,50 @@
 <section class='billing'>
-  {{#unless model}}
-    {{new-subscription-button account=account}}
+  {{#unless model}} {{new-subscription-button account=account}} {{/unless}} {{#if model.manageSubscription}} {{manage-subscription-button
+  subscription=model account=account}} {{/if}} {{#if model.isSubscribed}} {{#unless model.isManual}}
+  <h2>Plan Overview</h2>
+  <section class='plan'>
+    <h3 data-test-plan-name>{{model.plan.name}}</h3>
+    <p data-test-plan-concurrency>{{pluralize model.plan.builds 'concurrent job'}}</p>
+    <p>Renewing on {{moment-format model.validTo 'MMMM D, YYYY'}}</p>
+  </section>
   {{/unless}}
-  {{#if model.manageSubscription}}
-    {{manage-subscription-button subscription=model account=account}}
-  {{/if}}
-  {{#if model.isSubscribed}}
-    {{#unless model.isManual}}
-      <h2>Plan Overview</h2>
-      <section class='plan'>
-        <h3 data-test-plan-name>{{model.plan.name}}</h3>
-        <p data-test-plan-concurrency>{{pluralize model.plan.builds 'concurrent job'}}</p>
-        <p>Renewing on {{moment-format model.validTo 'MMMM D, YYYY'}}</p>
-      </section>
-    {{/unless}}
-    <h2>Billing Information</h2>
-    <section class='row'>
-      {{#if model.isStripe}}
-        <section class='contact'>
-          <h3>Billing Contact</h3>
-          {{billing-address billingInfo=model.billingInfo}}
-        </section>
-      {{/if}}
-      <section class='payment'>
-        {{#if model.isManual}}
-          <h3 class="manual">This is a manual subscription</h3>
-          {{payment-details subscription=model}}
-        {{else}}
-          <h3>Payment details</h3>
-          {{payment-details subscription=model}}
-        {{/if}}
-      </section>
+  <h2>Billing Information</h2>
+  <section class='row'>
+    {{#if model.isStripe}}
+    <section class='contact'>
+      <h3>Billing Contact</h3>
+      {{billing-address billingInfo=model.billingInfo}}
     </section>
+    {{/if}}
+    <section class='payment'>
+      <h3>Payment details</h3>
+      {{payment-details subscription=model}}
+    </section>
+  </section>
   {{else if model}}
-    <span data-test-expiry-message>
-      {{#if model.isExpired}}
-        You had a {{model.sourceWords}} subscription that expired on {{moment-format model.validTo 'MMMM D, YYYY'}}.
-      {{else}}
-        This subscription has been canceled by you and is valid through {{moment-format model.validTo 'MMMM D, YYYY'}}.
-      {{/if}}
-      {{#if model.isManual}}
-        {{manual-subscription-help}}
-      {{/if}}
-    </span>
-    {{#if model.isResubscribable}}
-      {{resubscribe-button subscription=model account=account}}
-    {{/if}}
-    {{#if model.isGithub}}
-      <a href={{config.marketplaceEndpoint}} class='button--blue marketplace-button'>Manage on GitHub Marketplace</a>
-    {{/if}}
-  {{/if}}
+  <span data-test-expiry-message>
+    {{#if model.isExpired}} You had a {{model.sourceWords}} subscription that expired on {{moment-format model.validTo 'MMMM
+    D, YYYY'}}. {{else}} This subscription has been canceled by you and is valid through {{moment-format model.validTo 'MMMM
+    D, YYYY'}}. {{/if}} {{#if model.isManual}} {{manual-subscription-help}} {{/if}}
+  </span>
+  {{#if model.isResubscribable}} {{resubscribe-button subscription=model account=account}} {{/if}} {{#if model.isGithub}}
+  <a href={{config.marketplaceEndpoint}} class='button--blue marketplace-button'>Manage on GitHub Marketplace</a>
+  {{/if}} {{/if}}
 </section>
 
 {{#if invoices}}
-  <section class='invoices'>
-    <h2>Invoice History</h2>
-    <p>
-      {{svg-jar 'icon-help' class='icon-help' alt=''}}
-      Having trouble with your invoices?
-      <a href='{{ config.urls.support }}' title='Email the Travis support team' {{action 'helpscoutTrigger'}}>We’re happy to help</a>.
-    </p>
-      <ul>
-        {{#each (sort-by 'createdAt:desc' invoices) as |invoice|}}
-          <li><a data-test-invoice href={{invoice.url}}>{{svg-jar 'icon-invoice' class='icon'}} {{invoice.id}} {{moment-format invoice.createdAt 'MMMM YYYY'}}</a></li>
-        {{/each}}
-      </ul>
-  </section>
+<section class='invoices'>
+  <h2>Invoice History</h2>
+  <p>
+    {{svg-jar 'icon-help' class='icon-help' alt=''}} Having trouble with your invoices?
+    <a href='{{ config.urls.support }}' title='Email the Travis support team' {{action 'helpscoutTrigger'}}>We’re happy to help</a>.
+  </p>
+  <ul>
+    {{#each (sort-by 'createdAt:desc' invoices) as |invoice|}}
+    <li>
+      <a data-test-invoice href={{invoice.url}}>{{svg-jar 'icon-invoice' class='icon'}} {{invoice.id}} {{moment-format invoice.createdAt 'MMMM YYYY'}}</a>
+    </li>
+    {{/each}}
+  </ul>
+</section>
 {{/if}}

--- a/app/templates/account/billing/index.hbs
+++ b/app/templates/account/billing/index.hbs
@@ -15,10 +15,10 @@
     <h2>Billing Information</h2>
     <section class='row'>
       {{#if model.isStripe}}
-      <section class='contact'>
-        <h3>Billing Contact</h3>
-        {{billing-address billingInfo=model.billingInfo}}
-      </section>
+        <section class='contact'>
+          <h3>Billing Contact</h3>
+          {{billing-address billingInfo=model.billingInfo}}
+        </section>
       {{/if}}
       <section class='payment'>
         <h3>Payment details</h3>

--- a/app/templates/components/payment-details.hbs
+++ b/app/templates/components/payment-details.hbs
@@ -1,4 +1,6 @@
-<p class='source' data-test-source>{{source}}</p>
+{{#if subscription.notManual}}
+  <p class='source' data-test-source>{{source}}</p>
+{{/if}}
 
 {{#if subscription.isStripe}}
   <p data-test-credit-card>

--- a/app/templates/components/payment-details.hbs
+++ b/app/templates/components/payment-details.hbs
@@ -1,6 +1,4 @@
-{{#if subscription.notManual}}
-  <p class='source' data-test-source>{{source}}</p>
-{{/if}}
+<p class='source {{if subscription.isManual "manual"}}' data-test-source>{{source}}</p>
 
 {{#if subscription.isStripe}}
   <p data-test-credit-card>

--- a/tests/acceptance/profile/billing-test.js
+++ b/tests/acceptance/profile/billing-test.js
@@ -170,7 +170,6 @@ test('view billing on a manual plan with no invoices', function (assert) {
 
   andThen(() => {
     assert.ok(profilePage.billing.manageButton.isHidden);
-    assert.ok(profilePage.billing.plan.isHidden);
     assert.ok(profilePage.billing.address.isHidden);
     assert.ok(profilePage.billing.creditCardNumber.isHidden);
     assert.ok(profilePage.billing.price.isHidden);


### PR DESCRIPTION
#### What does this PR do?
- Add `Plan Overview` for manual subscriptions
- Make it visually clear that the subscription is a manual subscription

#### Related Issue
[Issue](https://github.com/travis-pro/billing-v2/issues/131)

#### Where should I start?
`app/templates/account/billing/index.hbs`

#### How this PR makes you feel?
![bob_ross](https://user-images.githubusercontent.com/529465/42655491-9ad1a248-85d9-11e8-9f68-23e2ec25a3a4.gif)



