### PR TITLE
[Port to master] Fix issue of localStorage getting cleared too often for the Enterprise License Banner" 

### DIFF
--- a/app/components/enterprise-banner.js
+++ b/app/components/enterprise-banner.js
@@ -33,12 +33,15 @@ export default Component.extend({
         isTrial: response.license_type === 'trial',
         isPaid: response.license_type !== 'trial'
       });
-      if (!this.get('expiring')) {
-        this.get('storage').removeItem(this.get('lsLicense'));
-      }
-      if (!this.get('almostExceeding') && !this.get('exceeding')) {
-        this.get('storage').removeItem(this.get('lsSeats'));
-      }
+
+      // Temporary removing these until we can rework these to be more
+      // emberlike and resiliant to odd timing issues
+      // if (this.get('daysUntilExpiry') && !this.get('expiring')) {
+      //  this.get('storage').removeItem(this.get('lsLicense'));
+      // }
+      // if (!this.get('almostExceedingSeats') && !this.get('exceedingSeats')) {
+      //   this.get('storage').removeItem(this.get('lsSeats'));
+      // }
     });
   },
 


### PR DESCRIPTION
This is port of the changes in https://github.com/travis-ci/travis-web/pull/1671 to `master`

A while back we needed to do a quick fix in `enterprise-2.2` where we made it so banners would be sticky when you closed them. We didn't do this in `master` because ideally we'd rework this to not have some of the timing issues (can see more of the details in the original ticket). 

Unfortunately we don't have the time or manpower to do that at the moment and want to make sure when the next version of Travis CI Enterprise comes out, we don't have a regression of this bug, therefore, I'm porting it to master. :D 

This should not affect hosted what so ever, and is already in production in Enterprise 2.2.1. 