### PR TITLE
Always generate status image tokens in Enterprise 

### DIFF
--- a/app/services/status-images.js
+++ b/app/services/status-images.js
@@ -18,9 +18,9 @@ export default Service.extend({
 
     let slug = repo.get('slug');
 
-    // In Enterprise you can toggle public mode, where even "public" repositories are hidden
-    // in which cases we need to generate a token for all images
-    if (!config.publicMode || repo.get('private')) {
+    // In Enterprise you can toggle enforce authentication where even "public" repositories are hidden
+    // to anonymous users in which cases we need to generate a token for all images
+    if (config.enterprise || repo.get('private')) {
       const token = this.get('auth').assetToken();
       return `${prefix}/${slug}.svg?token=${token}${branch ? `&branch=${branch}` : ''}`;
     } else {

--- a/app/services/status-images.js
+++ b/app/services/status-images.js
@@ -18,8 +18,8 @@ export default Service.extend({
 
     let slug = repo.get('slug');
 
-    // In Enterprise you can toggle enforce authentication where even "public" repositories are hidden
-    // to anonymous users in which cases we need to generate a token for all images
+    // In Enterprise you can toggle enforce authentication where even "public" repositories are
+    // hidden to anonymous users in which cases we need to generate a token for all images
     if (config.enterprise || repo.get('private')) {
       const token = this.get('auth').assetToken();
       return `${prefix}/${slug}.svg?token=${token}${branch ? `&branch=${branch}` : ''}`;

--- a/tests/unit/services/status-images-test.js
+++ b/tests/unit/services/status-images-test.js
@@ -34,12 +34,12 @@ module('Unit | Service | status images', function (hooks) {
     assert.equal(url, `${root}/travis-ci/travis-web.svg?token=token-abc-123`);
   });
 
-  test('it generates an image url with a token for a repo when publicMode is false', function (assert) {
+  test('it generates an image url with a token for a repo when enterprise is true', function (assert) {
     const service = this.owner.lookup('service:status-images');
-    config.publicMode = false;
+    config.enterprise = true;
     const url = service.imageUrl(this.repo);
     assert.equal(url, `${root}/travis-ci/travis-web.svg?token=token-abc-123`);
-    config.publicMode = true;
+    config.enterprise = false;
   });
 
   test('it generates an image url with a repo', function (assert) {


### PR DESCRIPTION
This is a follow up to https://github.com/travis-ci/travis-web/pull/1677 and related to https://github.com/travis-ci/travis-api/pull/802

Previously we had Enterprise using `public_mode` to toggle if you have to login to see "Public" repositories. Turns out this isn't exactly how `public_mode` works and we had to switch approaches. Now `public_mode` is always on, but we still need to generate tokens as sometimes Enterprise can be configured to require login or not. 

This PR pegs the token generation for status images to the `enterprise` config var, so we always place a token for status images. 