### PR TITLE
[Backport] Always generate status image tokens in Enterprise (#1724)

### DIFF
--- a/app/services/status-images.js
+++ b/app/services/status-images.js
@@ -18,9 +18,9 @@ export default Service.extend({
 
     let slug = repo.get('slug');
 
-    // In Enterprise you can toggle public mode, where even "public" repositories are hidden
-    // in which cases we need to generate a token for all images
-    if (!config.publicMode || repo.get('private')) {
+    // In Enterprise you can toggle enforce authentication where even "public" repositories are hidden
+    // to anonymous users in which cases we need to generate a token for all images
+    if (config.enterprise || repo.get('private')) {
       const token = this.get('auth').assetToken();
       return `${prefix}/${slug}.svg?token=${token}${branch ? `&branch=${branch}` : ''}`;
     } else {

--- a/app/services/status-images.js
+++ b/app/services/status-images.js
@@ -18,8 +18,8 @@ export default Service.extend({
 
     let slug = repo.get('slug');
 
-    // In Enterprise you can toggle enforce authentication where even "public" repositories are hidden
-    // to anonymous users in which cases we need to generate a token for all images
+    // In Enterprise you can toggle enforce authentication where even "public" repositories are
+    // hidden to anonymous users in which cases we need to generate a token for all images
     if (config.enterprise || repo.get('private')) {
       const token = this.get('auth').assetToken();
       return `${prefix}/${slug}.svg?token=${token}${branch ? `&branch=${branch}` : ''}`;

--- a/tests/unit/services/status-images-test.js
+++ b/tests/unit/services/status-images-test.js
@@ -33,12 +33,12 @@ test('it generates an image url with a token for a private repo', function (asse
   assert.equal(url, `${root}/travis-ci/travis-web.svg?token=token-abc-123`);
 });
 
-test('it generates an image url with a token for a repo when publicMode is false', function (assert) {
+test('it generates an image url with a token for a repo when enterprise is true', function (assert) {
   const service = this.subject();
-  config.publicMode = false;
+  config.enterprise = true;
   const url = service.imageUrl(this.repo);
   assert.equal(url, `${root}/travis-ci/travis-web.svg?token=token-abc-123`);
-  config.publicMode = true;
+  config.enterprise = false;
 });
 
 test('it generates an image url with a repo', function (assert) {


### PR DESCRIPTION
Backport of (#1724) for `enterprise-2.2`

