### PR TITLE
Revert to Ember Data 3.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8070,9 +8070,9 @@
       }
     },
     "ember-data": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-3.2.1.tgz",
-      "integrity": "sha512-SrDBV1Y4H23janMEx53Vh5LSZTI/405tcKkCGCxCHnc+WN1tr58M/LvTfbO+9dJtqDKY77HcLy7L1HqkRmp5nA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-3.1.1.tgz",
+      "integrity": "sha512-fEoD80XZtu3U/iebFCNnqy+w0X9SD7oAtTJdLISlHJp872FfKV3UurdD098AJoGfDHy6FCZvCwjq0m4ZS+v+bw==",
       "dev": true,
       "requires": {
         "@ember/ordered-set": "^1.0.0",
@@ -8086,7 +8086,7 @@
         "broccoli-babel-transpiler": "^6.0.0",
         "broccoli-debug": "^0.6.2",
         "broccoli-file-creator": "^1.0.0",
-        "broccoli-funnel": "^2.0.1",
+        "broccoli-funnel": "^1.2.0",
         "broccoli-merge-trees": "^2.0.0",
         "broccoli-rollup": "^1.2.0",
         "calculate-cache-key-for-tree": "^1.1.0",
@@ -8098,6 +8098,7 @@
         "ember-cli-version-checker": "^2.1.0",
         "ember-inflector": "^2.0.0",
         "ember-runtime-enumerable-includes-polyfill": "^2.0.0",
+        "exists-sync": "0.0.3",
         "git-repo-info": "^1.1.2",
         "heimdalljs": "^0.3.0",
         "inflection": "^1.8.0",
@@ -8165,6 +8166,91 @@
             "json-stable-stringify": "^1.0.0",
             "rsvp": "^4.8.2",
             "workerpool": "^2.3.0"
+          },
+          "dependencies": {
+            "broccoli-funnel": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz",
+              "integrity": "sha512-C8Lnp9TVsSSiZMGEF16C0dCiNg2oJqUKwuZ1K4kVC6qRPG/2Cj/rtB5kRCC9qEbwqhX71bDbfHROx0L3J7zXQg==",
+              "dev": true,
+              "requires": {
+                "array-equal": "^1.0.0",
+                "blank-object": "^1.0.1",
+                "broccoli-plugin": "^1.3.0",
+                "debug": "^2.2.0",
+                "fast-ordered-set": "^1.0.0",
+                "fs-tree-diff": "^0.5.3",
+                "heimdalljs": "^0.2.0",
+                "minimatch": "^3.0.0",
+                "mkdirp": "^0.5.0",
+                "path-posix": "^1.0.0",
+                "rimraf": "^2.4.3",
+                "symlink-or-copy": "^1.0.0",
+                "walk-sync": "^0.3.1"
+              }
+            },
+            "heimdalljs": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.5.tgz",
+              "integrity": "sha1-aqVDCO7nk7ZCz/nPlHgURfN3MKw=",
+              "dev": true,
+              "requires": {
+                "rsvp": "~3.2.1"
+              },
+              "dependencies": {
+                "rsvp": {
+                  "version": "3.2.1",
+                  "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+                  "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "broccoli-funnel": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz",
+          "integrity": "sha1-zdw6/F/xaFqAI0iP/3TOb7WlEpY=",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "exists-sync": "0.0.4",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          },
+          "dependencies": {
+            "exists-sync": {
+              "version": "0.0.4",
+              "resolved": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.4.tgz",
+              "integrity": "sha1-l0TCxCjMA7AQYNtFTUsS8O88iHk=",
+              "dev": true
+            },
+            "heimdalljs": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.5.tgz",
+              "integrity": "sha1-aqVDCO7nk7ZCz/nPlHgURfN3MKw=",
+              "dev": true,
+              "requires": {
+                "rsvp": "~3.2.1"
+              }
+            },
+            "rsvp": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+              "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo=",
+              "dev": true
+            }
           }
         },
         "broccoli-merge-trees": {
@@ -8201,6 +8287,12 @@
             "resolve": "^1.3.3",
             "semver": "^5.3.0"
           }
+        },
+        "exists-sync": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.3.tgz",
+          "integrity": "sha1-uRAAC+27ETs3i4L19adjgQdiLc8=",
+          "dev": true
         },
         "hash-for-dep": {
           "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "ember-cli-uglify": "^2.0.0",
     "ember-composable-helpers": "^2.1.0",
     "ember-concurrency": "^0.8.15",
-    "ember-data": "~3.2.0",
+    "ember-data": "~3.1.1",
     "ember-data-filter": "ember-data/ember-data-filter#v2.0.0",
     "ember-decorators": "^1.3.4",
     "ember-exam": "1.0.0",


### PR DESCRIPTION
There’s something wrong with adapter:request where it can no
longer determine the relevant repository id when fetching
the parsing messages.