### PR TITLE
Add unsubscribe to mock Pusher

### DIFF
--- a/app/utils/pusher.js
+++ b/app/utils/pusher.js
@@ -18,6 +18,7 @@ TravisPusher.prototype.init = function (config, ajaxService) {
           bind_global() {}
         };
       },
+      unsubscribe() {},
       channel() {}
     };
   }


### PR DESCRIPTION
The absence of this causes spurious failures in tests.