### PR TITLE
Add ability to turn off log-rendering

### DIFF
--- a/app/models/log.js
+++ b/app/models/log.js
@@ -10,6 +10,7 @@ import { task } from 'ember-concurrency';
 export default EmberObject.extend({
   @service features: null,
   @service auth: null,
+  @service storage: null,
 
   version: 0,
   length: 0,
@@ -56,7 +57,13 @@ export default EmberObject.extend({
     } else {
       throw 'error';
     }
-    this.loadParts(json['log_parts']);
+
+    if (this.get('storage').getItem('travis.logRendering') === 'false') {
+      let text = "Log rendering is off because localStorage['travis.logRendering'] is `false`.";
+      this.loadParts([{content: `${text}\r\n`, number: 0, final: true}]);
+    } else {
+      this.loadParts(json['log_parts']);
+    }
     this.set('plainTextUrl', json['@raw_log_href']);
   }),
 

--- a/tests/acceptance/job/basic-layout-test.js
+++ b/tests/acceptance/job/basic-layout-test.js
@@ -308,3 +308,32 @@ travis_fold:end:afold
 
   percySnapshot(assert);
 });
+
+test('visiting a job when log-rendering is off', function (assert) {
+  localStorage.setItem('travis.logRendering', false);
+
+  let repo =  server.create('repository', { slug: 'travis-ci/travis-web' }),
+    branch = server.create('branch', { name: 'acceptance-tests' });
+
+  let  gitUser = server.create('git-user', { name: 'Mr T' });
+  let commit = server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
+  let build = server.create('build', { repository: repo, state: 'passed', commit, branch });
+  let job = server.create('job', { number: '1234.1', repository: repo, state: 'passed', commit, build });
+  commit.job = job;
+
+  job.save();
+  commit.save();
+
+  const log = 'I am a log that won’t render.';
+  server.create('log', { id: job.id, content: log });
+
+  jobPage.visit();
+
+  // An unfortunate workaround for log displaying being outside Ember facilities.
+  // eslint-disable-next-line
+  waitForElement('.log-container .log-line');
+
+  andThen(function () {
+    assert.equal(jobPage.logLines[0].text, "Log rendering is off because localStorage['travis.logRendering'] is `false`.");
+  });
+});


### PR DESCRIPTION
While it would be preferable to improve log-rendering speeds,
we probably won’t have time for that for a while.