### PR TITLE
Fix build job list alignment issue

### DIFF
--- a/app/styles/app/layouts/jobs.scss
+++ b/app/styles/app/layouts/jobs.scss
@@ -238,11 +238,11 @@
     }
 
     .job-env {
-      flex: 0 0 21em;
+      flex: 0 0 21.5em;
     }
 
     .job-lang {
-      flex: 0 0 21em;
+      flex: 0 0 21.5em;
     }
   }
 }

--- a/app/styles/app/layouts/jobs.scss
+++ b/app/styles/app/layouts/jobs.scss
@@ -31,6 +31,7 @@
       justify-content: flex-start;
       align-items: center;
       height: 34px;
+      min-width: 0;
     }
   }
 


### PR DESCRIPTION
Previously you could see this issue when viewing travis-ci/gimme.

Looks like it was due to a quirk of flexbox children with `white-space: nowrap;`. By default flex items won't become smaller than their contents. Setting `min-width: 0;` on the parent resolves the issue.