### PR TITLE
Fix alignment of branch name in requests

### DIFF
--- a/app/templates/components/requests-item.hbs
+++ b/app/templates/components/requests-item.hbs
@@ -6,10 +6,10 @@
   {{request-icon event=request.event_type state=requestClass}}
   <span class="label-align m-l-s" data-requests-item-related-model>
     {{#if request.isPullRequest}}
-      <strong class="label-align">#{{build.pullRequestNumber}}</strong>
+      <strong>#{{build.pullRequestNumber}}</strong>
     {{/if}}
     {{#if request.branchName}}
-      <strong class="label-align">{{request.branchName}}</strong>
+      <strong>{{request.branchName}}</strong>
     {{/if}}
     {{#if request.commit}}
       {{github-commit-link request.repo.slug request.commit.sha}}


### PR DESCRIPTION
Looks like this is due to nested elements with middle vertical align. I think the label-align class on the strong elements is superfluous, so I removed them. But if that's not the case, we could instead add some css to override the vertical align.