### PR TITLE
Add deprecation message for Xcode 6.4

### DIFF
--- a/app/components/job-infrastructure-notification.js
+++ b/app/components/job-infrastructure-notification.js
@@ -75,7 +75,9 @@ export default Component.extend({
   @computed('job.startedAt', 'macOSImage', 'job.isFinished', 'conjugatedRun', 'isDeprecatedOrRetiredMacImage')
   deprecatedOrRetiredMacImageMessage(startedAt, image, isFinished, conjugatedRun) {
     if (image === 'xcode6.4') {
-      return `Running builds with Xcode 6.4 in Travis CI is deprecated and will be removed in January 2019. If Xcode 6.4 is critical to your builds, please contact our support team at <a href="mailto:support@travis-ci.com">support@travis-ci.com</a> to discuss options.`;
+      return `Running builds with Xcode 6.4 in Travis CI is deprecated and will be
+removed in January 2019. If Xcode 6.4 is critical to your builds, please contact our support team
+at <a href="mailto:support@travis-ci.com">support@travis-ci.com</a> to discuss options.`;
     }
 
     const retirementDate = Date.parse(this.get('imageToRetirementDate')[image]);

--- a/app/components/job-infrastructure-notification.js
+++ b/app/components/job-infrastructure-notification.js
@@ -48,7 +48,7 @@ export default Component.extend({
 
   @alias('jobConfig.osx_image') macOSImage: null,
 
-  deprecatedXcodeImages: ['xcode8.1', 'xcode8.2'],
+  deprecatedXcodeImages: ['xcode8.1', 'xcode8.2', 'xcode6.4'],
 
   imageToRetirementDate: {
     'xcode8.1': NOVEMBER_2017_RETIREMENT,
@@ -74,6 +74,10 @@ export default Component.extend({
   // eslint-disable-next-line
   @computed('job.startedAt', 'macOSImage', 'job.isFinished', 'conjugatedRun', 'isDeprecatedOrRetiredMacImage')
   deprecatedOrRetiredMacImageMessage(startedAt, image, isFinished, conjugatedRun) {
+    if (image === 'xcode6.4') {
+      return `Running builds with Xcode 6.4 in Travis CI is deprecated and will be removed in January 2019. If Xcode 6.4 is critical to your builds, please contact our support team at <a href="mailto:support@travis-ci.com">support@travis-ci.com</a> to discuss options.`;
+    }
+
     const retirementDate = Date.parse(this.get('imageToRetirementDate')[image]);
 
     const newImage = this.get('imageToNewImage')[image];


### PR DESCRIPTION
Adds a message at the top of jobs that use Xcode 6.4 to call out that we are planning to deprecate the image.

Some previous discussion on this:
- https://github.com/travis-ci/product/issues/26
- https://github.com/travis-ci/travis-build/pull/1454