### PR TITLE
Reorganize and add plans and pricing to footer

### DIFF
--- a/app/styles/app/layouts/footer.scss
+++ b/app/styles/app/layouts/footer.scss
@@ -85,7 +85,6 @@ $styleguide-medium: 800px;
     margin-top: 1.5rem;
   }
   @media (min-width: $styleguide-medium) {
-    flex: 0 1 (100% - 2% * 6) * 1 / 6;
     padding-right: 2%;
     &:last-of-type {
       padding-right: 0;

--- a/app/templates/components/page-footer.hbs
+++ b/app/templates/components/page-footer.hbs
@@ -13,6 +13,9 @@
       <address>Rigaer Straße 8<br>10247 Berlin, Germany</address>
       <ul>
         <li><a data-test-footer-jobs-link href="{{ config.urls.jobs }}" title="Jobs at Travis CI">Work with Travis CI</a></li>
+        <li><a data-test-footer-blog-link href="{{ config.urls.blog }}" title="Travis CI Blog">Blog</a></li>
+        <li><a data-test-footer-support-link href="{{ config.urls.support }}" title="Email Travis CI support">Email</a></li>
+        <li><a data-test-footer-twitter-link href="{{ config.urls.twitter }}" title="Travis CI on Twitter">Twitter</a></li>
       </ul>
     </div>
   {{/unless}}
@@ -21,11 +24,11 @@
     <ul>
       <li><a href="{{ config.urls.docs }}" title="Travis CI Docs">Documentation</a></li>
       {{#unless features.enterpriseVersion}}
-        <li><a data-test-footer-blog-link href="{{ config.urls.community }}" title="Travis CI Community">Community</a></li>
-        <li><a data-test-footer-blog-link href="{{ config.urls.changelog }}" title="Travis CI Changelog">Changelog</a></li>
-        <li><a data-test-footer-blog-link href="{{ config.urls.blog }}" title="Travis CI Blog">Blog</a></li>
-        <li><a data-test-footer-support-link href="{{ config.urls.support }}" title="Email Travis CI support">Email</a></li>
-        <li><a data-test-footer-twitter-link href="{{ config.urls.twitter }}" title="Travis CI on Twitter">Twitter</a></li>
+        <li><a data-test-footer-community-link href="{{ config.urls.community }}" title="Travis CI Community">Community</a></li>
+        <li><a data-test-footer-changelog-link href="{{ config.urls.changelog }}" title="Travis CI Changelog">Changelog</a></li>
+        {{#if features.proVersion}}
+          <li><a data-test-footer-plans-link href="{{ config.urls.plans }}" title="Travis CI Plans">Plans and Pricing</a></li>
+        {{/if}}
       {{/unless}}
     </ul>
   </div>

--- a/config/environment.js
+++ b/config/environment.js
@@ -47,6 +47,7 @@ module.exports = function (environment) {
       enterprise: 'https://enterprise.travis-ci.com',
       imprint: 'https://docs.travis-ci.com/imprint.html',
       jobs: 'https://travisci.workable.com/',
+      plans: 'https://travis-ci.com/plans',
       privacy: 'https://docs.travis-ci.com/legal/privacy-policy',
       security: 'https://docs.travis-ci.com/legal/security',
       status: 'https://www.traviscistatus.com/',


### PR DESCRIPTION
#### What does this PR do?
- Add `plans and pricing` link to footer for `.com`
- Reorganize footer links

#### Related Issue
[49](https://github.com/travis-ci/product/issues/49)
 
#### Where should I start?
`app/templates/components/page-footer.hbs`

#### How this PR makes you feel?
![sounds_good](https://user-images.githubusercontent.com/529465/45554336-62f59e00-b7f3-11e8-9f39-552a18a5c22e.gif)

