### PR TITLE
Add workaround to preserve user installation

### DIFF
--- a/app/controllers/account/repositories.js
+++ b/app/controllers/account/repositories.js
@@ -1,6 +1,7 @@
 import { computed, action } from 'ember-decorators/object';
 import Controller from '@ember/controller';
 import { service } from 'ember-decorators/service';
+import { controller } from 'ember-decorators/controller';
 import config from 'travis/config/environment';
 
 import window from 'ember-window-mock';
@@ -12,6 +13,7 @@ import { alias } from 'ember-decorators/object/computed';
 export default Controller.extend({
   @service features: null,
   @service store: null,
+  @controller('accounts') accountsController: null,
 
   page: 1,
   'apps-page': 1,
@@ -51,8 +53,13 @@ export default Controller.extend({
     }
   },
 
-  @computed('account.id')
-  hasGitHubAppsInstallation(installationId) {
+  @computed('account.id', 'accountsController.userInstallation', 'account.type')
+  hasGitHubAppsInstallation(installationId, userInstallation, accountType) {
+    // See controllers:accounts#setupController for explanation.
+    if (accountType === 'user' && userInstallation) {
+      return true;
+    }
+
     // this lets us check for the presence of an installation without trying to fetch it
     return !!this.get('account').belongsTo('installation').id();
   },

--- a/app/routes/accounts.js
+++ b/app/routes/accounts.js
@@ -80,6 +80,16 @@ export default TravisRoute.extend({
     orgs = model.filterBy('type', 'organization');
     controller.set('user', user);
     controller.set('organizations', orgs);
+
+    /**
+     * This preserves the user’s installation which gets somehow overwritten
+     * before account/repositories gets to render. This started with #1782;
+     * specifically, the createdBy: belongsTo('user') relationship on a build.
+     */
+    if (user.belongsTo('installation').id()) {
+      controller.set('userInstallation', user.get('installation'));
+    }
+
     return controller.set('model', model);
   },
 });


### PR DESCRIPTION
User installations are somehow being deleted since the
merger of #1782. While my true desire is to figure out
why that’s the case, this is a workaround in the meantime,
as the serialiser code that’s likely responsible is often
still quite opaque to me.