### PR TITLE
fix display of errors in web tracing panel (naming conflict with global .error)

### DIFF
--- a/app/styles/app/modules/tracer.scss
+++ b/app/styles/app/modules/tracer.scss
@@ -62,7 +62,7 @@
   .status {
     color: #A8FF60;
   }
-  .status.error {
+  .status.err {
     color: #FF857F;
   }
   .duration {

--- a/app/templates/components/x-tracer.hbs
+++ b/app/templates/components/x-tracer.hbs
@@ -10,7 +10,7 @@
       <tr>
         <td class="method">{{req.method}}</td>
         <td class="url">{{req.url}}</td>
-        <td class="status {{if req.error 'error'}}">{{req.status}}</td>
+        <td class="status {{if req.error 'err'}}">{{req.status}}</td>
         <td class="duration">{{req.duration}}ms</td>
         <td class="request-id">
           {{#if req.requestId}}


### PR DESCRIPTION
A naming conflict with the global `.error` class was adding a lot of extra padding.

Before:

![screen shot 2018-09-24 at 13 32 11](https://user-images.githubusercontent.com/11158255/45950028-4e3cb580-bffe-11e8-9df7-60f75406e413.png)

After:

![screen shot 2018-09-24 at 13 32 46](https://user-images.githubusercontent.com/11158255/45950037-5b59a480-bffe-11e8-8b73-3d48bd6dc4e2.png)
