### PR TITLE
Make build-jobs loading conditional

### DIFF
--- a/app/adapters/build.js
+++ b/app/adapters/build.js
@@ -1,7 +1,7 @@
 import V3Adapter from 'travis/adapters/v3';
 import Ember from 'ember';
 
-let includes = 'build.commit,build.branch,build.request,build.created_by,build.jobs';
+let includes = 'build.commit,build.branch,build.request,build.created_by';
 
 // TODO this is a workaround for an infinite loop in Mirage serialising 😞
 if (!Ember.testing) {

--- a/app/models/repo.js
+++ b/app/models/repo.js
@@ -90,7 +90,6 @@ const Repo = Model.extend({
     const builds = this.store.filter('build', {
       event_type: ['push', 'api', 'cron'],
       repository_id: id,
-      limit: 10 // TODO Remove the limit after the API fix loading issue
     }, (b) => {
       let eventTypes = ['push', 'api', 'cron'];
       return this._buildRepoMatches(b, id) && eventTypes.includes(b.get('eventType'));
@@ -103,7 +102,6 @@ const Repo = Model.extend({
     const builds = this.store.filter('build', {
       event_type: 'pull_request',
       repository_id: id,
-      limit: 10 // TODO Remove the limit after the API fix loading issue
     }, (b) => {
       const isPullRequest = b.get('eventType') === 'pull_request';
       return this._buildRepoMatches(b, id) && isPullRequest;

--- a/app/routes/dashboard/builds.js
+++ b/app/routes/dashboard/builds.js
@@ -9,7 +9,8 @@ export default TravisRoute.extend({
     let eventTypes = ['api', 'pull_request', 'push'];
     let query = {
       limit: 30,
-      event_type: eventTypes.join(',')
+      event_type: eventTypes.join(','),
+      include: 'build.jobs'
     };
 
     return this.store.filter('build', query, build =>


### PR DESCRIPTION
The inclusion of a build’s jobs is needed on “My Builds“ to
determine whether builds can be restarted, but it caused
other builds queries to slow down.