### PR TITLE
Add logic and messaging for educational users in billing

### DIFF
--- a/app/controllers/account/billing/index.js
+++ b/app/controllers/account/billing/index.js
@@ -23,6 +23,13 @@ export default Controller.extend({
     }
   },
 
+  @computed('model', 'account')
+  isTrial(model, account) {
+    if(!model.subscriptions) {
+      return !model.subscriptions && !account.education;
+    }
+  },
+
   @action
   helpscoutTrigger() {
     HS.beacon.open();

--- a/app/controllers/account/billing/index.js
+++ b/app/controllers/account/billing/index.js
@@ -24,6 +24,13 @@ export default Controller.extend({
   },
 
   @computed('model', 'account')
+  isEducation(model, account) {
+    if (!model.subscriptions) {
+      return !model.subscriptions && account.education;
+    }
+  },
+
+  @computed('model', 'account')
   isTrial(model, account) {
     if (!model.subscriptions) {
       return !model.subscriptions && !account.education;

--- a/app/controllers/account/billing/index.js
+++ b/app/controllers/account/billing/index.js
@@ -25,7 +25,7 @@ export default Controller.extend({
 
   @computed('model', 'account')
   isTrial(model, account) {
-    if(!model.subscriptions) {
+    if (!model.subscriptions) {
       return !model.subscriptions && !account.education;
     }
   },

--- a/app/templates/account/billing/index.hbs
+++ b/app/templates/account/billing/index.hbs
@@ -1,8 +1,8 @@
 <section class='billing'>
-  {{#if account.education}}
-    {{billing-subscription model=model account=account config=config}}
+  {{#if isEducation}}
+    {{billing-education model=model account=account config=config}}
   {{/if}}
-  
+
   {{#if isTrial}}
     {{billing-trial model=model account=account config=config}}
   {{/if}}

--- a/app/templates/account/billing/index.hbs
+++ b/app/templates/account/billing/index.hbs
@@ -1,7 +1,11 @@
 <section class='billing'>
-  {{#unless model.subscriptions}}
+  {{#if account.education}}
+    {{billing-subscription model=model account=account config=config}}
+  {{/if}}
+  
+  {{#if isTrial}}
     {{billing-trial model=model account=account config=config}}
-  {{/unless}}
+  {{/if}}
 
   {{#if model.subscriptions.isManual}}
     {{billing-manual model=model}}

--- a/app/templates/components/billing-education.hbs
+++ b/app/templates/components/billing-education.hbs
@@ -1,6 +1,4 @@
 <h2>Plan Overview</h2>
-<section class='plan'>
-  <p data-test-education-message class="source plan-status-message">This is an educational account and includes a single build plan. <br /> Need help? <a data-test-trial-link href={{config.urls.gettingStarted}} class="billing-section-link">Check our
-    getting started guide</a></p>
-  {{new-subscription-button account=account}}
-</section>
+<p data-test-education-message class="source plan-status-message">This is an educational account and includes a single build plan. <br /> Need help? <a data-test-trial-link href={{config.urls.gettingStarted}} class="billing-section-link">Check our
+  getting started guide</a></p>
+{{new-subscription-button account=account}}

--- a/app/templates/components/billing-education.hbs
+++ b/app/templates/components/billing-education.hbs
@@ -1,0 +1,6 @@
+<h2>Plan Overview</h2>
+<section class='plan'>
+  <p data-test-education-message class="source plan-status-message">This is an educational account and includes a single build plan. <br /> Need help? <a data-test-trial-link href={{config.urls.gettingStarted}} class="billing-section-link">Check our
+    getting started guide</a></p>
+  {{new-subscription-button account=account}}
+</section>

--- a/app/templates/components/billing-subscription.hbs
+++ b/app/templates/components/billing-subscription.hbs
@@ -52,10 +52,3 @@
     {{new-subscription-button account=account}}
   {{/if}}
 {{/if}}
-{{#if account.education}}
-  <h2>Plan Overview</h2>
-  <section class='plan'>
-    <p data-test-trial-message class="source plan-status-message">This is an educational subscription</p>
-    {{new-subscription-button account=account}}
-  </section>
-{{/if}}

--- a/app/templates/components/billing-subscription.hbs
+++ b/app/templates/components/billing-subscription.hbs
@@ -52,3 +52,10 @@
     {{new-subscription-button account=account}}
   {{/if}}
 {{/if}}
+{{#if account.education}}
+  <h2>Plan Overview</h2>
+  <section class='plan'>
+    <p data-test-trial-message class="source plan-status-message">This is an educational subscription</p>
+    {{new-subscription-button account=account}}
+  </section>
+{{/if}}

--- a/tests/acceptance/profile/billing-test.js
+++ b/tests/acceptance/profile/billing-test.js
@@ -510,3 +510,21 @@ test('view billing tab with Github trial subscription has ended', function (asse
     assert.ok(profilePage.billing.annualInvitation.isHidden);
   });
 });
+
+test('view billing tab on education account', function (assert) {
+  this.subscription = null;
+  this.organization.attrs.education = true;
+  this.organization.permissions = { createSubscription: true };
+  this.organization.save();
+
+  profilePage.visit({
+    username: 'org-login'
+  });
+  profilePage.billing.visit();
+
+  andThen(() => {
+    percySnapshot(assert);
+    assert.equal(profilePage.billing.education.name, 'This is an educational account and includes a single build plan. Need help? Check our getting started guide');
+    assert.equal(profilePage.billing.manageButton.text, 'New subscription');
+  });
+});

--- a/tests/pages/profile.js
+++ b/tests/pages/profile.js
@@ -190,6 +190,11 @@ export default create({
       }
     },
 
+    education: {
+      scope: '.billing',
+      name: text('[data-test-education-message]'),
+    },
+
     address: {
       scope: '.contact .address',
     },


### PR DESCRIPTION
#### What does this PR do?
- Add logic to consider educational users
- Add new message for educational users

#### Related Issue
[2822](https://github.com/travis-pro/team-teal/issues/2822)
 
#### Where should I start?
` app/controllers/account/billing/index.js`

#### How this PR makes you feel?
![school](https://user-images.githubusercontent.com/529465/46124063-0de85d80-c1df-11e8-9f5d-4b1b08fd4e34.gif)


