### PR TITLE
Silence additional deprecation warnings

### DIFF
--- a/config/deprecation-workflow.js
+++ b/config/deprecation-workflow.js
@@ -2,8 +2,8 @@
 window.deprecationWorkflow = window.deprecationWorkflow || {};
 window.deprecationWorkflow.config = {
   workflow: [
-    { handler: "silence", matchId: "macro-computed-deprecated" },
-    { handler: "silence", matchId: "ember-routing.route-router" },
-    { handler: "silence", matchId: "ember-component.send-action" }
+    { handler: 'silence', matchId: 'macro-computed-deprecated' },
+    { handler: 'silence', matchId: 'ember-routing.route-router' },
+    { handler: 'silence', matchId: 'ember-component.send-action' }
   ]
 };

--- a/config/deprecation-workflow.js
+++ b/config/deprecation-workflow.js
@@ -2,6 +2,8 @@
 window.deprecationWorkflow = window.deprecationWorkflow || {};
 window.deprecationWorkflow.config = {
   workflow: [
-    { handler: 'silence', matchId: 'macro-computed-deprecated' },
+    { handler: "silence", matchId: "macro-computed-deprecated" },
+    { handler: "silence", matchId: "ember-routing.route-router" },
+    { handler: "silence", matchId: "ember-component.send-action" }
   ]
 };


### PR DESCRIPTION
This is currently clogging the output in tests/development, turning down the noise for now.