### PR TITLE
Extend test coverage to cover recent regression

### DIFF
--- a/tests/acceptance/home/with-repositories-test.js
+++ b/tests/acceptance/home/with-repositories-test.js
@@ -161,7 +161,7 @@ test('Pusher events change the main display', function (assert) {
       id: job.id,
       number: 0,
       final: false,
-      _log: '\u001B[0K\u001B[33;1mThe first line'
+      _log: '\u001B[0K\u001B[33;1mThe first line\n'
     });
   });
 

--- a/tests/acceptance/job/basic-layout-test.js
+++ b/tests/acceptance/job/basic-layout-test.js
@@ -207,7 +207,9 @@ I am another line finished by a CR.\rI replace that line?\r${ESCAPE}[0mI am the 
 This should also be gone.\r This should have replaced it.
 A particular log formation is addressed here, this should remain.\r${ESCAPE}[0m\nThis should be on a separate line.
 But it must be addressed repeatedly!\r${ESCAPE}[0m\nAgain.
+[${ESCAPE}[90m21:09:37${ESCAPE}[39m] ${ESCAPE}[32mRunning tests on 3 Sauce Labs browser(s)...${ESCAPE}[39m
 `;
+
   server.create('log', { id: job.id, content: complexLog });
 
   jobPage.visit();
@@ -219,19 +221,19 @@ But it must be addressed repeatedly!\r${ESCAPE}[0m\nAgain.
   jobPage.toggleLog();
 
   andThen(function () {
-    assert.equal(jobPage.logLines[0].text, 'I am the first line.');
+    assert.equal(jobPage.logLines[0].entireLineText, 'I am the first line.');
 
     assert.equal(jobPage.logFolds[0].name, 'afold');
     assert.notOk(jobPage.logFolds[0].isOpen);
 
-    assert.equal(jobPage.logLines[1].text, 'I am the first line of a fold.');
+    assert.equal(jobPage.logLines[1].entireLineText, 'I am the first line of a fold.');
 
     assert.equal(jobPage.logLines[2].text, 'I am the second line of a fold.');
 
-    assert.equal(jobPage.logLines[3].text, 'I am a line between folds.');
+    assert.equal(jobPage.logLines[3].entireLineText, 'I am a line between folds.');
 
     assert.equal(jobPage.logFolds[0].name, 'afold');
-    assert.equal(jobPage.logLines[4].text, 'I am the first line of a second fold.');
+    assert.equal(jobPage.logLines[4].entireLineText, 'I am the first line of a second fold.');
 
     assert.ok(jobPage.logLines[5].isBlack);
     assert.ok(jobPage.logLines[5].hasWhiteBackground);
@@ -262,18 +264,18 @@ But it must be addressed repeatedly!\r${ESCAPE}[0m\nAgain.
 
     assert.ok(jobPage.logLines[13].isGrey);
 
-    assert.equal(jobPage.logLines[14].text, 'I used to be the final line.');
+    assert.equal(jobPage.logLines[14].entireLineText, 'I used to be the final line.');
 
-    // FIXME why is this line in an adjacent span?
-    assert.equal(jobPage.logLines[15].nextText, 'I am the final replacer.');
-    assert.equal(jobPage.logLines[16].text, 'I do not replace because the previous line ended with a line feed.');
+    assert.equal(jobPage.logLines[15].entireLineText, 'I am the final replacer.');
+    assert.equal(jobPage.logLines[16].entireLineText, 'I do not replace because the previous line ended with a line feed.');
 
-    assert.equal(jobPage.logLines[17].nextText, 'This should have replaced it.');
+    assert.equal(jobPage.logLines[17].entireLineText, 'This should have replaced it.');
 
-    assert.equal(jobPage.logLines[18].text, 'A particular log formation is addressed here, this should remain.');
-    assert.equal(jobPage.logLines[19].text, 'This should be on a separate line.');
-    assert.equal(jobPage.logLines[20].text, 'But it must be addressed repeatedly!');
-    assert.equal(jobPage.logLines[21].text, 'Again.');
+    assert.equal(jobPage.logLines[18].entireLineText, 'A particular log formation is addressed here, this should remain.');
+    assert.equal(jobPage.logLines[19].entireLineText, 'This should be on a separate line.');
+    assert.equal(jobPage.logLines[20].entireLineText, 'But it must be addressed repeatedly!');
+    assert.equal(jobPage.logLines[21].entireLineText, 'Again.');
+    assert.equal(jobPage.logLines[22].entireLineText, '[21:09:37] Running tests on 3 Sauce Labs browser(s)...');
   });
 
   jobPage.logFolds[0].toggle();
@@ -347,7 +349,7 @@ test('visiting a job when log-rendering is off', function (assert) {
   waitForElement('.log-container .log-line');
 
   andThen(() => {
-    assert.equal(jobPage.logLines[0].text, "Log rendering is off because localStorage['travis.logRendering'] is `false`.");
+    assert.equal(jobPage.logLines[0].entireLineText, "Log rendering is off because localStorage['travis.logRendering'] is `false`.");
 
     this.application.pusher.receive('job:log', {
       id: job.id,

--- a/tests/pages/helpers/join-texts.js
+++ b/tests/pages/helpers/join-texts.js
@@ -1,0 +1,15 @@
+import { findElement } from 'ember-cli-page-object/extend';
+
+export default function joinTexts(selector) {
+  return {
+    isDescriptor: true,
+
+    get() {
+      const allTexts = findElement(this, selector, { multiple: true });
+      return allTexts.map(function() { return this.textContent })
+        .get()
+        .join('')
+        .trim();
+    }
+  };
+}

--- a/tests/pages/helpers/join-texts.js
+++ b/tests/pages/helpers/join-texts.js
@@ -6,10 +6,7 @@ export default function joinTexts(selector) {
 
     get() {
       const allTexts = findElement(this, selector, { multiple: true });
-      return allTexts.map(function() { return this.textContent })
-        .get()
-        .join('')
-        .trim();
+      return allTexts.map(function () { return this.textContent; }).get().join('').trim();
     }
   };
 }

--- a/tests/pages/job.js
+++ b/tests/pages/job.js
@@ -6,8 +6,10 @@ import {
   hasClass,
   isVisible,
   text,
-  attribute
+  attribute,
 } from 'ember-cli-page-object';
+
+import joinTexts from './helpers/join-texts';
 
 
 import ymlMessages from './yml-messages';
@@ -36,32 +38,31 @@ export default create({
 
   ymlMessages,
 
-  logLines: collection('pre#log .log-line span:first-of-type', {
-    text: text(),
-    nextText: text('+ span'),
+  logLines: collection('pre#log .log-line', {
+    entireLineText: joinTexts('span'),
 
-    isBlack: hasClass('black'),
-    isRed: hasClass('red'),
-    isGreen: hasClass('green'),
-    isYellow: hasClass('yellow'),
-    isBlue: hasClass('blue'),
-    isMagenta: hasClass('magenta'),
-    isCyan: hasClass('cyan'),
-    isWhite: hasClass('white'),
-    isGrey: hasClass('grey'),
+    isBlack: hasClass('black', 'span:first-of-type'),
+    isRed: hasClass('red', 'span:first-of-type'),
+    isGreen: hasClass('green', 'span:first-of-type'),
+    isYellow: hasClass('yellow', 'span:first-of-type'),
+    isBlue: hasClass('blue', 'span:first-of-type'),
+    isMagenta: hasClass('magenta', 'span:first-of-type'),
+    isCyan: hasClass('cyan', 'span:first-of-type'),
+    isWhite: hasClass('white', 'span:first-of-type'),
+    isGrey: hasClass('grey', 'span:first-of-type'),
 
-    hasBlackBackground: hasClass('bg-black'),
-    hasRedBackground: hasClass('bg-red'),
-    hasGreenBackground: hasClass('bg-green'),
-    hasYellowBackground: hasClass('bg-yellow'),
-    hasBlueBackground: hasClass('bg-blue'),
-    hasMagentaBackground: hasClass('bg-magenta'),
-    hasCyanBackground: hasClass('bg-cyan'),
-    hasWhiteBackground: hasClass('bg-white'),
+    hasBlackBackground: hasClass('bg-black', 'span:first-of-type'),
+    hasRedBackground: hasClass('bg-red', 'span:first-of-type'),
+    hasGreenBackground: hasClass('bg-green', 'span:first-of-type'),
+    hasYellowBackground: hasClass('bg-yellow', 'span:first-of-type'),
+    hasBlueBackground: hasClass('bg-blue', 'span:first-of-type'),
+    hasMagentaBackground: hasClass('bg-magenta', 'span:first-of-type'),
+    hasCyanBackground: hasClass('bg-cyan', 'span:first-of-type'),
+    hasWhiteBackground: hasClass('bg-white', 'span:first-of-type'),
 
-    isBolded: hasClass('bold'),
-    isItalicised: hasClass('italic'),
-    isUnderlined: hasClass('underline')
+    isBolded: hasClass('bold', 'span:first-of-type'),
+    isItalicised: hasClass('italic', 'span:first-of-type'),
+    isUnderlined: hasClass('underline', 'span:first-of-type')
   }),
 
   logFolds: collection('pre#log .fold-start', {


### PR DESCRIPTION
A user reported in https://github.com/travis-ci/travis-ci/issues/10112
that we were overwriting spaces when colored text was printed to the
console in logs.

I wasn't able to reproduce, but wanted to extend our current coverage in
to keep us from accidentally breaking this in the future.

As part of this work, I have added a new page object helper to easily
reference the entire text of a given line. Including this unfortunately
required modifying the scope of the page object's collection, so this
ended up being a bit more invasive than I would have liked. But it seems
worth it given the ability to assert on more complex lines in the future,
given that we were previously only able to assert against the contents of 
the first (and second) span.