### PR TITLE
Fix config fetching logic

### DIFF
--- a/app/adapters/job.js
+++ b/app/adapters/job.js
@@ -1,7 +1,7 @@
 import V3Adapter from 'travis/adapters/v3';
 
 export default V3Adapter.extend({
-  includes: 'build.request,build.commit,build.created_by',
+  includes: 'build.request,build.commit,build.created_by,job.config',
 
   coalesceFindRequests: true,
 

--- a/app/services/job-config-fetcher.js
+++ b/app/services/job-config-fetcher.js
@@ -37,8 +37,7 @@ export default Service.extend({
   flush() {
     Object.keys(this.toFetch).forEach(id => {
       const data = this.toFetch[id];
-      this.store.findRecord('job', id, { include: 'job.config', reload: true })
-        .then(job => data.resolve(job._config));
+      this.store.findRecord('job', id).then(job => data.resolve(job._config));
     });
     this.toFetch = {};
   }

--- a/app/services/job-config-fetcher.js
+++ b/app/services/job-config-fetcher.js
@@ -16,14 +16,15 @@ export default Service.extend({
   fetch(job) {
     let PromiseObject = ObjectProxy.extend(PromiseProxyMixin);
 
-    if (job.get('_config')) {
-      return PromiseObject.create({promise: EmberPromise.resolve(job.get('_config'))});
+    if (job._config) {
+      return PromiseObject.create({
+        promise: EmberPromise.resolve(job._config)
+      });
     }
-    let jobId = job.get('id');
-    if (this.toFetch[jobId]) {
-      return this.toFetch[jobId].promise;
+    if (this.toFetch[job.id]) {
+      return this.toFetch[job.id].promise;
     } else {
-      let data = this.toFetch[jobId] = { job };
+      let data = this.toFetch[job.id] = {};
       let promise = new EmberPromise((resolve, reject) => {
         data.resolve = resolve;
       });
@@ -34,22 +35,12 @@ export default Service.extend({
   },
 
   flush() {
-    let toFetch = this.toFetch;
-    this.toFetch = {};
-    let buildIds = new Set();
-    Object.values(toFetch).forEach(data => buildIds.add(data.job.get('build.id')));
-
-    buildIds.forEach(id => {
-      let queryParams = { id, include: 'job.config,build.jobs' };
-      this.get('store').queryRecord('build', queryParams).then(build => {
-        build.get('jobs').forEach(job => {
-          let data = toFetch[job.get('id')];
-          if (data) {
-            data.resolve(job.get('_config'));
-          }
-        });
-      });
+    Object.keys(this.toFetch).forEach(id => {
+      const data = this.toFetch[id];
+      this.store.findRecord('job', id, { include: 'job.config', reload: true })
+        .then(job => data.resolve(job._config));
     });
+    this.toFetch = {};
   }
 });
 


### PR DESCRIPTION
Context: https://travisci.slack.com/archives/CD38XGFGU/p1539344280000100

Example: https://travis-ci.org/junit-team/junit5/jobs/440495645/config - config does not load. 

As per investigation, `job-config-fetcher` service fetched builds by `job.build.id`, but `build` is an async relationship on `job`, which caused querying builds with `id: undefined` for unresolved builds. 