### PR TITLE
Add link to support forum for Windows builds

### DIFF
--- a/app/components/job-tabs.js
+++ b/app/components/job-tabs.js
@@ -1,10 +1,13 @@
-import { isEmpty } from '@ember/utils';
 import Component from '@ember/component';
+import { isEmpty } from '@ember/utils';
+import { equal } from '@ember/object/computed';
 
 export default Component.extend({
 
   tagName: 'div',
   classNames: ['travistab'],
+
+  isWindows: equal('job.config.content.os', 'windows'),
 
   didRender() {
     // Set the log to be default active tab unless something else is active

--- a/app/styles/app/modules/tabs.scss
+++ b/app/styles/app/modules/tabs.scss
@@ -93,6 +93,14 @@ $border-size: 2px;
       }
     }
   }
+
+  &.half-width {
+    width: 50%;
+
+    li {
+      width: calc(50% - 1em);
+    }
+  }
 }
 
 .travistab-nav {
@@ -125,4 +133,33 @@ $border-size: 2px;
     width: 1.2em;
     height: 1.4em;
   }
+}
+
+.support-forum-link {
+  float: right;
+  padding: 0.5em 0;
+
+  a {
+    padding: 0.5em;
+    border-bottom: $border-size solid $pebble-grey;
+
+    &:hover {
+      color: $oxide-blue;
+      border-bottom-color: $oxide-blue;
+
+      .icon-help {
+        @include colorSVG($oxide-blue);
+        border-color: $oxide-blue;
+      }
+    }
+
+    .icon-help {
+      margin-right: 5px;
+    }
+  }
+}
+
+.support-forum-link-tooltip {
+  max-width: 220px;
+  text-align: center;
 }

--- a/app/templates/components/job-tabs.hbs
+++ b/app/templates/components/job-tabs.hbs
@@ -1,9 +1,22 @@
-<nav class="travistab-nav--secondary">
-  <ul>
-    <li>{{link-to 'Job log' 'job.index' repo job data-test-job-log-tab id="tab_log" title="Look at this job's log"}}</li>
-    <li>{{link-to 'View config' 'job.config' repo job data-test-job-config-tab id="tab_config" title="Look at this job's config"}}</li>
-  </ul>
-</nav>
+<div class="clearfix">
+  {{#if isWindows}}
+    <div class='support-forum-link'>
+      <a href="https://travis-ci.community/c/windows" target="_blank">
+        {{svg-jar 'icon-help' class="icon-help"}} Support forum
+      </a>
+      {{tooltip-on-element
+        class='support-forum-link-tooltip'
+        text='Windows builds are in early access stage. Please head to the Travis CI Community forum to get help or post ideas.'
+      }}
+    </div>
+  {{/if}}
+  <nav class="travistab-nav--secondary half-width">
+    <ul>
+      <li>{{link-to 'Job log' 'job.index' repo job data-test-job-log-tab id="tab_log" title="Look at this job's log"}}</li>
+      <li>{{link-to 'View config' 'job.config' repo job data-test-job-config-tab id="tab_config" title="Look at this job's config"}}</li>
+    </ul>
+  </nav>
+</div>
 <div class="travistab-body">
 
   {{outlet}}


### PR DESCRIPTION
Suggestion: https://travisci.slack.com/archives/C1FAZPJNP/p1539297161000100

Here's how it looks like:
![image](https://user-images.githubusercontent.com/4066489/47016371-2bfb0b00-d158-11e8-91a9-b702ae3f9cf0.png)

The link is only shown for `windows` jobs. Here's an example of one: https://as-windows-support-link.test-deployments.travis-ci.org/yargs/yargs/jobs/440203815