### PR TITLE
Add notice about support for windows builds

### DIFF
--- a/app/components/job-infrastructure-notification.js
+++ b/app/components/job-infrastructure-notification.js
@@ -15,6 +15,8 @@ export default Component.extend({
   @alias('job.queue') queue: null,
   @alias('job.config') jobConfig: null,
 
+  @equal('jobConfig.os', 'windows') isWindows: null,
+
   @computed('job.isFinished')
   conjugatedRun(isFinished) {
     return isFinished ? 'ran' : 'is running';

--- a/app/styles/app/mixins.scss
+++ b/app/styles/app/mixins.scss
@@ -6,10 +6,10 @@
 
 @mixin linkStyle($color: $cement-grey) {
   a {
-    display: inline-block;
     color: inherit;
     text-decoration: none;
     border-bottom: 1px solid $color;
+    padding-bottom: 0.1rem;
     transition: color 200ms ease, border 200ms ease;
 
     &:hover,

--- a/app/styles/app/mixins.scss
+++ b/app/styles/app/mixins.scss
@@ -6,10 +6,10 @@
 
 @mixin linkStyle($color: $cement-grey) {
   a {
+    display: inline-block;
     color: inherit;
     text-decoration: none;
     border-bottom: 1px solid $color;
-    padding-bottom: 0.1rem;
     transition: color 200ms ease, border 200ms ease;
 
     &:hover,

--- a/app/templates/components/job-infrastructure-notification.hbs
+++ b/app/templates/components/job-infrastructure-notification.hbs
@@ -16,7 +16,10 @@
 {{#if isWindows}}
   {{#notice-banner}}
     Windows builds are in early access stage. Please head to the
-    <a href='https://travis-ci.community/c/windows' target='_blank'>Travis CI Community</a>
+    {{external-link-to
+      content='Travis CI Community'
+      href='https://travis-ci.community/c/windows'
+    }}
     forum to get help or post ideas.
   {{/notice-banner}}
 {{/if}}

--- a/app/templates/components/job-infrastructure-notification.hbs
+++ b/app/templates/components/job-infrastructure-notification.hbs
@@ -12,3 +12,11 @@
     {{/if}}
   {{/if}}
 {{/unless}}
+
+{{#if isWindows}}
+  {{#notice-banner}}
+    Windows builds are in early access stage. Please head to the
+    <a href='https://travis-ci.community/c/windows' target='_blank'>Travis CI Community</a>
+    forum to get help or post ideas.
+  {{/notice-banner}}
+{{/if}}


### PR DESCRIPTION
Suggestion: https://travisci.slack.com/archives/C1FAZPJNP/p1539297161000100

Here's how it looks like:
![image](https://user-images.githubusercontent.com/4066489/47019942-e7c03880-d160-11e8-8b02-060f6b7dc10f.png)


The link is only shown for `windows` jobs. Here's an example of one: https://as-windows-support-link-v2.test-deployments.travis-ci.org/yargs/yargs/jobs/440203815