### PR TITLE
Fix repo title alignment issue on owner page

### DIFF
--- a/app/templates/components/owner-repo-tile.hbs
+++ b/app/templates/components/owner-repo-tile.hbs
@@ -16,7 +16,7 @@
       <h2 class="repo-title color">
         {{status-icon status=repo.defaultBranch.lastBuild.state}}
         {{#link-to "repo" ownerName repoName class="label-align"}}
-          <span class="label-align">{{repoName}}</span>
+          {{repoName}}
         {{/link-to}}
       </h2>
     </section>

--- a/app/templates/components/owner-repo-tile.hbs
+++ b/app/templates/components/owner-repo-tile.hbs
@@ -62,6 +62,7 @@
           <span class="finished-at label-align">{{format-time repo.defaultBranch.lastBuild.finishedAt}}</span>
         </p>
       </section>
+
     {{else}}
       <section class="owner-tile-section owner-tile-no-build"><p class="row-content">There is no build on the default branch yet.</p></section>
     {{/if}}

--- a/app/templates/components/owner-repo-tile.hbs
+++ b/app/templates/components/owner-repo-tile.hbs
@@ -16,7 +16,7 @@
       <h2 class="repo-title color">
         {{status-icon status=repo.defaultBranch.lastBuild.state}}
         {{#link-to "repo" ownerName repoName class="label-align"}}
-          {{repoName}}
+          <span class="repo-title-text">{{repoName}}</span>
         {{/link-to}}
       </h2>
     </section>

--- a/tests/integration/components/owner-repo-tile-test.js
+++ b/tests/integration/components/owner-repo-tile-test.js
@@ -48,7 +48,7 @@ module('OwnerRepoTileComponent', function (hooks) {
     await render(hbs`{{owner-repo-tile repo=repo}}`);
 
     assert.dom('.owner-tile').hasClass('passed', 'component should have state class (passed)');
-    assert.dom('.owner-tile-section:nth-of-type(1) span.label-align').hasText('travis-chat', 'should display correct repo name');
+    assert.dom('.owner-tile-section:nth-of-type(1) span.repo-title-text').hasText('travis-chat', 'should display correct repo name');
     assert.dom('.owner-tile-section:nth-of-type(2) span.label-align').hasText('25', 'should display correct build number');
     assert.dom('.owner-tile-section:nth-of-type(3) span.default-branch-name').hasText('master', 'should display branch name');
     assert.dom('.owner-tile-section:nth-of-type(4) span.commit-compare').hasText('16fff34', 'should display correct commit sha');

--- a/tests/pages/owner.js
+++ b/tests/pages/owner.js
@@ -9,7 +9,7 @@ export default create({
   visit: visitable('/:username'),
 
   repos: collection('.owner-tiles .owner-tile', {
-    name: text('.repo-title span.label-align'),
+    name: text('.repo-title span.repo-title-text'),
     buildNumber: text('.build-number .label-align'),
     defaultBranch: text('.default-branch .default-branch-name'),
     commitSha: text('.commit-sha .commit-compare'),


### PR DESCRIPTION
Addresses a repo title alignment issue found by @artursmirnov in https://github.com/travis-ci/travis-web/pull/1843

![owner-no-build-align](https://user-images.githubusercontent.com/1923979/47299907-4bc38080-d5e9-11e8-8990-b38826b19ae1.png)
