### PR TITLE
Organization repos pagination links use organization route

### DIFF
--- a/app/templates/components/account-repositories.hbs
+++ b/app/templates/components/account-repositories.hbs
@@ -52,7 +52,11 @@
           {{/if}}
         </div>
         {{#unless filter.isFiltering}}
-          {{pagination-navigation collection=notLockedGithubAppsRepositories route="account.repositories" queryParam='apps-page' inner=6 outer=2}}
+          {{#if account.isOrganization}}
+            {{pagination-navigation collection=notLockedGithubAppsRepositories route='organization.repositories' queryParam='apps-page' inner=6 outer=2}}
+          {{else}}
+            {{pagination-navigation collection=notLockedGithubAppsRepositories route='account.repositories' queryParam='apps-page' inner=6 outer=2}}
+          {{/if}}
         {{/unless}}
       {{/repository-filter}}
       {{#if lockedGithubAppsRepositories}}
@@ -168,7 +172,11 @@
       {{/if}}
     </div>
     {{#unless filter.isFiltering}}
-      {{pagination-navigation collection=deprecated route="account.repositories" inner=6 outer=2}}
+      {{#if account.isOrganization}}
+        {{pagination-navigation collection=deprecated route="organization.repositories" inner=6 outer=2}}
+      {{else}}
+        {{pagination-navigation collection=deprecated route="account.repositories" inner=6 outer=2}}
+      {{/if}}
     {{/unless}}
   {{/repository-filter}}
 {{/if}}


### PR DESCRIPTION
#### What does this PR do?
- Organization repos pagination links will use organization route instead of account route

#### Related Issue
[2851](https://github.com/travis-pro/team-teal/issues/2851)
 
#### How this PR makes you feel?
![turn_page](https://user-images.githubusercontent.com/529465/47326563-88619d00-d626-11e8-9171-0f022ffcd9ef.gif)




