### PR TITLE
Allow failures for ember beta builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ matrix:
       node_js: 10.7
     - if: NOT type = cron
       node_js: 10.7
+  allow_failures:
+    - env: TRY_CONFIG=ember-beta
+    - env: TRY_CONFIG=ember-data-beta
 
 sudo: required
 dist: trusty


### PR DESCRIPTION
Issue: cron jobs for Ember beta releases fail the entire build on master branch. 
Example: https://travis-ci.org/travis-ci/travis-web/builds/444616978