### PR TITLE
Change switch so switch is to the left when disabled

### DIFF
--- a/app/styles/app/modules/switch.scss
+++ b/app/styles/app/modules/switch.scss
@@ -54,7 +54,7 @@
 
   .on {
     display: none;
-    margin-left: -50%;
+    margin-left: 50%;
 
     .icon-on {
       @include colorSVG($oxide-blue);
@@ -63,7 +63,7 @@
   }
 
   .off {
-    margin-left: 50%;
+    margin-left: -50%;
 
     .icon-off {
       @include colorSVG(darken($pebble-grey, 10));


### PR DESCRIPTION
This is currently confusing as it's the opposite of what iOS or other similar implementations do.

Here's what this looks like after the change:
<img width="673" alt="screen shot 2018-10-26 at 09 59 33" src="https://user-images.githubusercontent.com/366944/47553260-e0d6ba00-d906-11e8-9854-212cc440f7cb.png">
