### PR TITLE
Ensure correct status shown after repository migration

### DIFF
--- a/app/controllers/repo.js
+++ b/app/controllers/repo.js
@@ -17,6 +17,9 @@ export default Controller.extend({
   @service features: null,
   @service('updateTimes') updateTimesService: null,
 
+  queryParams: ['migrationStatus'],
+  migrationStatus: null,
+
   @controller('job') jobController: null,
   @controller('build') buildController: null,
   @controller('builds') buildsController: null,

--- a/app/routes/repo/index.js
+++ b/app/routes/repo/index.js
@@ -14,6 +14,7 @@ export default TravisRoute.extend({
   deactivate() {
     this.controllerFor('build').set('build', null);
     this.controllerFor('job').set('job', null);
+    this.controllerFor('repo').set('migrationStatus', null);
     this.stopObservingRepoStatus();
     return this._super(...arguments);
   },

--- a/app/routes/repo/index.js
+++ b/app/routes/repo/index.js
@@ -39,7 +39,9 @@ export default TravisRoute.extend({
   renderTemplate() {
     let controller = this.controllerFor('repo');
 
-    if (this.get('features.github-apps') && controller.get('repo.active_on_org')) {
+    if (this.get('features.github-apps') &&
+      controller.get('repo.active_on_org') &&
+      controller.get('migrationStatus') !== 'success') {
       this.render('repo/active-on-org');
     } else if (!controller.get('repo.active')) {
       this.render('repo/not-active');

--- a/app/templates/components/github-apps-repository.hbs
+++ b/app/templates/components/github-apps-repository.hbs
@@ -1,8 +1,16 @@
 {{repository-visibility-icon repository=repository}}
 
-{{#link-to "repo" repository.owner.login repository.name class="profile-repo"}}
+{{#link-to
+  "repo"
+  repository.owner.login
+  repository.name
+  (query-params migrationStatus=repository.migrationStatus)
+  class="profile-repo"
+}}
   {{name}}
 {{/link-to}}
+
+
 
 {{#if repository.active_on_org}}
   {{#if migrationEnabled}}

--- a/tests/acceptance/profile/migration-test.js
+++ b/tests/acceptance/profile/migration-test.js
@@ -4,6 +4,7 @@ import {
   visit,
   click,
   waitFor,
+  currentURL,
 } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import signInUser from 'travis/tests/helpers/sign-in-user';
@@ -123,6 +124,11 @@ module('Acceptance | profile/migration', function (hooks) {
     assert.dom('[data-test-migration-status="success"]').exists();
 
     percySnapshot(assert);
+
+    await click('[data-test-locked-github-app-repository="github-apps-locked-repository"] a');
+    assert.equal(currentURL(), '/user-login/github-apps-locked-repository?migrationStatus=success');
+
+    assert.dom('[data-test-missing-notice-header]').exists();
   });
 
   test('migrating locked GitHub repositories (sad path)', async function (assert) {


### PR DESCRIPTION
We can't apply `active_on_org` prematurely, as it would remove the repository from the migration list before the user sees the migration result. 