### PR TITLE
Fix blank lines in log

### DIFF
--- a/app/utils/log.js
+++ b/app/utils/log.js
@@ -193,6 +193,7 @@ Log.Part = function (id, num, string) {
   this.string = this.string.replace(/\r\u001B\[0m\n/g, '\n');
 
   this.string = this.string.replace(/\r+\n/gm, '\n');
+  this.string = this.string.replace(/\r+/gm, '\r');
   this.strings = this.string.split(/^/gm) || [];
   this.slices = ((function () {
     let _results;
@@ -233,7 +234,8 @@ Log.Part.prototype = Log.extend(new Log.Node, {
         spans.push(span);
       }
       if ((_ref3 = spans[0]) != null ? (_ref4 = _ref3.line) != null ? _ref4.cr : void 0 : void 0) {
-        spans[0].line.clear();
+        _ref3['class'] = ['clears'];
+        _ref4.clear();
       }
     }
     if (!(slice >= this.slices.length - 1)) {
@@ -249,15 +251,7 @@ newLineRegexp = new RegExp('\n');
 rRegexp = new RegExp('\r');
 
 removeCarriageReturns = function (string) {
-  let index;
-  index = string.lastIndexOf('\r');
-  if (index === -1) {
-    return string;
-  }
-  // FIXME the previous code is below. It surely was this way for a reason!
-  return string.substr(index + 1);
-  // FIXME indeed it was, reverting for now…
-  // return string.replace('\r', '');
+  return string.replace(/[\r,\n]+$/, '');
 };
 
 let foldNameCount = {};
@@ -298,7 +292,7 @@ Log.Span = function (id, num, text, classes) {
     this.text = this.text.replace(newLineAtTheEndRegexp, '');
     this.nl = !!((_ref = text[text.length - 1]) != null ? _ref.match(newLineRegexp) : void 0);
     this.cr = !!text.match(rRegexp);
-    this['class'] = this.cr && ['clears'] || classes;
+    this['class'] = classes;
   }
   return this;
 };
@@ -866,7 +860,7 @@ Object.defineProperty(Log.Times.Time.prototype, 'stats', {
 Log.Deansi = {
   CLEAR_ANSI: /(?:\033)(?:\[0?c|\[[0356]n|\[7[lh]|\[\?25[lh]|\(B|H|\[(?:\d+(;\d+){,2})?G|\[(?:[12])?[JK]|[DM]|\[0K)/gm,
   apply: function (string) {
-    if (!string) {
+    if (!string || !string.length) {
       return [];
     }
     string = string.replace(this.CLEAR_ANSI, '');

--- a/tests/acceptance/job/basic-layout-test.js
+++ b/tests/acceptance/job/basic-layout-test.js
@@ -207,6 +207,7 @@ I am another line finished by a CR.\rI replace that line?\r${ESCAPE}[0mI am the 
 This should also be gone.\r This should have replaced it.
 A particular log formation is addressed here, this should remain.\r${ESCAPE}[0m\nThis should be on a separate line.
 But it must be addressed repeatedly!\r${ESCAPE}[0m\nAgain.
+I should not be blank.\r${ESCAPE}
 `;
   server.create('log', { id: job.id, content: complexLog });
 
@@ -274,6 +275,8 @@ But it must be addressed repeatedly!\r${ESCAPE}[0m\nAgain.
     assert.equal(jobPage.logLines[19].text, 'This should be on a separate line.');
     assert.equal(jobPage.logLines[20].text, 'But it must be addressed repeatedly!');
     assert.equal(jobPage.logLines[21].text, 'Again.');
+
+    assert.equal(jobPage.logLines[22].text, 'I should not be blank.');
   });
 
   jobPage.logFolds[0].toggle();


### PR DESCRIPTION
Issues: 
- https://github.com/travis-pro/team-teal/issues/2782
- https://github.com/travis-ci/travis-ci/issues/10133

@backspace please take a look once you have a chance. This is basically the same fix as last time with a small difference to make sure, that it doesn't break formatting for other users. The difference is in this line: https://github.com/travis-ci/travis-web/pull/1783/files#diff-a9f1ee3a2839d79578ecf5adef53afe1R254 (I removed `\s` from regexp).

I tested it against both jobs and they both look good:
- https://as-fix-log.test-deployments.travis-ci.org/Ortus-Solutions/JSONPrettyPrint/jobs/417099159
- https://as-fix-log.test-deployments.travis-ci.org/mozilla/treeherder/jobs/430084979
