### PR TITLE
Fix apps redirect issue

### DIFF
--- a/app/controllers/github-apps-installation.js
+++ b/app/controllers/github-apps-installation.js
@@ -19,7 +19,7 @@ export default Controller.extend({
 
   startPolling() {
     this.initialDelayPromise().then(() => this.fetchPromise().then(installation => {
-      this.transitionToRoute('account', installation.owner.login);
+      this.transitionToRoute('account');
     }));
   },
 


### PR DESCRIPTION
This should address an issue where the Github Apps installation redirect page was not redirecting correctly.