### PR TITLE
Lower case name and owner on repo route to make url case-insensitive

### DIFF
--- a/app/routes/repo.js
+++ b/app/routes/repo.js
@@ -54,8 +54,12 @@ export default TravisRoute.extend(ScrollResetMixin, {
   },
 
   model(params) {
+    // Lowercase owner and repo name to allow case-insenstive urls
+    Object.assign(params, {name: params.name.toLowerCase(), owner: params.owner.toLowerCase()});
+
     const { name, owner } = params;
     const slug = `${owner}/${name}`;
+
     return Repo.fetchBySlug(this.get('store'), slug);
   },
 });


### PR DESCRIPTION
#### What does this PR do?
- Lowercase name and owner on repo route to allow case-insensitive repo urls
 
#### Related Issue
[1250](https://github.com/travis-pro/team-teal/issues/1250)

#### How this PR makes you feel?
![kitty_type](https://user-images.githubusercontent.com/529465/48242571-00ef8a00-e399-11e8-9e4d-5801cbc1ee14.gif)

