### PR TITLE
Add beta instructions docs to profile

### DIFF
--- a/app/services/external-links.js
+++ b/app/services/external-links.js
@@ -36,7 +36,7 @@ export default Service.extend({
   },
 
   openSourceMigrationDocs: 'https://docs.travis-ci.com/user/open-source-on-travis-ci-com/#existing-open-source-repositories-on-travis-ciorg',
-  betaMigrationDocs: 'https://docs.travis-ci.com/user/open-source-repository-migration/,
+  betaMigrationDocs: 'https://docs.travis-ci.com/user/open-source-repository-migration/',
 
   platformLink(platform, rest) {
     return `https://travis-ci.${platform}/${rest}`;

--- a/app/services/external-links.js
+++ b/app/services/external-links.js
@@ -36,6 +36,7 @@ export default Service.extend({
   },
 
   openSourceMigrationDocs: 'https://docs.travis-ci.com/user/open-source-on-travis-ci-com/#existing-open-source-repositories-on-travis-ciorg',
+  betaMigrationDocs: 'https://docs.travis-ci.com/user/open-source-repository-migration/,
 
   platformLink(platform, rest) {
     return `https://travis-ci.${platform}/${rest}`;

--- a/app/templates/components/account-repositories.hbs
+++ b/app/templates/components/account-repositories.hbs
@@ -68,7 +68,7 @@
                 Authorized users can now migrate the following repositories
                 currently active on our legacy platform travis-ci.org to travis-ci.com.
                 Please
-                {{#external-link-to href=externalLinks.openSourceMigrationDocs}}
+                {{#external-link-to href=externalLinks.betaMigrationDocs}}
                 read our docs on open source migration
                 {{/external-link-to}}
                 to learn more.


### PR DESCRIPTION
The URL I included here doesn't work yet, as it depends on https://github.com/travis-ci/docs-travis-ci-com/pull/2137 being merged which will happen shortly.

This way the documentation we're redirecting our customers to is the new one created specifically for migration beta testing.