### PR TITLE
Display language as shell for shell

### DIFF
--- a/app/utils/keys-map.js
+++ b/app/utils/keys-map.js
@@ -36,7 +36,9 @@ languageConfigKeys = {
   xcode_scheme: 'Xcode scheme',
   r: 'R',
   nix: 'Nix',
-  shell: 'Shell'
+  shell: 'Shell',
+  bash: 'Shell',
+  sh: 'Shell'
 };
 
 configKeys = {

--- a/app/utils/keys-map.js
+++ b/app/utils/keys-map.js
@@ -35,7 +35,8 @@ languageConfigKeys = {
   osx_image: 'Xcode',
   xcode_scheme: 'Xcode scheme',
   r: 'R',
-  nix: 'Nix'
+  nix: 'Nix',
+  shell: 'Shell'
 };
 
 configKeys = {


### PR DESCRIPTION
Currently, with `language: bash`, _no language set_ is displayed in the build matrix overview and job overview. This should be set to _Shell_.