### PR TITLE
Add node_modules to .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -10,6 +10,7 @@
 
 # dependencies
 /bower_components/
+/node_modules/
 
 # misc
 /coverage/


### PR DESCRIPTION
I don’t know why errors like these are suddenly showing up,
but it seems obv that we shouldn’t be linting dependencies:
https://travis-ci.org/travis-ci/travis-web/builds/458959836#L509-L540