### PR TITLE
Fix broken settings page after migration

### DIFF
--- a/app/controllers/settings.js
+++ b/app/controllers/settings.js
@@ -8,6 +8,7 @@ import { service } from 'ember-decorators/service';
 
 export default Controller.extend({
   @service externalLinks: null,
+  @service features: null,
 
   @computed('unsortedEnvVars')
   envVars(envVars) {


### PR DESCRIPTION
The service was not injected, which our tests unfortunately did not catch. It looks like when you enable a feature within the test suite, it actually injects the service, masking this type of error.