### PR TITLE
Revert ember-intercom-io update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5029,12 +5029,6 @@
       "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
       "dev": true
     },
-    "babel-plugin-syntax-object-rest-spread": {
-      "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
-      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
-      "dev": true
-    },
     "babel-plugin-syntax-trailing-function-commas": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
@@ -5303,16 +5297,6 @@
         "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
         "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
         "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-object-rest-spread": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
-      "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
-        "babel-runtime": "^6.26.0"
       }
     },
     "babel-plugin-transform-regenerator": {
@@ -11526,120 +11510,26 @@
       }
     },
     "ember-intercom-io": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ember-intercom-io/-/ember-intercom-io-1.1.5.tgz",
-      "integrity": "sha512-tfbLhK2iyEoAI/MmslqrVupBIuOYEWhCqXzMZIMbvsCqhzgiCfqk95AOSws4PiHjoh79eGLD8swg/WAxu/mrWw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ember-intercom-io/-/ember-intercom-io-0.3.0.tgz",
+      "integrity": "sha1-rubBYnFGgvvJUujU6GCi1a32wpw=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-object-rest-spread": "^6.26.0",
-        "ember-cli-babel": "^7.1.3",
-        "ember-cli-htmlbars": "^3.0.0"
+        "ember-cli-babel": "^6.6.0",
+        "ember-cli-htmlbars": "^2.0.1"
       },
       "dependencies": {
-        "amd-name-resolver": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
-          "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
+        "ember-cli-htmlbars": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-2.0.4.tgz",
+          "integrity": "sha512-WSGODKKG65M/Q7QcLflmxnJKMA32JqFLyX0a5ghMRDWRqvUVkKWSZDbjJsNsCw/OCeBbPWQLQWq0wtpCnTTjwA==",
           "dev": true,
           "requires": {
-            "ensure-posix-path": "^1.0.1"
-          }
-        },
-        "babel-plugin-debug-macros": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.2.0.tgz",
-          "integrity": "sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==",
-          "dev": true,
-          "requires": {
-            "semver": "^5.3.0"
-          }
-        },
-        "babel-plugin-ember-modules-api-polyfill": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.5.0.tgz",
-          "integrity": "sha512-o1rOgWFHR0IRBjC9Dvqc2V4MKE2UvdMv/fD/c5GUMAkS6DlTjQV54iMH9sdQ3TGfXPukPKBIOpoSoH/hdfGiMg==",
-          "dev": true,
-          "requires": {
-            "ember-rfc176-data": "^0.3.5"
-          }
-        },
-        "broccoli-babel-transpiler": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-7.1.0.tgz",
-          "integrity": "sha512-pXB5CZXHKcfwvQwqPYzNVcHLUgPYhgz7929NxTSGMlwYmQ3tU+cl/ZxrEvTRVZLJ+WcMKcbzo9SvpoRV9PTumA==",
-          "dev": true,
-          "requires": {
-            "@babel/core": "^7.0.0",
-            "broccoli-funnel": "^2.0.1",
-            "broccoli-merge-trees": "^3.0.0",
             "broccoli-persistent-filter": "^1.4.3",
-            "clone": "^2.1.2",
             "hash-for-dep": "^1.2.3",
-            "heimdalljs-logger": "^0.1.9",
-            "json-stable-stringify": "^1.0.1",
-            "rsvp": "^4.8.3",
-            "workerpool": "^2.3.1"
+            "json-stable-stringify": "^1.0.0",
+            "strip-bom": "^3.0.0"
           }
-        },
-        "broccoli-debug": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.5.tgz",
-          "integrity": "sha512-RIVjHvNar9EMCLDW/FggxFRXqpjhncM/3qq87bn/y+/zR9tqEkHvTqbyOc4QnB97NO2m6342w4wGkemkaeOuWg==",
-          "dev": true,
-          "requires": {
-            "broccoli-plugin": "^1.2.1",
-            "fs-tree-diff": "^0.5.2",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "symlink-or-copy": "^1.1.8",
-            "tree-sync": "^1.2.2"
-          }
-        },
-        "clone": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-          "dev": true
-        },
-        "ember-cli-babel": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-7.1.3.tgz",
-          "integrity": "sha512-wkftzRiPiLTKAhBKphsJEH8gmJIspq04f03DUvoS2/bqrssF04hhQVRquF4EF0ZiNxKI8f4ka/puVOGeBuRWDg==",
-          "dev": true,
-          "requires": {
-            "@babel/core": "^7.0.0",
-            "@babel/plugin-transform-modules-amd": "^7.0.0",
-            "@babel/polyfill": "^7.0.0",
-            "@babel/preset-env": "^7.0.0",
-            "amd-name-resolver": "1.2.0",
-            "babel-plugin-debug-macros": "^0.2.0-beta.6",
-            "babel-plugin-ember-modules-api-polyfill": "^2.5.0",
-            "babel-plugin-module-resolver": "^3.1.1",
-            "broccoli-babel-transpiler": "^7.1.0",
-            "broccoli-debug": "^0.6.4",
-            "broccoli-funnel": "^2.0.1",
-            "broccoli-source": "^1.1.0",
-            "clone": "^2.1.2",
-            "ember-cli-version-checker": "^2.1.2",
-            "ensure-posix-path": "^1.0.2",
-            "semver": "^5.5.0"
-          }
-        },
-        "ember-cli-version-checker": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.2.tgz",
-          "integrity": "sha512-sjkHGr4IGXnO3EUcY21380Xo9Qf6bC8HWH4D62bVnrQop/8uha5XgMQRoAflMCeH6suMrezQL287JUoYc2smEw==",
-          "dev": true,
-          "requires": {
-            "resolve": "^1.3.3",
-            "semver": "^5.3.0"
-          }
-        },
-        "ember-rfc176-data": {
-          "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.5.tgz",
-          "integrity": "sha512-5NfL1iTkIQDYs16/IZ7/jWCEglNsUrigLelBkBMsNcib9T3XzQwmhhVTjoSsk66s57LmWJ1bQu+2c1CAyYCV7A==",
-          "dev": true
         },
         "hash-for-dep": {
           "version": "1.2.3",
@@ -11653,26 +11543,11 @@
             "resolve": "^1.4.0"
           }
         },
-        "rsvp": {
-          "version": "4.8.4",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.4.tgz",
-          "integrity": "sha512-6FomvYPfs+Jy9TfXmBpBuMWNH94SgCsZmJKcanySzgNNP6LjWxBvyLTa9KaMfDDM5oxRfrKDB0r/qeRsLwnBfA==",
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
-        },
-        "semver": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
-          "dev": true
-        },
-        "workerpool": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.3.tgz",
-          "integrity": "sha512-L1ovlYHp6UObYqElXXpbd214GgbEKDED0d3sj7pRdFXjNkb2+un/AUcCkceHizO0IVI6SOGGncrcjozruCkRgA==",
-          "dev": true,
-          "requires": {
-            "object-assign": "4.1.1"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "ember-fetch": "^6.0.0",
     "ember-in-viewport": "^3.0.0",
     "ember-inflector": "^2.3.0",
-    "ember-intercom-io": "^1.1.5",
+    "ember-intercom-io": "^0.3.0",
     "ember-keyboard-shortcuts": "^1.0.2",
     "ember-load-initializers": "1.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",


### PR DESCRIPTION
This reverts #1918, which is failing to deploy and I can’t look
more deeply at the moment.