### PR TITLE
Remove route action helper addon

### DIFF
--- a/app/components/repository-sidebar.js
+++ b/app/components/repository-sidebar.js
@@ -59,17 +59,13 @@ export default Component.extend({
 
     showMyRepositories: function () {
       this.set('tabStates.sidebarTab', 'owned');
-      this.actions.showRepositories();
+      this.router.transitionTo('index');
     },
 
     onQueryChange(query) {
       if (query === '' || query === this.get('repositories.searchQuery')) { return; }
       this.set('repositories.searchQuery', query);
       this.get('repositories.showSearchResults').perform();
-    },
-
-    showRepositories() {
-      this.router.transitionTo('index');
     },
 
     viewSearchResults(query) {

--- a/app/components/repository-sidebar.js
+++ b/app/components/repository-sidebar.js
@@ -59,14 +59,22 @@ export default Component.extend({
 
     showMyRepositories: function () {
       this.set('tabStates.sidebarTab', 'owned');
-      this.attrs.showRepositories();
+      this.actions.showRepositories();
     },
 
     onQueryChange(query) {
       if (query === '' || query === this.get('repositories.searchQuery')) { return; }
       this.set('repositories.searchQuery', query);
       this.get('repositories.showSearchResults').perform();
-    }
+    },
+
+    showRepositories() {
+      this.router.transitionTo('index');
+    },
+
+    viewSearchResults(query) {
+      this.router.transitionTo('search', query);
+    },
   },
 
   startedJobsCount: alias('runningJobs.length'),

--- a/app/components/repository-sidebar.js
+++ b/app/components/repository-sidebar.js
@@ -66,7 +66,7 @@ export default Component.extend({
       if (query === '' || query === this.get('repositories.searchQuery')) { return; }
       this.set('repositories.searchQuery', query);
       this.get('repositories.showSearchResults').perform();
-    },
+    }
   },
 
   startedJobsCount: alias('runningJobs.length'),

--- a/app/components/repository-sidebar.js
+++ b/app/components/repository-sidebar.js
@@ -67,10 +67,6 @@ export default Component.extend({
       this.set('repositories.searchQuery', query);
       this.get('repositories.showSearchResults').perform();
     },
-
-    viewSearchResults(query) {
-      this.router.transitionTo('search', query);
-    },
   },
 
   startedJobsCount: alias('runningJobs.length'),

--- a/app/controllers/owner-error.js
+++ b/app/controllers/owner-error.js
@@ -1,0 +1,6 @@
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+
+export default Controller.extend({
+  auth: service(),
+});

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -135,15 +135,6 @@ export default TravisRoute.extend(BuildFaviconMixin, KeyboardShortcuts, {
         return true;
       }
     },
-
-    showRepositories() {
-      this.transitionTo('index');
-    },
-
-    viewSearchResults(query) {
-      this.transitionTo('search', query);
-    }
-
   },
 
   afterSignIn() {

--- a/app/services/auth.js
+++ b/app/services/auth.js
@@ -285,4 +285,10 @@ export default Service.extend({
   }),
 
   permissions: alias('currentUser.permissions'),
+
+  actions: {
+    signOut() {
+      this.signOut();
+    }
+  }
 });

--- a/app/services/auth.js
+++ b/app/services/auth.js
@@ -6,6 +6,7 @@ import { Promise as EmberPromise } from 'rsvp';
 import Service, { inject as service } from '@ember/service';
 import config from 'travis/config/environment';
 import { alias } from '@ember/object/computed';
+import { getOwner } from '@ember/application';
 
 import URLPolyfill from 'travis/utils/url';
 
@@ -287,6 +288,11 @@ export default Service.extend({
   permissions: alias('currentUser.permissions'),
 
   actions: {
+    signIn(runAfterSignIn) {
+      let applicationRoute = getOwner(this).lookup('route:application');
+      applicationRoute.send('signIn', runAfterSignIn);
+    },
+
     signOut() {
       this.signOut();
     }

--- a/app/templates/components/zendesk-request-form.hbs
+++ b/app/templates/components/zendesk-request-form.hbs
@@ -78,7 +78,7 @@
       <button
         title="Sign into Travis CI"
         class="hero-button"
-        {{action (route-action 'signIn' false)}}
+        {{action (action 'signIn' false target=auth)}}
         data-test-zendesk-form-log-in-button
       >
         {{svg-jar 'icon-repooctocat' }} Sign in with GitHub

--- a/app/templates/getting-started.hbs
+++ b/app/templates/getting-started.hbs
@@ -49,9 +49,7 @@
   {{#if auth.signedIn}}
   {{#unless features.dashboard}}
     <aside id="left" class="{{unless auth.signedIn 'hidden'}}">
-      {{repository-sidebar
-        showRepositories=(route-action 'showRepositories')
-        viewSearchResults=(route-action 'viewSearchResults')}}
+      {{repository-sidebar}}
     </aside>
   {{/unless}}
   {{/if}}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -24,7 +24,7 @@
 {{else}}
   <div class='wrapper centered'>
     {{component landingPage
-      signIn=(route-action 'signIn')
+      signIn=(action 'signIn' target=auth)
       signOut=(action 'signOut' target=auth)}}
   </div>
 {{/if}}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -16,9 +16,7 @@
     {{#if auth.signedIn}}
     {{#unless features.dashboard}}
       <aside id="left" class="{{unless auth.signedIn 'hidden'}}">
-        {{repository-sidebar
-          showRepositories=(route-action 'showRepositories')
-          viewSearchResults=(route-action 'viewSearchResults')}}
+        {{repository-sidebar}}
       </aside>
     {{/unless}}
     {{/if}}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -25,6 +25,6 @@
   <div class='wrapper centered'>
     {{component landingPage
       signIn=(route-action 'signIn')
-      signOut=(route-action 'signOut')}}
+      signOut=(action 'signOut' target=auth)}}
   </div>
 {{/if}}

--- a/app/templates/owner-error.hbs
+++ b/app/templates/owner-error.hbs
@@ -1,3 +1,3 @@
 {{#error-page-layout}}
-  {{owner-not-found ownerLogin=model.ownerName signIn=(route-action 'signIn')}}
+  {{owner-not-found ownerLogin=model.ownerName signIn=(action 'signIn' target=auth)}}
 {{/error-page-layout}}

--- a/app/templates/repo.hbs
+++ b/app/templates/repo.hbs
@@ -27,9 +27,7 @@
   {{#if auth.signedIn}}
   {{#unless features.dashboard}}
     <aside id="left" class="{{unless auth.signedIn 'hidden'}}">
-      {{repository-sidebar
-        showRepositories=(route-action 'showRepositories')
-        viewSearchResults=(route-action 'viewSearchResults')}}
+      {{repository-sidebar}}
     </aside>
   {{/unless}}
   {{/if}}

--- a/app/templates/search.hbs
+++ b/app/templates/search.hbs
@@ -20,9 +20,7 @@
   {{#if auth.signedIn}}
   {{#unless features.dashboard}}
     <aside id="left" class="{{unless auth.signedIn 'hidden'}}">
-      {{repository-sidebar
-        showRepositories=(route-action 'showRepositories')
-        viewSearchResults=(route-action 'viewSearchResults')}}
+      {{repository-sidebar}}
     </aside>
   {{/unless}}
   {{/if}}

--- a/app/templates/signin.hbs
+++ b/app/templates/signin.hbs
@@ -7,7 +7,7 @@
   <h1 class="content-title auth">We're so glad you're here!</h1>
   <h2 class="content-subtitle">Please sign in to view your repositories.</h2>
   <p>
-    <button type="button" {{action (route-action 'signIn')}} title="Sign into Travis CI" class="content-button">Sign in with GitHub</button>
+    <button type="button" {{action (action 'signIn' target=auth)}} title="Sign into Travis CI" class="content-button">Sign in with GitHub</button>
   </p>
 {{/if}}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6855,7 +6855,7 @@
         },
         "svgo": {
           "version": "0.6.6",
-          "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.6.6.tgz",
+          "resolved": "http://registry.npmjs.org/svgo/-/svgo-0.6.6.tgz",
           "integrity": "sha1-s0CIkDbyD5tEdUMHfQ9Vc+0ETAg=",
           "dev": true,
           "requires": {
@@ -7263,7 +7263,7 @@
     },
     "cheerio": {
       "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+      "resolved": "http://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
       "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
       "dev": true,
       "requires": {
@@ -7781,7 +7781,7 @@
             },
             "chalk": {
               "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
@@ -8079,7 +8079,7 @@
     },
     "css-select": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "dev": true,
       "requires": {
@@ -10855,15 +10855,6 @@
         "silent-error": "^1.0.0"
       }
     },
-    "ember-cli-version-checker": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
-      "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
-      "dev": true,
-      "requires": {
-        "semver": "^5.3.0"
-      }
-    },
     "ember-composable-helpers": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ember-composable-helpers/-/ember-composable-helpers-2.1.0.tgz",
@@ -11210,15 +11201,6 @@
       "dev": true,
       "requires": {
         "ember-cli-babel": "^6.0.0-beta.7"
-      }
-    },
-    "ember-factory-for-polyfill": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.2.0.tgz",
-      "integrity": "sha512-6Kr/FqL0h4F0f4AcG6EX9+9ml0BpSLuN82S3fYvwTFuh1HdrPUmGUcOCTuzZZLpS+n5BZjQukokJLSHzXewmyA==",
-      "dev": true,
-      "requires": {
-        "ember-cli-version-checker": "^1.2.0"
       }
     },
     "ember-feature-flags": {
@@ -12383,28 +12365,6 @@
       "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.2.7.tgz",
       "integrity": "sha512-pJE2w+sI22UDsYmudI4nCp3WcImpUzXwe9qHfpOcEu3yM/HD1nGpDRt6kZD0KUnDmqkLeik/nYyzEwN/NU6xxA==",
       "dev": true
-    },
-    "ember-route-action-helper": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/ember-route-action-helper/-/ember-route-action-helper-2.0.6.tgz",
-      "integrity": "sha1-HVBFQ1DXESvjJqtEBY8GzykdX9k=",
-      "dev": true,
-      "requires": {
-        "ember-cli-babel": "^6.8.1",
-        "ember-getowner-polyfill": "^2.0.0"
-      },
-      "dependencies": {
-        "ember-getowner-polyfill": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/ember-getowner-polyfill/-/ember-getowner-polyfill-2.0.1.tgz",
-          "integrity": "sha1-m/4rTVJ+0XTnb+8sjzCTfXfLZvs=",
-          "dev": true,
-          "requires": {
-            "ember-cli-version-checker": "^1.2.0",
-            "ember-factory-for-polyfill": "^1.1.0"
-          }
-        }
-      }
     },
     "ember-router-generator": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "ember-qunit": "^4.0.0",
     "ember-qunit-nice-errors": "1.2.0",
     "ember-resolver": "^5.0.1",
-    "ember-route-action-helper": "^2.0.3",
     "ember-sinon": "^3.0.0",
     "ember-source": "~3.5.1",
     "ember-svg-jar": "^1.2.1",


### PR DESCRIPTION
This is throwing deprecations as of Ember 3.6. It’s not that
widely-used in the application and route actions aren’t that
favoured in the RFC discussion, so we decided to remove it.

https://github.com/emberjs/rfcs/pull/394