### PR TITLE
Add silencing for method-calls-on-destroyed-store

### DIFF
--- a/config/deprecation-workflow.js
+++ b/config/deprecation-workflow.js
@@ -2,6 +2,7 @@
 window.deprecationWorkflow = window.deprecationWorkflow || {};
 window.deprecationWorkflow.config = {
   workflow: [
-    { handler: 'silence', matchId: 'ember-component.send-action' }
+    { handler: 'silence', matchId: 'ember-component.send-action' },
+    { handler: 'silence', matchId: 'ember-data:method-calls-on-destroyed-store' }
   ]
 };


### PR DESCRIPTION
This has been around for a while it seems, but I didn’t notice
it. It’s produced 30 times by the “we query the API for all
the jobs” test and I haven’t been able to figure it out.