### PR TITLE
Bump har-validator in package-lock.json to latest version (v5.1.3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15754,9 +15754,9 @@
       "dev": true
     },
     "har-validator": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.2.tgz",
-      "integrity": "sha512-OFxb5MZXCUMx43X7O8LK4FKggEQx6yC5QPmOcBnYbJ9UjxEcMcrMbaR0af5HZpqeFopw2GwQRQi34ZXI7YLM5w==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "dev": true,
       "requires": {
         "ajv": "^6.5.5",


### PR DESCRIPTION
This is to address fresh runs of `npm install` caused by the yanking of v5.1.2 of `har-validator`. See [here](https://github.com/ahmadnassri/node-har-validator/issues/112) for further reading on the yank. The author has stated that v5.1.3 is identical to v5.1.0, which is what the `requests` package relies upon.