### PR TITLE
update documentation link wording

### DIFF
--- a/app/templates/help.hbs
+++ b/app/templates/help.hbs
@@ -7,8 +7,8 @@
     </h1>
 
     <div class="subheading align-center" data-test-help-page-navigation-links>
-      Find our most
-      <a href={{docsUrl}} target="_blank" ref="noopener noreferrer">used resources</a>,
+      View our most read
+      <a href={{docsUrl}} target="_blank" ref="noopener noreferrer">documentation</a>,
       popular topics in our
       <a href={{communityUrl}} target="_blank" ref="noopener noreferrer">Community forum</a>,
       or


### PR DESCRIPTION
Since `Documentation` is more recognizable than `resources`. Thank you!