### PR TITLE
Humanize build states for build history tab

### DIFF
--- a/app/templates/components/branch-row.hbs
+++ b/app/templates/components/branch-row.hbs
@@ -25,7 +25,7 @@
       {{#if branch.last_build}}
         {{#link-to "build" branch.last_build.id}}
           {{svg-jar 'icon-hash' class=(concat branch.last_build.state ' icon')}}
-          <span class="label-align inner-underline {{branch.last_build.state}}">{{branch.last_build.number}} {{branch.last_build.state}}</span>
+          <span class="label-align inner-underline {{branch.last_build.state}}">{{branch.last_build.number}} {{humanize-state branch.last_build.state}}</span>
         {{/link-to}}
       {{else}}
         {{request-icon event=branch.last_build.eventType state=branch.last_build.state}} -

--- a/app/templates/components/builds-item.hbs
+++ b/app/templates/components/builds-item.hbs
@@ -42,7 +42,7 @@
         {{else}}
           {{request-icon event=build.eventType state=build.state}}
         {{/if}}
-        <span class="label-align inner-underline">#{{build.number}} {{build.state}}</span>
+        <span class="label-align inner-underline">#{{build.number}} {{humanize-state build.state}}</span>
       {{/link-to}}
     {{/if}}
   </h3>


### PR DESCRIPTION
#### What does this PR do?
- Fix state copy for build history tab to be consistent with rest of `Travis-Web`

#### How this PR makes you feel?
![fix_it](https://user-images.githubusercontent.com/529465/51264470-cd6e4480-1973-11e9-9921-12569de00b19.gif)

