### PR TITLE
Add handling for mis-configured language

### DIFF
--- a/app/utils/job-config-language.js
+++ b/app/utils/job-config-language.js
@@ -18,6 +18,9 @@ export default function jobConfigLanguage(config) {
         if (languageName === 'Android') {
           output.push('Android');
           completedLanguageNames.push(languageName);
+        } else if (version instanceof Object) {
+          output.push(languageName);
+          completedLanguageNames.push(languageName);
         } else {
           output.push(`${languageName}: ${version}`);
           completedLanguageNames.push(languageName);

--- a/app/utils/job-config-language.js
+++ b/app/utils/job-config-language.js
@@ -17,14 +17,13 @@ export default function jobConfigLanguage(config) {
 
         if (languageName === 'Android') {
           output.push('Android');
-          completedLanguageNames.push(languageName);
         } else if (version instanceof Object) {
           output.push(languageName);
-          completedLanguageNames.push(languageName);
         } else {
           output.push(`${languageName}: ${version}`);
-          completedLanguageNames.push(languageName);
         }
+
+        completedLanguageNames.push(languageName);
       }
     }
     gemfile = config.gemfile;

--- a/tests/unit/utils/job-config-language-test.js
+++ b/tests/unit/utils/job-config-language-test.js
@@ -38,4 +38,8 @@ module('jobConfigLanguage', function () {
   test('a job with Android components and Android language only has Android once', (assert) => {
     assert.equal(jobConfigLanguage({ language: 'android', android: { components: ['dumont', 'riel'] } }), 'Android');
   });
+
+  test('an incorrectly-structured config doesn’t print [object Object]', assert => {
+    assert.equal(jobConfigLanguage({ osx_image: { osx_image: 'xcode10' }}), 'Xcode');
+  });
 });


### PR DESCRIPTION
This avoids the rendering of `[object Object]` when a language
is mis-specified.

It may be that we want something more here, like an alert of
some kind, but this is an interim measure at least.