### PR TITLE
Add ability to deploy travis-web locally

### DIFF
--- a/config/deployment/deploy-local.sh
+++ b/config/deployment/deploy-local.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+export CLEANED_BRANCH_SUBDOMAIN=`git name-rev --name-only HEAD | tr '.' '-' | tr '/' '-' | tr '[:upper:]' '[:lower:]'`
+
+eval $(./config/deployment/store-redis-urls.sh)
+
+if [[ $TRAVIS_PULL_REQUEST_BRANCH = *staging* ]]
+then
+  echo "Staging branch is not allowed to be deployed locally"
+  exit 1
+fi
+
+ember deploy org-production-pull-request --activate
+TRAVIS_PRO=true ember deploy com-production-pull-request --activate
+
+echo "Deployment URLs:"
+echo "- https://$CLEANED_BRANCH_SUBDOMAIN.test-deployments.travis-ci.org"
+echo "- https://$CLEANED_BRANCH_SUBDOMAIN.test-deployments.travis-ci.com"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",
     "start": "ember serve",
-    "test": "ember test --reporter dot"
+    "test": "ember test --reporter dot",
+    "deploy": "bash ./config/deployment/deploy-local.sh"
   },
   "devDependencies": {
     "@ember/jquery": "^0.5.2",


### PR DESCRIPTION
This PR enables test deployments from local environment. It works similar to PR deployments, but disabled for staging branches and picks branch from current git head. Basically, it pushes changes to the same subdomain that PR deployments do, so if there is a PR for the branch, the deployments will just be updated and the PR links will still work. Although, it's not necessary to have a PR to deploy test build, the script prints out deployment URLs. 

To deploy current branch just execute `npm run deploy` in project directory.

Of course, in order to upload assets, AWS credentials must be provided as environment variables `AWS_KEY` and `AWS_SECRET`. These could be acquired (generated) in AWS console.

The most convenient way to provide them would be to put them to `.env` file:
```
AWS_KEY=<your key>
AWS_SECRET=<your secret>
```
This file is excluded from git index and automatically supported by `ember-cli-deploy`.