### PR TITLE
Address top bar testing inconsistencies

### DIFF
--- a/app/components/top-bar.js
+++ b/app/components/top-bar.js
@@ -35,6 +35,7 @@ export default Component.extend(InViewportMixin, {
 
   didInsertElement() {
     if (Ember.testing) {
+      this._super(...arguments);
       return;
     }
 


### PR DESCRIPTION
AFAIK this._super should always be called in cases like this.