### PR TITLE
Update job banner to message PHP default jobs

### DIFF
--- a/app/components/job-infrastructure-notification.js
+++ b/app/components/job-infrastructure-notification.js
@@ -53,14 +53,9 @@ export default Component.extend({
     }
   }),
 
-  isPHPDefault: computed('queue', 'job.config.language', function () {
-    let queue = this.get('queue');
-    let language = this.get('job.config.language');
-    if (queue === 'builds.gce') {
-      if (language !== 'php') {
-        return true;
-      }
-    }
+  isPHPDefault: computed('job.config.{language,php}', function () {
+    const { language, php } = this.get('job.config') || {};
+    return language === 'php' && !php;
   }),
 
   macOSImage: alias('jobConfig.osx_image'),

--- a/app/components/job-infrastructure-notification.js
+++ b/app/components/job-infrastructure-notification.js
@@ -53,6 +53,16 @@ export default Component.extend({
     }
   }),
 
+  isPHPDefault: computed('queue', 'job.config.language', function () {
+    let queue = this.get('queue');
+    let language = this.get('job.config.language');
+    if (queue === 'builds.gce') {
+      if (language !== 'php') {
+        return true;
+      }
+    }
+  }),
+
   macOSImage: alias('jobConfig.osx_image'),
   deprecatedXcodeImages: ['xcode8.1', 'xcode8.2', 'xcode6.4'],
 

--- a/app/components/job-infrastructure-notification.js
+++ b/app/components/job-infrastructure-notification.js
@@ -54,7 +54,8 @@ export default Component.extend({
   }),
 
   isPHPDefault: computed('job.config.{language,php}', function () {
-    const { language, php } = this.get('job.config') || {};
+    const language = this.get('job.config.language');
+    const php = this.get('job.config.php');
     return language === 'php' && !php;
   }),
 

--- a/app/templates/components/job-infrastructure-notification.hbs
+++ b/app/templates/components/job-infrastructure-notification.hbs
@@ -7,7 +7,12 @@
     {{/if}}
     {{#if isPreciseEOL}}
       {{#notice-banner}}
-        This job {{conjugatedRun}} on our <b>Precise</b> environment, which is in the process of being decommissioned.  Please read about the status of the rollout <a href="https://blog.travis-ci.com/2017-08-31-trusty-as-default-status">on the blog</a>, and take note that you can explicitly stay on Precise by specifying <code>dist: precise</code> in your .travis.yml.
+        This job {{conjugatedRun}} on our <b>Precise</b> environment, which is in the process of being decommissioned.  Please update to a newer Ubuntu version by specifying <code>dist: xenial</code> in your <em>.travis.yml</em>.
+      {{/notice-banner}}
+    {{/if}}
+    {{#if isPHPDefault}}
+      {{#notice-banner}}
+        This job {{conjugatedRun}} using the default <b>PHP</b> version, which will be updated to 7.2 on March 12th, 2019. You can explicitly stay on your current default by specifying <code>php: 5.5</code> in your <em>.travis.yml</em>.
       {{/notice-banner}}
     {{/if}}
   {{/if}}


### PR DESCRIPTION
For upcoming PHP default update from 5.5 to 7.2

While I was there, also updated precise banner to recommend upgrading to Xenial

I need help evaluating there's not a pinned php version, rather than just the language check, is that feasible?