### PR TITLE
Loading overlay and loading indicator

### DIFF
--- a/app/components/loading-indicator.js
+++ b/app/components/loading-indicator.js
@@ -4,9 +4,11 @@ export default Component.extend({
   tagName: 'div',
   classNameBindings: [
     'center:loading-container',
+    'single:loading-single',
     'inline:inline-block',
     'height:icon-height',
     'white:white'
   ],
-  center: false
+  center: false,
+  single: false
 });

--- a/app/components/loading-overlay.js
+++ b/app/components/loading-overlay.js
@@ -1,0 +1,9 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+  classNames: ['loading-overlay'],
+  classNameBindings: ['visible:loading-overlay--visible'],
+
+  visible: false
+
+});

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -49,6 +49,7 @@
 @import "app/modules/paper-block";
 @import "app/modules/travis-form";
 @import "app/modules/yaml";
+@import "app/modules/loading-overlay";
 
 @import "app/animation/tractor";
 @import "app/animation/barricade";

--- a/app/styles/app/modules/loading-overlay.scss
+++ b/app/styles/app/modules/loading-overlay.scss
@@ -1,0 +1,58 @@
+.loading-overlay {
+  position: relative;
+  min-height: 15px;
+
+  &--visible &__backdrop {
+    opacity: 1;
+    top: 0;
+    bottom: 0;
+  }
+
+  &__backdrop {
+    opacity: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: absolute;
+    top: 50%;
+    bottom: 50%;
+    left: 0;
+    right: 0;
+    background: rgba(255, 255, 255, 0.8);
+    overflow: hidden;
+
+    transition: all 0.2s ease-in;
+  }
+
+  &__indicator {
+    width: 7%;
+    min-width: 30px;
+    position: relative;
+
+    &:before {
+      content: '';
+      display: block;
+      padding-top: 100%;
+    }
+
+    .loading-indicator {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
+
+      display: flex;
+      justify-content: center;
+      align-items: center;
+
+      i {
+        width: 30%;
+        height: 30%;
+      }
+
+    }
+
+  }
+
+}

--- a/app/templates/components/loading-indicator.hbs
+++ b/app/templates/components/loading-indicator.hbs
@@ -1,1 +1,7 @@
-<span class="loading-indicator"><i></i><i></i><i></i></span>
+<span class="loading-indicator">
+  <i></i>
+  {{#unless single}}
+    <i></i>
+    <i></i>
+  {{/unless}}
+</span>

--- a/app/templates/components/loading-overlay.hbs
+++ b/app/templates/components/loading-overlay.hbs
@@ -1,0 +1,5 @@
+{{yield}}
+
+<div class='loading-overlay__backdrop'>
+  {{loading-indicator class='loading-overlay__indicator'}}
+</div>


### PR DESCRIPTION
Another portion of extractions from https://github.com/travis-ci/travis-web/pull/1949/

This PR introduces a new component `loading-overlay` which wraps any content and dims it when `visible=true`. Here's a short demo:

![image](https://cl.ly/c6275bd1a3bb/Screen%252520Recording%2525202019-03-13%252520at%25252007.02%252520PM.gif)

Also this PR adds a `{{loading-indicator single=true}}` mode to `loading-indicator` component that makes it show only one dot instead of three, which may be useful when there's not enough space to show three (like over the checkbox).