### PR TITLE
Fix tooltips appearance

### DIFF
--- a/app/styles/app/modules/tooltips.scss
+++ b/app/styles/app/modules/tooltips.scss
@@ -1,7 +1,27 @@
+$tooltip-color: $asphalt-grey;
+
 .ember-tooltip {
   padding: 3px 6px;
   font-size: 12px;
-  background-color: #666;
+  background-color: $tooltip-color;
+  text-align: center;
+
+  &[x-placement^="top"] .ember-tooltip-arrow {
+    border-top-color: $tooltip-color;
+  }
+
+  &[x-placement^="bottom"] .ember-tooltip-arrow {
+    border-bottom-color: $tooltip-color;
+  }
+
+  &[x-placement^="left"] .ember-tooltip-arrow {
+    border-left-color: $tooltip-color;
+  }
+
+  &[x-placement^="right"] .ember-tooltip-arrow {
+    border-right-color: $tooltip-color;
+  }
+
 }
 
 body > .ember-tooltip {


### PR DESCRIPTION
This PR fixes tooltip arrow color.

Ever since update of `ember-tooltip` add-on the arrow was a different color:

![image](https://user-images.githubusercontent.com/4066489/54296612-51d0f280-45c6-11e9-98ac-9a3ff7527172.png)

Now it's the same color:

![image](https://user-images.githubusercontent.com/4066489/54296676-690fe000-45c6-11e9-86e3-ae16400e2b3d.png)
