### PR TITLE
Add red button

### DIFF
--- a/app/styles/app/modules/buttons.scss
+++ b/app/styles/app/modules/buttons.scss
@@ -181,6 +181,18 @@
   }
 }
 
+.button--red {
+  @extend %button;
+
+  border: none;
+  color: white;
+  background-color: $brick-red;
+
+  &:hover {
+    background-color: darken($brick-red, 10);
+  }
+}
+
 .button--compact {
   padding: 3px 7px;
 }


### PR DESCRIPTION
Modeled after `.button--green`. We have buttons of various colors, why not red as well? Split off from https://github.com/travis-ci/travis-web/pull/1953