### PR TITLE
Add build-count and insights-glance components

### DIFF
--- a/app/components/build-count.js
+++ b/app/components/build-count.js
@@ -1,0 +1,94 @@
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
+import { computed } from '@ember/object';
+import { pluralize } from 'ember-inflector';
+import { reads, equal, or } from '@ember/object/computed';
+import { task } from 'ember-concurrency';
+import { DEFAULT_INSIGHTS_INTERVAL } from 'travis/services/insights';
+
+export default Component.extend({
+  classNames: ['insights-build-count'],
+  private: false,
+  interval: DEFAULT_INSIGHTS_INTERVAL,
+  owner: null,
+
+  insights: service(),
+
+  // Current Interval Chart Data
+  requestData: task(function* () {
+    return yield this.insights.getChartData.perform(
+      this.owner,
+      this.interval,
+      'builds',
+      'sum',
+      ['count_started'],
+      {
+        calcAvg: true,
+        private: this.private,
+      }
+    );
+  }),
+  chartData: reads('requestData.lastSuccessful.value'),
+  builds: reads('chartData.data.count_started.plotValues'),
+  labels: reads('chartData.labels'),
+
+  isLoading: reads('requestData.isRunning'),
+  isEmpty: equal('totalBuilds', 0),
+  showPlaceholder: or('isLoading', 'isEmpty'),
+
+  // Total / average
+  totalBuilds: reads('chartData.data.total'),
+  avgBuilds: reads('chartData.data.average'),
+
+  totalBuildText: computed('totalBuilds', function () {
+    if (typeof this.totalBuilds !== 'number') { return '\xa0'; }
+    return this.totalBuilds.toLocaleString();
+  }),
+
+  // Previous interval chart data
+  requestPastData: task(function* () {
+    return yield this.insights.getChartData.perform(
+      this.owner,
+      this.interval,
+      'builds',
+      'sum',
+      ['count_started'],
+      { startInterval: -2, endInterval: -1, calcTotal: true, calcAvg: true, private: this.private }
+    );
+  }),
+  pastIntervalData: reads('requestPastData.lastSuccessful.value'),
+  prevTotalBuilds: reads('pastIntervalData.data.count_started.total'),
+
+  // Percent change
+  percentChangeTitle: computed('prevTotalBuilds', 'interval', function () {
+    if (this.prevTotalBuilds) {
+      return [
+        this.prevTotalBuilds.toLocaleString(),
+        pluralize(this.prevTotalBuilds, 'build', {withoutCount: true}),
+        `the previous ${this.interval}`
+      ].join(' ');
+    }
+
+    return '';
+  }),
+
+  percentageChange: computed('prevTotalBuilds', 'totalBuilds', function () {
+    if (this.prevTotalBuilds && this.totalBuilds) {
+      const change = ((this.totalBuilds - this.prevTotalBuilds) / this.prevTotalBuilds);
+      const percent = change * 100;
+      return (Math.round(percent * 10) / 10);
+    }
+
+    return 0;
+  }),
+
+  percentageChangeText: computed('percentageChange', function () {
+    return `${Math.abs(this.percentageChange)}%`;
+  }),
+
+  // Request chart data
+  didReceiveAttrs() {
+    this.requestData.perform();
+    this.requestPastData.perform();
+  }
+});

--- a/app/components/build-count.js
+++ b/app/components/build-count.js
@@ -27,7 +27,7 @@ export default Component.extend({
         private: this.private,
       }
     );
-  }),
+  }).drop(),
   chartData: reads('requestData.lastSuccessful.value'),
   builds: reads('chartData.data.count_started.plotValues'),
   labels: reads('chartData.labels'),
@@ -55,7 +55,7 @@ export default Component.extend({
       ['count_started'],
       { startInterval: -2, endInterval: -1, calcTotal: true, calcAvg: true, private: this.private }
     );
-  }),
+  }).drop(),
   pastIntervalData: reads('requestPastData.lastSuccessful.value'),
   prevTotalBuilds: reads('pastIntervalData.data.count_started.total'),
 

--- a/app/components/insights-glance.js
+++ b/app/components/insights-glance.js
@@ -1,0 +1,87 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { or } from '@ember/object/computed';
+import { format as d3format } from 'd3';
+
+export default Component.extend({
+  classNames: ['insights-glance'],
+  classNameBindings: ['isLoading:insights-glance--loading'],
+
+  isLoading: true,
+  isEmpty: false,
+
+  title: '',
+  statistic: '',
+
+  delta: 0,
+  deltaTitle: '',
+  deltaText: '',
+
+  labels: [],
+  values: [],
+  datasetTitle: 'Data',
+  centerline: null,
+
+  showPlaceholder: or('isLoading', 'isEmpty'),
+
+  // Chart component data
+  data: computed('values', 'labels', 'datasetTitle', function () {
+    return {
+      type: 'spline',
+      x: 'x',
+      columns: [
+        ['x', ...this.labels],
+        [this.datasetTitle, ...this.values],
+      ],
+      colors: {
+        [this.datasetTitle]: '#666',
+      },
+    };
+  }),
+
+  // Chart component options
+  legend: { show: false },
+  size: { height: 50 },
+
+  point: {
+    r: 0,
+    focus: {
+      expand: { r: 4 },
+    }
+  },
+
+  axis: {
+    x: {
+      type: 'timeseries',
+      tick: { format: '%A, %b %e' },
+      show: false,
+    },
+    y: { show: false }
+  },
+
+  tooltip: {
+    position: (data, width, height, element) => {
+      let top = -50;
+      let left = (element.getAttribute('width') - width) / 2;
+      return ({ top, left });
+    },
+    format: {
+      value: d3format(','),
+    }
+  },
+
+  grid: computed('centerline', function () {
+    const grid = {
+      lines: { front: false },
+    };
+    if (this.centerline) {
+      grid.y = {
+        lines: [{
+          value: this.centerline,
+          class: 'insights-glance__centerline',
+        }],
+      };
+    }
+    return grid;
+  }),
+});

--- a/app/components/insights-glance.js
+++ b/app/components/insights-glance.js
@@ -17,15 +17,15 @@ export default Component.extend({
   deltaTitle: '',
   deltaText: '',
 
-  labels: [],
-  values: [],
+  labels: computed(() => []),
+  values: computed(() => []),
   datasetTitle: 'Data',
   centerline: null,
 
   showPlaceholder: or('isLoading', 'isEmpty'),
 
   // Chart component data
-  data: computed('values', 'labels', 'datasetTitle', function () {
+  data: computed('values.[]', 'labels.[]', 'datasetTitle', function () {
     return {
       type: 'spline',
       x: 'x',
@@ -40,26 +40,26 @@ export default Component.extend({
   }),
 
   // Chart component options
-  legend: { show: false },
-  size: { height: 50 },
+  legend: computed(() => ({ show: false })),
+  size: computed(() => ({ height: 50 })),
 
-  point: {
+  point: computed(() => ({
     r: 0,
     focus: {
       expand: { r: 4 },
     }
-  },
+  })),
 
-  axis: {
+  axis: computed(() => ({
     x: {
       type: 'timeseries',
       tick: { format: '%A, %b %e' },
       show: false,
     },
     y: { show: false }
-  },
+  })),
 
-  tooltip: {
+  tooltip: computed(() => ({
     position: (data, width, height, element) => {
       let top = -50;
       let left = (element.getAttribute('width') - width) / 2;
@@ -68,7 +68,7 @@ export default Component.extend({
     format: {
       value: d3format(','),
     }
-  },
+  })),
 
   grid: computed('centerline', function () {
     const grid = {

--- a/app/templates/components/build-count.hbs
+++ b/app/templates/components/build-count.hbs
@@ -1,0 +1,16 @@
+{{insights-glance
+  isLoading=isLoading
+  isEmpty=isEmpty
+
+  title='Builds'
+  statistic=totalBuildText
+
+  delta=percentageChange
+  deltaTitle=percentChangeTitle
+  deltaText=percentageChangeText
+
+  labels=labels
+  values=builds
+  datasetTitle='Builds'
+  centerline=avgBuilds
+}}

--- a/app/templates/components/insights-glance.hbs
+++ b/app/templates/components/insights-glance.hbs
@@ -1,0 +1,27 @@
+<h3 class="insights-glance__title">{{title}}</h3>
+<div class="insights-glance__center">
+  <div class="insights-glance__stat">
+    {{#if isLoading}}
+      {{loading-indicator}}
+    {{else}}
+      {{statistic}}
+    {{/if}}
+  </div>
+  {{#if delta}}
+    <div
+      class="insights-glance-delta"
+      data-dir="{{if (gte delta 0) '+' '-'}}"
+      title="{{deltaTitle}}"
+    >
+      {{svg-jar 'icon-dropdown-arrow' class="icon"}}
+      <span class="insights-glance-delta__stat">{{deltaText}}</span>
+    </div>
+  {{/if}}
+</div>
+<div class="insights-glance__chart">
+  {{#if showPlaceholder}}
+    <hr class="insights-glance__chart-placeholder" />
+  {{else}}
+    {{c3-chart class='chart-component' data=data axis=axis legend=legend grid=grid size=size point=point tooltip=tooltip}}
+  {{/if}}
+</div>

--- a/app/templates/components/insights-glance.hbs
+++ b/app/templates/components/insights-glance.hbs
@@ -10,8 +10,8 @@
   {{#if delta}}
     <div
       class="insights-glance-delta"
-      data-dir="{{if (gte delta 0) '+' '-'}}"
-      title="{{deltaTitle}}"
+      data-dir={{if (gte delta 0) '+' '-'}}
+      title={{deltaTitle}}
     >
       {{svg-jar 'icon-dropdown-arrow' class="icon"}}
       <span class="insights-glance-delta__stat">{{deltaText}}</span>

--- a/tests/integration/components/build-count-test.js
+++ b/tests/integration/components/build-count-test.js
@@ -1,0 +1,49 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, settled, waitFor } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { INSIGHTS_INTERVALS } from 'travis/services/insights';
+
+
+module('Integration | Component | build-count', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    const user = this.server.create('user');
+    this.setProperties({
+      ownerData: user,
+      private: true,
+    });
+  });
+
+  test('builds stats', async function (assert) {
+    this.set('interval', INSIGHTS_INTERVALS.MONTH);
+
+    this.server.createList('insight-metric', 15);
+
+    await render(hbs`{{build-count interval=interval owner=ownerData private=private}}`);
+    await settled();
+
+    assert.dom('.insights-glance').doesNotHaveClass('insights-glance--loading');
+    assert.dom('.insights-glance__title').hasText('Builds');
+    assert.dom('.insights-glance__stat').hasText('448');
+    assert.dom('.insights-glance-delta').hasAttribute('data-dir', '+');
+    assert.dom('.insights-glance-delta').hasAttribute('title', '120 builds the previous month');
+    assert.dom('.insights-glance-delta__stat').hasText('273.3%');
+    assert.dom('.insights-glance__chart .chart-component').exists();
+  });
+
+  test('loading state renders', async function (assert) {
+    this.set('interval', INSIGHTS_INTERVALS.WEEK);
+
+    render(hbs`{{build-count interval=interval owner=ownerData private=private}}`);
+    await waitFor('.insights-glance--loading');
+
+    assert.dom('.insights-glance').hasClass('insights-glance--loading');
+    assert.dom('.insights-glance__title').hasText('Builds');
+    assert.dom('.insights-glance__stat').hasText('');
+    assert.dom('.insights-glance-delta').doesNotExist();
+    assert.dom('.insights-glance__chart .chart-component').doesNotExist();
+    assert.dom('.insights-glance__chart-placeholder').exists();
+  });
+});

--- a/tests/integration/components/insights-glance-test.js
+++ b/tests/integration/components/insights-glance-test.js
@@ -1,0 +1,43 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | insights-glance', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('loading state renders', async function (assert) {
+    this.set('isLoading', true);
+
+    await render(hbs`{{insights-glance isLoading=isLoading}}`);
+    assert.dom('.insights-glance').hasClass('insights-glance--loading');
+    assert.dom('.insights-glance__stat').hasText('');
+    assert.dom('.insights-glance__chart .chart-component').doesNotExist();
+  });
+
+  test('loaded state renders', async function (assert) {
+    this.setProperties({
+      title: 'Test title',
+      isLoading: false,
+      statistic: 100,
+      isEmpty: false,
+    });
+
+    await render(hbs`{{insights-glance isLoading=isLoading statistic=statistic isEmpty=isEmpty title=title}}`);
+
+    assert.dom('.insights-glance__title').hasText('Test title');
+    assert.dom('.insights-glance__stat').hasText('100');
+    assert.dom('.insights-glance__chart .chart-component').exists();
+  });
+
+  test('delta section renders', async function (assert) {
+    this.set('delta', 5);
+    this.set('deltaTitle', 'Test 1');
+    this.set('deltaText', 'Test 2');
+
+    await render(hbs`{{insights-glance delta=delta deltaTitle=deltaTitle deltaText=deltaText}}`);
+    assert.dom('.insights-glance-delta').hasAttribute('data-dir', '+');
+    assert.dom('.insights-glance-delta').hasAttribute('title', 'Test 1');
+    assert.dom('.insights-glance-delta__stat').hasText('Test 2');
+  });
+});


### PR DESCRIPTION
Split from https://github.com/travis-ci/travis-web/pull/1966

This adds a build-count component that generates a graph displaying build count data, along with some stats. It is one of 4 very similar components, which all utilize the insights-glance component, which handles a lot of the shared functionality.