### PR TITLE
Add insights build-minutes component

### DIFF
--- a/app/components/build-minutes.js
+++ b/app/components/build-minutes.js
@@ -1,0 +1,57 @@
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
+import { computed } from '@ember/object';
+import { pluralize } from 'ember-inflector';
+import { reads, equal, or } from '@ember/object/computed';
+import { task } from 'ember-concurrency';
+import { DEFAULT_INSIGHTS_INTERVAL } from 'travis/services/insights';
+
+
+export default Component.extend({
+  classNames: ['insights-build-minutes'],
+  private: false,
+  interval: DEFAULT_INSIGHTS_INTERVAL,
+  owner: null,
+
+  insights: service(),
+
+  // Current Interval Chart Data
+  requestData: task(function* () {
+    return yield this.insights.getChartData.perform(
+      this.owner,
+      this.interval,
+      'builds',
+      'sum',
+      ['times_running'],
+      {
+        calcAvg: true,
+        private: this.private,
+        customSerialize: (key, val) => [key, Math.round(val / 60)],
+      }
+    );
+  }).drop(),
+  chartData: reads('requestData.lastSuccessful.value'),
+  buildMins: reads('chartData.data.times_running.plotValues'),
+  labels: reads('chartData.labels'),
+
+  isLoading: reads('requestData.isRunning'),
+  isEmpty: equal('totalBuildMins', 0),
+  showPlaceholder: or('isLoading', 'isEmpty'),
+
+  // Total / average
+  totalBuildMins: reads('chartData.data.times_running.total'),
+  avgBuildMins: reads('chartData.data.times_running.average'),
+
+  totalBuildText: computed('isLoading', 'totalBuildMins', function () {
+    if (this.isLoading || typeof this.totalBuildMins !== 'number') { return '\xa0'; }
+    return `
+      ${this.totalBuildMins.toLocaleString()}
+      ${pluralize(this.totalBuildMins, 'min', { withoutCount: true })}
+    `.trim();
+  }),
+
+  // Request chart data
+  didReceiveAttrs() {
+    this.requestData.perform();
+  }
+});

--- a/app/templates/components/build-minutes.hbs
+++ b/app/templates/components/build-minutes.hbs
@@ -1,0 +1,12 @@
+{{insights-glance
+  isLoading=isLoading
+  isEmpty=isEmpty
+
+  title='Total Build Minutes'
+  statistic=totalBuildText
+
+  labels=labels
+  values=buildMins
+  datasetTitle='Minutes'
+  centerline=avgBuildMins
+}}

--- a/tests/integration/components/build-minutes-test.js
+++ b/tests/integration/components/build-minutes-test.js
@@ -1,0 +1,41 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, settled, waitFor } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { INSIGHTS_INTERVALS } from 'travis/services/insights';
+
+module('Integration | Component | build-minutes', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    const user = this.server.create('user');
+    this.setProperties({
+      ownerData: user,
+      private: true,
+      interval: INSIGHTS_INTERVALS.WEEK,
+    });
+  });
+
+  test('it renders', async function (assert) {
+    this.server.createList('insight-metric', 5);
+
+    await render(hbs`{{build-minutes interval=interval owner=ownerData private=private}}`);
+    await settled();
+
+    assert.dom('.insights-glance').doesNotHaveClass('insights-glance--loading');
+    assert.dom('.insights-glance__title').hasText('Total Build Minutes');
+    assert.dom('.insights-glance__stat').hasText('5 mins');
+    assert.dom('.insights-glance__chart .chart-component').exists();
+  });
+
+  test('loading state renders', async function (assert) {
+    render(hbs`{{build-minutes interval=interval owner=ownerData private=private}}`);
+    await waitFor('.insights-glance--loading');
+
+    assert.dom('.insights-glance').hasClass('insights-glance--loading');
+    assert.dom('.insights-glance__title').hasText('Total Build Minutes');
+    assert.dom('.insights-glance__stat').hasText('');
+    assert.dom('.insights-glance__chart .chart-component').doesNotExist();
+    assert.dom('.insights-glance__chart-placeholder').exists();
+  });
+});


### PR DESCRIPTION
Split from https://github.com/travis-ci/travis-web/pull/1966

Adds a glance component that shows build minute chart and stats.