### PR TITLE
Add insights queue-times component

### DIFF
--- a/app/components/queue-times.js
+++ b/app/components/queue-times.js
@@ -1,0 +1,112 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { pluralize } from 'ember-inflector';
+import { reads, equal, or } from '@ember/object/computed';
+import { task } from 'ember-concurrency';
+
+export default Component.extend({
+  classNames: ['insights-queue-times'],
+  private: false,
+
+  insights: service(),
+
+  // Current Interval Chart Data
+  requestData: task(function* () {
+    return yield this.insights.getChartData.perform(
+      this.owner,
+      this.interval,
+      'jobs',
+      'avg',
+      ['times_waiting'],
+      {
+        calcAvg: true,
+        private: this.private,
+        customSerialize: (key, val) => [key, (Math.round((val / 60) * 100) / 100)],
+      }
+    );
+  }).drop(),
+  chartData: reads('requestData.lastSuccessful.value'),
+  waitMins: reads('chartData.data.times_waiting.plotValues'),
+  labels: reads('chartData.labels'),
+
+  isLoading: reads('requestData.isRunning'),
+  isEmpty: equal('totalWaitMins', 0),
+  showPlaceholder: or('isLoading', 'isEmpty'),
+
+  // Total / average
+  totalWaitMins: reads('chartData.data.times_waiting.total'),
+  average: reads('chartData.data.times_waiting.average'),
+  averageRounded: computed('average', function () {
+    return Math.round(this.average * 100) / 100;
+  }),
+
+  avgWaitText: computed('isLoading', 'averageRounded', function () {
+    const { isLoading, averageRounded } = this;
+
+    if (isLoading || typeof averageRounded !== 'number') { return '\xa0'; }
+
+    return `
+      ${averageRounded.toLocaleString()}
+      ${pluralize(averageRounded, 'min', {withoutCount: true})}
+    `.trim();
+  }),
+
+  // Previous interval chart data
+  requestPastData: task(function* () {
+    return yield this.insights.getChartData.perform(
+      this.owner,
+      this.interval,
+      'jobs',
+      'avg',
+      ['times_waiting'],
+      {
+        startInterval: -2,
+        endInterval: -1,
+        calcAvg: true,
+        private: this.private,
+        customSerialize: (key, val) => [key, Math.round(val / 60)]
+      }
+    );
+  }).drop(),
+  pastIntervalData: reads('requestPastData.lastSuccessful.value'),
+
+  previousAverage: reads('pastIntervalData.data.times_waiting.average'),
+  previousAverageRounded: computed('previousAverage', function () {
+    return Math.round(this.previousAverage * 100) / 100;
+  }),
+
+  // Percent change
+  percentageChange: computed('previousAverageRounded', 'averageRounded', function () {
+    const { previousAverageRounded, averageRounded } = this;
+
+    if (previousAverageRounded && averageRounded) {
+      const change = ((averageRounded - previousAverageRounded) / previousAverageRounded);
+      const percent = change * 100;
+      return (Math.round(percent * 10) / 10);
+    }
+
+    return 0;
+  }),
+
+  percentageChangeText: computed('percentageChange', function () {
+    return `${Math.abs(this.percentageChange)}%`;
+  }),
+
+  percentChangeTitle: computed('previousAverageRounded', 'interval', function () {
+    const { previousAverageRounded, interval } = this;
+
+    return [
+      'Averaged',
+      previousAverageRounded.toLocaleString(),
+      pluralize(previousAverageRounded, 'min', { withoutCount: true }),
+      `the previous ${interval}`
+    ].join(' ');
+  }),
+
+  // Request chart data
+  didReceiveAttrs() {
+    this.requestData.perform();
+    this.requestPastData.perform();
+  }
+});

--- a/app/templates/components/queue-times.hbs
+++ b/app/templates/components/queue-times.hbs
@@ -1,0 +1,16 @@
+{{insights-glance
+  isLoading=isLoading
+  isEmpty=isEmpty
+
+  title='Average Queue Time'
+  statistic=avgWaitText
+
+  delta=percentageChange
+  deltaTitle=percentChangeTitle
+  deltaText=percentageChangeText
+
+  labels=labels
+  values=waitMins
+  datasetTitle='Minutes'
+  centerline=averageRounded
+}}

--- a/tests/integration/components/queue-times-test.js
+++ b/tests/integration/components/queue-times-test.js
@@ -1,0 +1,47 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, settled, waitFor } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { INSIGHTS_INTERVALS } from 'travis/services/insights';
+
+module('Integration | Component | queue-times', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    const user = this.server.create('user');
+    this.setProperties({
+      ownerData: user,
+      private: true,
+    });
+  });
+
+  test('stats exist', async function (assert) {
+    this.set('interval', INSIGHTS_INTERVALS.MONTH);
+
+    this.server.createList('insight-metric', 15);
+
+    await render(hbs`{{queue-times interval=interval owner=ownerData private=private}}`);
+    await settled();
+
+    assert.dom('.insights-glance').doesNotHaveClass('insights-glance--loading');
+    assert.dom('.insights-glance__title').hasText('Average Queue Time');
+    assert.dom('.insights-glance__stat').hasText('0.6 mins');
+    assert.dom('.insights-glance-delta').hasAttribute('data-dir', '-');
+    assert.dom('.insights-glance-delta').hasAttribute('title', 'Averaged 1 min the previous month');
+    assert.dom('.insights-glance-delta__stat').hasText('40%');
+    assert.dom('.insights-glance__chart .chart-component').exists();
+  });
+
+  test('loading state renders', async function (assert) {
+    this.set('interval', INSIGHTS_INTERVALS.WEEK);
+
+    render(hbs`{{queue-times interval=interval owner=ownerData private=private}}`);
+    await waitFor('.insights-glance--loading');
+
+    assert.dom('.insights-glance').hasClass('insights-glance--loading');
+    assert.dom('.insights-glance__title').hasText('Average Queue Time');
+    assert.dom('.insights-glance__stat').hasText('');
+    assert.dom('.insights-glance__chart .chart-component').doesNotExist();
+    assert.dom('.insights-glance__chart-placeholder').exists();
+  });
+});


### PR DESCRIPTION
Split from https://github.com/travis-ci/travis-web/pull/1966

Adds an insights-glance component that shows average queue time chart and stats.