### PR TITLE
Add insights active-repo-count component

### DIFF
--- a/app/components/active-repo-count.js
+++ b/app/components/active-repo-count.js
@@ -1,0 +1,59 @@
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
+import { computed } from '@ember/object';
+import { reads, equal, or } from '@ember/object/computed';
+import { task } from 'ember-concurrency';
+import { DEFAULT_INSIGHTS_INTERVAL } from 'travis/services/insights';
+
+export default Component.extend({
+  classNames: ['insights-active-repo-count'],
+  private: false,
+  interval: DEFAULT_INSIGHTS_INTERVAL,
+  owner: null,
+
+  insights: service(),
+
+  // Chart data
+  requestData: task(function* () {
+    return yield this.insights.getChartData.perform(
+      this.owner,
+      this.interval,
+      'jobs',
+      'sum',
+      ['count_started'],
+      {
+        aggregator: 'count',
+        calcAvg: true,
+        private: this.private,
+      }
+    );
+  }).drop(),
+  chartData: reads('requestData.lastSuccessful.value'),
+  activeRepos: reads('chartData.data.count_started.plotValues'),
+  labels: reads('chartData.labels'),
+
+  isLoading: reads('requestData.isRunning'),
+  isEmpty: equal('chartData.data.total', 0),
+  showPlaceholder: or('isLoading', 'isEmpty'),
+
+  // Average
+  avgRepos: reads('chartData.data.average'),
+  avgReposRounded: computed('avgRepos', function () {
+    return Math.round(this.avgRepos);
+  }),
+
+  // Active Repos has its own separate endpoint for totals, its calculation is somewhat unique
+  requestActiveTotal: task(function* () {
+    return yield this.insights.getActiveRepos(this.owner, this.interval, this.private);
+  }).drop(),
+  activeTotal: reads('requestActiveTotal.lastSuccessful.value.data.count'),
+  activeTotalIsLoading: reads('requestActiveTotal.isRunning'),
+  isAnythingLoading: or('isLoading', 'activeTotalIsLoading'),
+
+  // Request chart data
+  didReceiveAttrs() {
+    this._super(...arguments);
+    this.requestData.perform();
+    this.requestActiveTotal.perform();
+  }
+});

--- a/app/templates/components/active-repo-count.hbs
+++ b/app/templates/components/active-repo-count.hbs
@@ -1,0 +1,12 @@
+{{insights-glance
+  isLoading=isAnythingLoading
+  isEmpty=isEmpty
+
+  title='Active Repositories'
+  statistic=activeTotal
+
+  labels=labels
+  values=activeRepos
+  datasetTitle='Active Repositories'
+  centerline=avgReposRounded
+}}

--- a/tests/integration/components/active-repo-count-test.js
+++ b/tests/integration/components/active-repo-count-test.js
@@ -1,0 +1,41 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, settled, waitFor } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { INSIGHTS_INTERVALS } from 'travis/services/insights';
+
+module('Integration | Component | active-repo-count', function (hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    const user = this.server.create('user');
+    this.setProperties({
+      ownerData: user,
+      private: true,
+      interval: INSIGHTS_INTERVALS.WEEK,
+    });
+  });
+
+  test('it renders', async function (assert) {
+    server.createList('insight-metric', 1);
+
+    await render(hbs`{{active-repo-count interval=interval owner=ownerData private=private}}`);
+    await settled();
+
+    assert.dom('.insights-glance').doesNotHaveClass('insights-glance--loading');
+    assert.dom('.insights-glance__title').hasText('Active Repositories');
+    assert.dom('.insights-glance__stat').hasText('75');
+    assert.dom('.insights-glance__chart .chart-component').exists();
+  });
+
+  test('loading state renders', async function (assert) {
+    render(hbs`{{active-repo-count interval=interval owner=ownerData private=private}}`);
+    await waitFor('.insights-glance--loading');
+
+    assert.dom('.insights-glance').hasClass('insights-glance--loading');
+    assert.dom('.insights-glance__title').hasText('Active Repositories');
+    assert.dom('.insights-glance__stat').hasText('');
+    assert.dom('.insights-glance__chart .chart-component').doesNotExist();
+    assert.dom('.insights-glance__chart-placeholder').exists();
+  });
+});


### PR DESCRIPTION
Split from https://github.com/travis-ci/travis-web/pull/1966

Adds an insights-glance component that shows active repositories chart and stats.