### PR TITLE
Make success flash messages behave more consistently

### DIFF
--- a/app/services/flashes.js
+++ b/app/services/flashes.js
@@ -87,11 +87,13 @@ export default Service.extend({
   removeFlash(msg) {
     setTimeout(() => {
       run(this, () => {
-        if (this.get('flashes.content')) {
-          return this.get('flashes.content').removeObject(msg);
+        if (this.get('flashes').length > 0) {
+          return this.get('flashes').removeObject(msg);
         }
       });
-    }, 15000);
+      // Fadeout is currently done separatly with css, and completes at 7s. Keeping the message around longer than that can result in weird situations
+      // where reloading a page can result in a message showing again that you thought was gone.
+    }, 7000);
   },
 
   close(msg) {


### PR DESCRIPTION
Split from https://github.com/travis-ci/travis-web/pull/1953

In testing I found that success flash messages behaved somewhat inconsistently, and it seems like the `removeFlash` function was maybe just broken?

It referenced `flashes.content`, which doesn't seem to exist nor is referenced anywhere else. And the `close` function below calls `removeObject` on `flashes` rather than `flashes.content`, so I updated `removeFlash` to match that.

It only affected success messages because `removeFlash` is only called for flash messages without close buttons.