### PR TITLE
Add insights privacy selector component

### DIFF
--- a/app/components/insights-privacy-selector.js
+++ b/app/components/insights-privacy-selector.js
@@ -1,0 +1,36 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+
+export const INSIGHTS_PRIVACY_OPTIONS = {
+  PUBLIC: 'public builds',
+  PRIVATE: 'public and private builds',
+};
+
+export default Component.extend({
+  tagName: 'span',
+  classNames: ['insights-privacy-selector'],
+  classNameBindings: ['isPrivateViewable:insights-privacy-selector--selectable'],
+
+  isPrivateViewable: false,
+  includePrivate: false,
+  showFrame: false,
+
+  availableOptions: computed('isPrivateViewable', function () {
+    if (!this.isPrivateViewable) {
+      return [];
+    }
+    return Object.values(INSIGHTS_PRIVACY_OPTIONS);
+  }),
+
+  currentState: computed('isPrivateViewable', 'includePrivate', function () {
+    return (this.isPrivateViewable && this.includePrivate) ? INSIGHTS_PRIVACY_OPTIONS.PRIVATE : INSIGHTS_PRIVACY_OPTIONS.PUBLIC;
+  }),
+
+  setRequestPrivateInsights: () => {},
+
+  actions: {
+    selectInsightScope(option) {
+      this.setRequestPrivateInsights(option === INSIGHTS_PRIVACY_OPTIONS.PRIVATE);
+    }
+  },
+});

--- a/app/components/insights-privacy-selector.js
+++ b/app/components/insights-privacy-selector.js
@@ -16,17 +16,14 @@ export default Component.extend({
   showFrame: false,
 
   availableOptions: computed('isPrivateViewable', function () {
-    if (!this.isPrivateViewable) {
-      return [];
-    }
-    return Object.values(INSIGHTS_PRIVACY_OPTIONS);
+    return this.isPrivateViewable ? Object.values(INSIGHTS_PRIVACY_OPTIONS) : [];
   }),
 
   currentState: computed('isPrivateViewable', 'includePrivate', function () {
     return (this.isPrivateViewable && this.includePrivate) ? INSIGHTS_PRIVACY_OPTIONS.PRIVATE : INSIGHTS_PRIVACY_OPTIONS.PUBLIC;
   }),
 
-  setRequestPrivateInsights: () => {},
+  setRequestPrivateInsights() {},
 
   actions: {
     selectInsightScope(option) {

--- a/app/templates/components/insights-privacy-selector.hbs
+++ b/app/templates/components/insights-privacy-selector.hbs
@@ -1,0 +1,18 @@
+<span class="insights-privacy-selector__title">View:</span>
+{{#if isPrivateViewable}}
+  {{#travis-form as |form|}}
+    {{#form.field
+      value=currentState
+      onChange=(action 'selectInsightScope')
+      showFrame=showFrame
+      data-test-insights-privacy-selector-main-field=true
+      as |field|
+    }}
+      {{#field.select options=availableOptions as |option|}}
+        {{option}}
+      {{/field.select}}
+    {{/form.field}}
+  {{/travis-form}}
+{{else}}
+  <span class="insights-privacy-selector__selected">{{currentState}}</span>
+{{/if}}

--- a/tests/integration/components/insights-privacy-selector-test.js
+++ b/tests/integration/components/insights-privacy-selector-test.js
@@ -1,0 +1,69 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { INSIGHTS_PRIVACY_OPTIONS } from 'travis/components/insights-privacy-selector';
+import { selectChoose } from 'ember-power-select/test-support';
+
+module('Integration | Component | insights-privacy-selector', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('default', async function (assert) {
+    await render(hbs`{{insights-privacy-selector}}`);
+    assert.dom('.insights-privacy-selector__selected').hasText(INSIGHTS_PRIVACY_OPTIONS.PUBLIC);
+  });
+
+  test('only public available', async function (assert) {
+    this.setProperties({
+      isPrivateViewable: false,
+      includePrivate: false,
+    });
+
+    await render(hbs`{{insights-privacy-selector isPrivateViewable=isPrivateViewable includePrivate=includePrivate}}`);
+    assert.dom('.insights-privacy-selector__selected').hasText(INSIGHTS_PRIVACY_OPTIONS.PUBLIC);
+
+    this.set('includePrivate', true);
+    await render(hbs`{{insights-privacy-selector isPrivateViewable=isPrivateViewable includePrivate=includePrivate}}`);
+    assert.dom('.insights-privacy-selector__selected').hasText(INSIGHTS_PRIVACY_OPTIONS.PUBLIC);
+  });
+
+  test('private available, public selected', async function (assert) {
+    this.setProperties({
+      isPrivateViewable: true,
+      includePrivate: false,
+      setPrivate: (actual) => {
+        assert.equal(actual, !this.includePrivate);
+      }
+    });
+
+    await render(hbs`{{insights-privacy-selector
+      isPrivateViewable=isPrivateViewable
+      includePrivate=includePrivate
+      setRequestPrivateInsights=setPrivate
+    }}`);
+
+    assert.dom('.ember-power-select-selected-item').hasText(INSIGHTS_PRIVACY_OPTIONS.PUBLIC);
+
+    selectChoose('.travis-form__field-select', INSIGHTS_PRIVACY_OPTIONS.PRIVATE);
+  });
+
+  test('private available, private selected', async function (assert) {
+    this.setProperties({
+      isPrivateViewable: true,
+      includePrivate: true,
+      setPrivate: (actual) => {
+        assert.equal(actual, !this.includePrivate);
+      }
+    });
+
+    await render(hbs`{{insights-privacy-selector
+      isPrivateViewable=isPrivateViewable
+      includePrivate=includePrivate
+      setRequestPrivateInsights=setPrivate
+    }}`);
+
+    assert.dom('.ember-power-select-selected-item').hasText(INSIGHTS_PRIVACY_OPTIONS.PRIVATE);
+
+    selectChoose('.travis-form__field-select', INSIGHTS_PRIVACY_OPTIONS.PUBLIC);
+  });
+});


### PR DESCRIPTION
Split from https://github.com/travis-ci/travis-web/pull/1966

This adds the selector on the charts page for choosing whether to look at private build stats (if they're available)