### PR TITLE
Reinstate day of week on tooltips for the build status chart

### DIFF
--- a/app/components/build-status-chart.js
+++ b/app/components/build-status-chart.js
@@ -86,7 +86,7 @@ export default Component.extend({
   axis: computed(() => ({
     x: {
       type: 'timeseries',
-      tick: { format: '%b %e' },
+      tick: { format: '%A, %b %e' },
     },
     y: {
       tick: { format: d3format('d'), count: 6 }


### PR DESCRIPTION
Fairly straightforward, addresses this issue: https://github.com/travis-ci/travis-insights/issues/71

Not urgent to review, whenever you have time for it is fine 👍 