### PR TITLE
Add a way to hide things from percy snapshots. Apply to insights.

### DIFF
--- a/app/components/insights-date-display.js
+++ b/app/components/insights-date-display.js
@@ -9,7 +9,7 @@ export const INSIGHTS_DATE_RANGE_PLACEHOLDER = '...';
 
 export default Component.extend({
   tagName: 'span',
-  classNames: ['insights-dates'],
+  classNames: ['insights-dates', 'snapshot-hide'],
 
   insights: service(),
 

--- a/app/styles/app/base.scss
+++ b/app/styles/app/base.scss
@@ -143,3 +143,7 @@ span.emoji.emoji-sizer {
 .vertical-align {
   vertical-align: middle;
 }
+
+.snapshot-hide {
+  @include snapshotHide;
+}

--- a/app/styles/app/layouts/insights.scss
+++ b/app/styles/app/layouts/insights.scss
@@ -294,12 +294,12 @@ $med-small-up: "only screen and (min-width: 38em)";
 
   // Odyssey C3 customizations
   .c3-axis {
-    @include snapshotHide;
-
     .domain {
       stroke: $axis-line-color;
     }
     .tick {
+      @include snapshotHide;
+
       line {
         stroke: $axis-tick-color;
       }

--- a/app/styles/app/layouts/insights.scss
+++ b/app/styles/app/layouts/insights.scss
@@ -294,6 +294,8 @@ $med-small-up: "only screen and (min-width: 38em)";
 
   // Odyssey C3 customizations
   .c3-axis {
+    @include snapshotHide;
+
     .domain {
       stroke: $axis-line-color;
     }

--- a/app/styles/app/mixins.scss
+++ b/app/styles/app/mixins.scss
@@ -170,3 +170,9 @@
     @include colorStatusIcons(map-get($colorMap, color), $state);
   }
 }
+
+@mixin snapshotHide {
+  @media only percy {
+    visibility: hidden;
+  }
+}

--- a/app/templates/components/insights-glance.hbs
+++ b/app/templates/components/insights-glance.hbs
@@ -22,6 +22,6 @@
   {{#if showPlaceholder}}
     <hr class="insights-glance__chart-placeholder" data-test-insights-glance-chart-placeholder />
   {{else}}
-    {{c3-chart class='chart-component' data=data axis=axis legend=legend grid=grid size=size point=point tooltip=tooltip}}
+    {{c3-chart class='chart-component snapshot-hide' data=data axis=axis legend=legend grid=grid size=size point=point tooltip=tooltip}}
   {{/if}}
 </div>


### PR DESCRIPTION
I noticed in https://github.com/travis-ci/travis-web/pull/1996 that Percy was flagging for review when nothing in the snapshot should have really been different. It seems due to changing dates on the x-axis as well as tiny variations in drawing the line charts. This PR should address that and also provides a way to hide other things from snapshots if we need to in the future.

Reference: https://docs.percy.io/docs/percy-specific-css