### PR TITLE
Ensure that nav menu styles do not get merged during minification

### DIFF
--- a/app/styles/app/modules/navigation.scss
+++ b/app/styles/app/modules/navigation.scss
@@ -245,6 +245,7 @@ ul #profile-menu-link ul:hover {
 }
 
 ul #profile-menu-link:focus-within > ul {
+  opacity: 1;
   display: block;
 }
 

--- a/app/styles/app/modules/navigation.scss
+++ b/app/styles/app/modules/navigation.scss
@@ -245,7 +245,7 @@ ul #profile-menu-link ul:hover {
 }
 
 ul #profile-menu-link:focus-within > ul {
-  opacity: 1;
+  opacity: 1; // Prevents this rule from being merged with the one above during minification. For IE support.
   display: block;
 }
 


### PR DESCRIPTION
After deploying https://github.com/travis-ci/travis-web/pull/1998 to staging, I noticed a difference in behavior of the navigation in IE/Edge between the deployed and locally run versions. I suspect that the CSS minifier / optimizer is merging together some nearly identical rules during the build for deployment. Testing out this hypothesis.