### PR TITLE
Org help form submit to new forum topic

### DIFF
--- a/app/components/zendesk-request-form.js
+++ b/app/components/zendesk-request-form.js
@@ -8,6 +8,7 @@ import moment from 'moment';
 import config from 'travis/config/environment';
 
 const { apiHost, createRequestEndpoint } = config.zendesk;
+const { community } = config.urls;
 
 export const UTC_START_TIME = moment.utc({ h: 9, m: 0, s: 0 });
 export const UTC_END_TIME = moment.utc({ h: 23, m: 0, s: 0 });
@@ -23,6 +24,7 @@ export default Component.extend({
   auth: service(),
   flashes: service(),
   raven: service(),
+  features: service(),
 
   page: '',
 
@@ -40,7 +42,12 @@ export default Component.extend({
     return buildDescriptionTemplate(this.page);
   }),
 
+  newTopicURL: computed('subject', 'description', function () {
+    return `${community}/new-topic?title=${encodeURIComponent(this.subject)}&body=${encodeURIComponent(this.description)}`;
+  }),
+
   isLoggedIn: reads('auth.signedIn'),
+  isPro: reads('features.proVersion'),
 
   startTime: UTC_START_TIME.local().format(DATE_FORMAT),
   endTime: UTC_END_TIME.local().format(DATE_FORMAT),

--- a/app/components/zendesk-request-form.js
+++ b/app/components/zendesk-request-form.js
@@ -42,8 +42,12 @@ export default Component.extend({
     return buildDescriptionTemplate(this.page);
   }),
 
-  newTopicURL: computed('subject', 'description', function () {
-    return `${community}/new-topic?title=${encodeURIComponent(this.subject)}&body=${encodeURIComponent(this.description)}`;
+  newTopicURL: computed(() => `${community}/new-topic`),
+  encodedSubject: computed('subject', function () {
+    return encodeURIComponent(this.subject);
+  }),
+  encodedDescription: computed('description', function () {
+    return encodeURIComponent(this.description);
   }),
 
   isLoggedIn: reads('auth.signedIn'),

--- a/app/templates/components/job-infrastructure-notification.hbs
+++ b/app/templates/components/job-infrastructure-notification.hbs
@@ -7,17 +7,23 @@
     {{/if}}
     {{#if isPreciseEOL}}
       {{#notice-banner}}
-        This job {{conjugatedRun}} on our <b>Precise</b> environment, which is in the process of being decommissioned.  Please update to a newer Ubuntu version by specifying <code>dist: xenial</code> in your <em>.travis.yml</em>.
+        This job {{conjugatedRun}} on our <b>Precise</b> environment, 
+        which is in the process of being decommissioned.  
+        Please update to a newer Ubuntu version by specifying <code>dist: xenial</code> in your <em>.travis.yml</em>.
       {{/notice-banner}}
     {{/if}}
     {{#if isPHPDefault}}
       {{#notice-banner}}
-        This job {{conjugatedRun}} using the default <b>PHP</b> version, which was updated to 7.2 on March 12th, 2019. You can explicitly stay on the previous version by specifying <code>php: 5.5</code> in your <em>.travis.yml</em>.
+        This job {{conjugatedRun}} using the default <b>PHP</b> version, 
+        which was updated to 7.2 on March 12th, 2019. 
+        You can explicitly stay on the previous version by specifying <code>php: 5.5</code> in your <em>.travis.yml</em>.
       {{/notice-banner}}
     {{/if}}
     {{#if isPythonDefault}}
       {{#notice-banner}}
-        This job {{conjugatedRun}} using the default <b>Python</b> version, which will be updated to 3.6 on April 16th, 2019. You can explicitly stay on the previous version by specifying <code>python: 2.7</code> in your <em>.travis.yml</em>.
+        This job {{conjugatedRun}} using the default <b>Python</b> version, 
+        which was updated to 3.6 on April 16th, 2019. 
+        You can explicitly stay on the previous version by specifying <code>python: 2.7</code> in your <em>.travis.yml</em>.
       {{/notice-banner}}
     {{/if}}
   {{/if}}

--- a/app/templates/components/zendesk-request-form.hbs
+++ b/app/templates/components/zendesk-request-form.hbs
@@ -73,17 +73,31 @@
         {{/form.field}}
 
         <div class="align-center">
-          <button
-            onclick={{form.submit}}
-            class='submit-button button--blue button--large'
-            data-test-zendesk-form-submit
-          >
-            {{#if isSubmitting}}
-              {{loading-indicator white=true }}
-            {{else}}
-              Submit
-            {{/if}}
-          </button>
+          {{#if isPro}}
+            <button
+              onclick={{form.submit}}
+              class='submit-button button--blue button--large'
+              data-test-zendesk-form-submit
+            >
+              {{#if isSubmitting}}
+                {{loading-indicator white=true }}
+              {{else}}
+                Submit
+              {{/if}}
+            </button>
+          {{else}}
+            <a
+              href={{newTopicURL}}
+              class='submit-button button--blue button--large'
+              data-test-zendesk-form-submit
+            >
+              {{#if isSubmitting}}
+                {{loading-indicator white=true }}
+              {{else}}
+                Submit
+              {{/if}}
+            </a>
+          {{/if}}
         </div>
 
       {{/travis-form}}

--- a/app/templates/components/zendesk-request-form.hbs
+++ b/app/templates/components/zendesk-request-form.hbs
@@ -87,7 +87,7 @@
             </button>
           {{else}}
             <a
-              href={{newTopicURL}}
+              href='{{newTopicURL}}?title={{encodedSubject}}&body={{encodedDescription}}'
               class='submit-button button--blue button--large'
               data-test-zendesk-form-submit
             >

--- a/app/templates/help.hbs
+++ b/app/templates/help.hbs
@@ -12,7 +12,7 @@
       popular topics in our
       <a href={{communityUrl}} target="_blank" ref="noopener noreferrer">Community forum</a>,
       or
-      <a class="pointer" onclick={{action 'setAnchor' 'form'}}>talk with us!</a>
+      <a class="pointer" onclick={{action 'setAnchor' 'form'}}>talk with us</a>!
     </div>
 
     <div class="status align-center" data-test-help-page-status>

--- a/tests/acceptance/help-page-test.js
+++ b/tests/acceptance/help-page-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { settled } from '@ember/test-helpers';
 import { selectChoose } from 'ember-power-select/test-support';
+import { enableFeature } from 'ember-feature-flags/test-support';
 import moment from 'moment';
 import { setupApplicationTest } from 'travis/tests/helpers/setup-application-test';
 import signInUser from 'travis/tests/helpers/sign-in-user';
@@ -47,6 +48,7 @@ module('Acceptance | help page', function (hooks) {
   module('for authorised user', function (hooks) {
     hooks.beforeEach(async function () {
       this.user = server.create('user');
+      enableFeature('proVersion');
       await signInUser(this.user);
       await helpPage.visit();
     });


### PR DESCRIPTION
A quick prototype of another possible way to address this issue: https://travisci.assembla.com/spaces/Web/tickets/16/details

This solution involves changing the submit button into a link to pre-fill a new forum topic, for example like this: http://travis-ci.community/new-topic?title=topic%20title

There's an awkward issue that can happen when trying to do so if you aren't logged into the forums. Basically, the authorization popup can tend to be blocked, since it isn't triggered directly by a user action.

So for now, this is only a prototype and I haven't updated any of the tests etc.