### PR TITLE
Fix issue where date change can cause percy to flag a visual change

### DIFF
--- a/app/templates/owner/repositories.hbs
+++ b/app/templates/owner/repositories.hbs
@@ -14,7 +14,7 @@
     {{#if buildsReady}}
       <div class="travistab-body">
         <div class="insights-controls">
-          <div class="insights-controls-left">
+          <div class="insights-controls-left snapshot-hide">
             {{insights-date-display interval=timeInterval}}
             <span class="insights-control-divider">|</span>
             {{insights-privacy-selector


### PR DESCRIPTION
I noticed that percy is flagging the insights page again, based on dynamic content. Since the date range is the current 30 days, different dates in the date display component will have different widths, which causes the content on the right to move.