### PR TITLE
Update style to prevent commit message from overflowing on mobile

### DIFF
--- a/app/styles/app/modules/build-header.scss
+++ b/app/styles/app/modules/build-header.scss
@@ -135,6 +135,7 @@
 .build-info {
   font-size: 15px;
   padding-left: 43px;
+  overflow-x: hidden;
 
   @media #{$medium-up} {
     flex: 0 1 37%;


### PR DESCRIPTION
When on the build history page on a mobile device, it is possible for the commit message to overflow off the screen. This commit will fix that issue.
![Screenshot from 2019-06-03 11-27-39](https://user-images.githubusercontent.com/47195730/58776372-dd509300-85b9-11e9-98fe-71117799410d.png)
![Screenshot from 2019-06-03 12-21-10](https://user-images.githubusercontent.com/47195730/58776374-dde92980-85b9-11e9-86e8-a5a11e023a73.png)
