### PR TITLE
Only use the package-json.lock for npm deps installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,15 +19,13 @@ matrix:
     - env: TRY_CONFIG=ember-beta
     - env: TRY_CONFIG=ember-data-beta
 
-sudo: required
 dist: trusty
 
 addons:
   chrome: stable
 
 cache:
-  directories:
-    - node_modules
+  npm: true
 
 env:
   global:
@@ -41,7 +39,7 @@ before_install:
   - npm install -g greenkeeper-lockfile@1
 
 install:
-  - npm install
+  - npm ci
 
 before_script:
   - if [ $TRAVIS_PULL_REQUEST = 'false' ] && [ $TRAVIS_EVENT_TYPE != 'cron' ]; then echo "Enabling Percy on push with default Ember" && export PERCY_ENABLE=1; else export PERCY_ENABLE=0; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,8 +63,9 @@ COPY waiter       /usr/src/app/waiter
 RUN bundle install --without assets development test
 
 COPY package.json /usr/src/app
+COPY package-lock.json /usr/src/app
 
-RUN npm install --quiet
+RUN npm ci --production
 
 COPY . /usr/src/app
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ with npm installed.
 
 In order to run the app you need to install dependencies with:
 
-    npm install
+    npm ci
 
 And then install ember-cli globally in order to have access to the `ember` command:
 


### PR DESCRIPTION
Based on https://docs.npmjs.com/cli/install and https://stackoverflow.com/questions/52499617/what-is-the-difference-between-npm-install-and-npm-ci

> This command is similar to npm-install, except it’s meant to be used in automated environments such as test platforms, continuous integration, and deployment – or any situation where you want to make sure you’re doing a clean install of your dependencies.