### PR TITLE
Fix jumpy animation on Safari

### DIFF
--- a/app/styles/app/modules/build-header.scss
+++ b/app/styles/app/modules/build-header.scss
@@ -403,10 +403,10 @@
 }
 @keyframes loading-circle {
 		0% {
-      stroke-dashoffset: 0
+      stroke-dashoffset: 600
     }
 		100% {
-      stroke-dashoffset: -600;
+      stroke-dashoffset: 0;
     }
 }
 


### PR DESCRIPTION
_Fixes https://github.com/travis-ci/bugs-questions-comments-ideas/issues/181_

It looks like Safari doesn't support negative stroke-dashoffset.

https://stackoverflow.com/a/39127818

## Safari

![2019-06-19 22 00 57](https://user-images.githubusercontent.com/51964575/59811007-4cc6c200-92de-11e9-9099-58bca8a6e38d.gif)


## Chrome

![2019-06-19 22 01 57](https://user-images.githubusercontent.com/51964575/59811010-52240c80-92de-11e9-86dd-96f3c3c304fe.gif)
