### PR TITLE
Slice commit messages

### DIFF
--- a/app/helpers/format-message.js
+++ b/app/helpers/format-message.js
@@ -14,6 +14,11 @@ emojiConvertor.allow_native = false;
 
 function formatMessage(message, options) {
   message = message || '';
+
+  if (options.maxLength) {
+    message = message.slice(0, options.maxLength);
+  }
+
   if (options.short) {
     message = message.split(/\n/)[0];
   }

--- a/app/templates/components/build-header.hbs
+++ b/app/templates/components/build-header.hbs
@@ -16,7 +16,7 @@
           <small class="commit-branch"
                  title={{item.branch.name}}>{{item.branch.name}}</small>
         {{/if}}
-        {{format-message commit.subject repo=item.repo eventType=build.eventType}}
+        {{format-message commit.subject repo=item.repo eventType=build.eventType maxLength=60}}
       {{/if}}
     </h2>
     <div class="commit-info">

--- a/app/templates/components/builds-item.hbs
+++ b/app/templates/components/builds-item.hbs
@@ -27,7 +27,7 @@
       </div>
     {{else}}
       <div class="row-message">
-        {{{format-message build.commit.message short="true" repo=build.repo eventType=build.eventType}}}
+        {{{format-message build.commit.message short="true" repo=build.repo eventType=build.eventType maxLength=50}}}
       </div>
     {{/if}}
   </div>


### PR DESCRIPTION
_Fixes https://github.com/travis-ci/bugs-questions-comments-ideas/issues/89_

## The problem

The problem is with RegExp matching a long string without spaces, it takes ~13 seconds on my macbook to process a String with ~2000 chars.

<img width="1400" alt="Build__5_-_rafael-travis_test_-_Travis_CI" src="https://user-images.githubusercontent.com/51964575/60193271-bfb7c780-980d-11e9-83b7-748cea8e9441.png">

The browser's CPU usage also increases a lot while processing that.

See this JSPerf with an example:

https://jsperf.com/long-string-match/1

## Solution

The commit message just shows about 50 characters on those 2 pages, my solution is to limit the string to that amount of characters, the UI looks the same and the RegExp matching is faster.