### PR TITLE
add css class icon-alert and alert.svg for config messages

### DIFF
--- a/app/components/build-message.js
+++ b/app/components/build-message.js
@@ -143,7 +143,8 @@ export default Component.extend({
     return {
       info: 'information',
       warn: 'warning',
-      error: 'error'
+      error: 'error',
+      alert: 'alert'
     }[level];
   })
 });

--- a/app/components/build-message.js
+++ b/app/components/build-message.js
@@ -66,7 +66,7 @@ export default Component.extend({
   },
 
   empty(key, args) {
-    return `<code>${escape(key)}</code> dropping empty section`;
+    return `<code>${escape(key)}</code> empty section`;
   },
 
   find_key(key, args) {
@@ -102,11 +102,11 @@ export default Component.extend({
   },
 
   unknown_value(key, args) {
-    return `<code>${escape(key)}</code> dropping unknown value: <code>${escape(args.value)}</code>`;
+    return `<code>${escape(key)}</code> unknown value: <code>${escape(args.value)}</code>`;
   },
 
   unknown_default(key, args) {
-    return `<code>${escape(key)}</code> dropping unknown value: <code>${escape(args.value)}</code>, defaulting to: <code>${escape(args.default)}</code>`;
+    return `<code>${escape(key)}</code> unknown value: <code>${escape(args.value)}</code>, defaulting to: <code>${escape(args.default)}</code>`;
   },
 
   unknown_var(key, args) {
@@ -118,11 +118,11 @@ export default Component.extend({
   },
 
   invalid_type(key, args) {
-    return `<code>${escape(key)}</code> dropping unexpected <code>${escape(args.actual)}</code>, expected <code>${escape(args.expected)}</code> (<code>${escape(args.value)}</code>)`;
+    return `<code>${escape(key)}</code> unexpected <code>${escape(args.actual)}</code>, expected <code>${escape(args.expected)}</code> (<code>${escape(args.value)}</code>)`;
   },
 
   invalid_format(key, args) {
-    return `<code>${escape(key)}</code> dropping invalid format: <code>${escape(args.value)}</code>`;
+    return `<code>${escape(key)}</code> invalid format: <code>${escape(args.value)}</code>`;
   },
 
   invalid_condition(key, args) {

--- a/app/styles/app/modules/build-messages.scss
+++ b/app/styles/app/modules/build-messages.scss
@@ -45,7 +45,7 @@
     }
 
     code {
-      background-color: #f4f6fa;
+      background-color: #f1f1f1;
       font-family: $font-family-monospace;
       font-size: $font-size-sm - 1px;
       padding: 2px;

--- a/app/styles/app/modules/build-messages.scss
+++ b/app/styles/app/modules/build-messages.scss
@@ -45,7 +45,7 @@
     }
 
     code {
-      background-color: #eef0f4;
+      background-color: #f4f6fa;
       font-family: $font-family-monospace;
       font-size: $font-size-sm - 1px;
       padding: 2px;

--- a/app/styles/app/modules/build-messages.scss
+++ b/app/styles/app/modules/build-messages.scss
@@ -34,6 +34,10 @@
       @include colorSVG($brick-red);
     }
 
+    .icon-alert {
+      @include colorSVG($brick-red);
+    }
+
     .message {
       padding-left: 7px;
       border-left: 1px solid $dry-cement;

--- a/public/images/config/alert.svg
+++ b/public/images/config/alert.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 18.6 18" style="enable-background:new 0 0 18.6 18;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#EDDE3F;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
+</style>
+<polygon class="st0" points="9.6,2.5 3,14.1 16.3,14.1 "/>
+</svg>


### PR DESCRIPTION
Build config validation messages have a new level `alert`. This will be used when a plain string is given on a node that represents a secret and a `secure` value should be given:

![image](https://user-images.githubusercontent.com/2208/65272324-26a00080-db1f-11e9-9e7b-59daeb113854.png)

Before:

![image](https://user-images.githubusercontent.com/2208/65272476-7252aa00-db1f-11e9-8ce9-395e05fa2300.png)

After:

![image](https://user-images.githubusercontent.com/2208/65275046-0a9f5d80-db25-11e9-921d-857ae9555ef9.png)
