### PR TITLE
tweak line number styles

### DIFF
--- a/app/styles/app/modules/yaml.scss
+++ b/app/styles/app/modules/yaml.scss
@@ -37,12 +37,16 @@ pre.codedisplay[class*='language-'] {
   code {
     font-family: $font-family-monospace;
     font-size: $yaml-code-font-size;
+    color: $asphalt-grey;
     line-height: 20px;
   }
 
   .line-numbers-rows {
+    margin-top: -1px;
+    border-right: 0px;
+    color: $dry-cement;
     font-size: $yaml-code-font-size;
-    line-height: 16px;
+    line-height: 17px;
   }
 }
 
@@ -54,4 +58,3 @@ pre.codedisplay[class*='language-'] {
   padding: 1em;
   border-bottom: 1px solid $pebble-grey;
 }
-


### PR DESCRIPTION
i believe this fixes the vertical alignment of the line numbers. e.g: https://sf-tweak-line-nums.test-deployments.travis-ci.com/travis-ci/perl-builder/builds/128712741/config

before:

![linenumbers-before](https://user-images.githubusercontent.com/2208/66144395-0c7b1d80-e609-11e9-9988-d5623f2b5365.gif)

after:

![linenumbers-after](https://user-images.githubusercontent.com/2208/66144320-e9506e00-e608-11e9-9ceb-0b6731b38a2d.gif)

in these recordings i have tried to use the mac osx native zoom feature ... but obviously that wouldn't make it into the recorded gif 🤦‍♂ i hope it's still visible enough ...

