### PR TITLE
add a help icon to build config msgs

### DIFF
--- a/app/styles/app/modules/build-messages.scss
+++ b/app/styles/app/modules/build-messages.scss
@@ -22,7 +22,7 @@
 
     svg {
       width: 18px;
-      transform: scale(1.2);
+      height: 18px;
     }
 
     .icon-info {
@@ -48,9 +48,23 @@
     }
 
     .message {
+      flex-grow: 1;
       padding-left: 7px;
       border-left: 1px solid $dry-cement;
       margin-left: 2px;
+    }
+
+    .message-help svg {
+      display: none;
+      transform: scale(0.8);
+      border-color: $oxide-blue;
+      @include colorSVG($oxide-blue);
+    }
+
+    &:hover {
+      .message-help svg {
+        display: block;
+      }
     }
 
     code {

--- a/app/templates/components/build-message-line.hbs
+++ b/app/templates/components/build-message-line.hbs
@@ -1,9 +1,12 @@
 <div class="yml-message-line">
-  <div class="tooltip-wrapper">
+  <div class="tooltip-wrapper level-icon">
     <SvgImage @name={{this.level}} @class={{this.iconClass}} />
     <EmberTooltip @text={{this.tooltipText}} />
   </div>
   <div class="message">
     {{this.message}}
   </div>
+  <ExternalLinkTo href="{{config-get 'urls.buildConfigValidation'}}#{{this.code}}" class="message-help">
+    <SvgImage @name='icon-help' @class='icon-help' />
+  </ExternalLinkTo>
 </div>

--- a/app/templates/components/build-message.hbs
+++ b/app/templates/components/build-message.hbs
@@ -9,6 +9,7 @@
       <BuildMessageLine
         @iconClass={{this.iconClass}}
         @level={{this.message.level}}
+        @code={{this.message.code}}
         @message={{this.readableMessage}}
         @tooltipText={{this.tooltipText}}
       />
@@ -18,6 +19,7 @@
       <BuildMessageLine
         @iconClass={{this.iconClass}}
         @level={{this.message.level}}
+        @code={{this.message.code}}
         @message={{this.readableMessage}}
         @tooltipText={{this.tooltipText}}
       />

--- a/config/environment.js
+++ b/config/environment.js
@@ -47,6 +47,7 @@ module.exports = function (environment) {
       bestpracticessecurity: 'https://docs.travis-ci.com/user/best-practices-security#recommendations-on-how-to-avoid-leaking-secrets-to-build-logs',
       blog: 'https://blog.travis-ci.com',
       buildMatrix: 'https://docs.travis-ci.com/user/build-matrix/',
+      buildConfigValidation: 'https://docs.travis-ci.com/user/build-config-validation/',
       changelog: 'https://changelog.travis-ci.com',
       community: 'https://travis-ci.community',
       communityEarlyReleases: 'https://travis-ci.community/c/early-releases',

--- a/tests/pages/build.js
+++ b/tests/pages/build.js
@@ -90,7 +90,7 @@ export default create({
 
   ymlMessages: collection('.yml-message', {
     icon: {
-      scope: 'svg',
+      scope: '.level-icon svg',
       isInfo: hasClass('icon-info'),
       isWarning: hasClass('icon-warn'),
       isError: hasClass('icon-error')


### PR DESCRIPTION
if hovered the message has a help icon on the right side, which links to the build config validation docs https://github.com/travis-ci/docs-travis-ci-com/pull/2548 to the respective message type

![image](https://user-images.githubusercontent.com/2208/66394014-3e5afe00-e9d4-11e9-971d-68e633eb1b54.png)
