### PR TITLE
summarize and toggle config messages

### DIFF
--- a/app/components/build-message.js
+++ b/app/components/build-message.js
@@ -3,6 +3,7 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { and, notEmpty } from '@ember/object/computed';
 import { htmlSafe } from '@ember/string';
+import { typeOf } from '@ember/utils';
 import { codeblockName } from 'travis/utils/format-config';
 import Ember from 'ember';
 
@@ -26,11 +27,11 @@ export default Component.extend({
   },
 
   alias_value(key, args) {
-    return `<code>${escape(key)}</code>: value <code>${escape(args.alias)}</code> is an alias for <code>${escape(args.value)}</code>, using <code>${escape(args.value)}</code>`;
+    return `<code>${escape(key)}</code>: value <code>${escape(args.alias)}</code> is an alias for <code>${format(args.value)}</code>, using <code>${format(args.value)}</code>`;
   },
 
   cast(key, args) {
-    return `<code>${escape(key)}</code>: casting value <code>${escape(args.given_value)}</code> (<code>${escape(args.given_type)}</code>) to <code>${escape(args.value)}</code> (<code>${escape(args.type)}</code>)`;
+    return `<code>${escape(key)}</code>: casting value <code>${format(args.given_value)}</code> (<code>${escape(args.given_type)}</code>) to <code>${format(args.value)}</code> (<code>${escape(args.type)}</code>)`;
   },
   condition(key, args) {
     return `<code>${escape(key)}</code>: condition <code>${escape(args.condition)}</code> does not match, skipping notification`;
@@ -49,7 +50,7 @@ export default Component.extend({
   },
 
   deprecated_value(key, args) {
-    return `<code>${escape(key)}</code>: deprecated value <code>${escape(args.value)}</code> (${escape(args.info)})`;
+    return `<code>${escape(key)}</code>: deprecated value <code>${format(args.value)}</code> (${escape(args.info)})`;
   },
 
   downcase(key, args) {
@@ -57,7 +58,7 @@ export default Component.extend({
   },
 
   duplicate(key, args) {
-    return `<code>${escape(key)}</code>: duplicate values: <code>${escape(args.values)}</code>`;
+    return `<code>${escape(key)}</code>: duplicate values: <code>${format(args.values)}</code>`;
   },
 
   edge(key, args) {
@@ -105,7 +106,7 @@ export default Component.extend({
   },
 
   unexpected_seq(key, args) {
-    return `<code>${escape(key)}</code> <code>${escape(args.key)}</code> unexpected sequence, using the first value (<code>${escape(args.value)}</code>)`;
+    return `<code>${escape(key)}</code> <code>${escape(args.key)}</code> unexpected sequence, using the first value (<code>${format(args.value)}</code>)`;
   },
 
   unknown_key(key, args) {
@@ -129,7 +130,7 @@ export default Component.extend({
   },
 
   invalid_type(key, args) {
-    return `<code>${escape(key)}</code> unexpected <code>${escape(args.actual)}</code>, expected <code>${escape(args.expected)}</code> (<code>${escape(args.value)}</code>)`;
+    return `<code>${escape(key)}</code> unexpected <code>${escape(args.actual)}</code>, expected <code>${escape(args.expected)}</code> (<code>${format(args.value)}</code>)`;
   },
 
   invalid_format(key, args) {
@@ -146,7 +147,7 @@ export default Component.extend({
 
   iconClass: computed('message.level', function () {
     let level = this.get('message.level');
-    return `icon icon-${level}`;
+    return `icon icon-level icon-${level}`;
   }),
 
   tooltipText: computed('message.level', function () {
@@ -168,4 +169,29 @@ export default Component.extend({
     return `#${codeblockName(src)}.${line + 1}`;
   }),
 });
+
+function format(obj, length) {
+  length = length || 30;
+  return escape(truncate(dump(obj, length), 30));
+}
+
+function dump(obj, length) {
+  switch (typeOf(obj)) {
+    case 'array':
+      return `[${obj.map((obj) => dump(obj, 10)).join(', ')}]`;
+    case 'object':
+      return `{ ${Object.entries(obj).map((entry) => `${entry[0]}: ${dump(entry[1], 10)}`).join(', ')} }`;
+    case 'string':
+      return `${truncate(obj, length)}`;
+    default:
+      return obj;
+  }
+}
+
+function truncate(str, length) {
+  if (str.length > length) {
+    str = `${str.substring(0, length)} ...`;
+  }
+  return str;
+}
 /* eslint-enable max-len */

--- a/app/components/build-messages-list.js
+++ b/app/components/build-messages-list.js
@@ -1,83 +1,60 @@
-import { A } from '@ember/array';
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-import { not } from '@ember/object/computed';
+import { filter, notEmpty } from '@ember/object/computed';
+import { pluralize } from 'ember-inflector';
+
+const READABLE_LEVELS = {
+  'alert': 'alert',
+  'error': 'error',
+  'warn': 'warning',
+};
 
 export default Component.extend({
   tagName: '',
-  toggleStatus: undefined,
-  readableLevels: {
-    'alert': 'alert',
-    'error': 'error',
-    'warn': 'warning',
-  },
+  toggleStatus: null,
 
-  nonInfoMessages: computed('request.messages', function () {
-    return A(this.get('request.messages')).rejectBy('level', 'info');
-  }),
-
-  maxLevel: computed('job.build.request', function () {
-    let msgs = this.get('nonInfoMessages');
-    if (msgs.length > 0) {
-      return msgs.sortBy('level')[0].level;
-    }
-  }),
-
-  iconClass: computed('maxLevel', function () {
-    let level = this.get('maxLevel');
-    return `icon icon-${level}`;
-  }),
-
-  summary: computed('nonInfoMessages', function () {
-    let counts = this.countBy(this.get('nonInfoMessages'), 'level');
-    if (Object.entries(counts).length > 0) {
-      let summary = Object.entries(counts).map((entry) => this.formatLevel(...entry)).join(', ');
-      return `(${summary})`;
-    }
-  }),
-
-  formatLevel: function (level, count) {
-    return [count, this.readableLevel(level, count)].join(' ');
-  },
-
-  readableLevel: function (level, count) {
-    level = this.get('readableLevels')[level];
-    if (count > 1) {
-      level = `${level}s`;
-    }
-    return level;
-  },
-
-  isExpanded: computed('nonInfoMessages', 'toggleStatus', function () {
-    if (this.get('toggleStatus') != undefined) {
-      return this.get('toggleStatus');
-    }
-    return this.get('nonInfoMessages').length > 0;
-  }),
-
-  isCollapsed: not('isExpanded'),
+  isExpanded: notEmpty('nonInfoMessages'),
 
   toggleStatusClass: computed('isExpanded', function () {
     return this.get('isExpanded') ? 'expanded' : 'collapsed';
   }),
 
-  toggle: function () {
-    this.set('toggleStatus', !this.get('isExpanded'));
-  },
+  nonInfoMessages: filter('request.messages', (message) =>
+    message.level !== 'info'
+  ),
+
+  maxLevel: computed('nonInfoMessages.[].level', function () {
+    return this.nonInfoMessages.sortBy('level')[0].level;
+  }),
+
+  iconClass: computed('maxLevel', function () {
+    return `icon icon-${this.get('maxLevel')}`;
+  }),
+
+  summary: computed('nonInfoMessages', function () {
+    let counts = countBy(this.get('nonInfoMessages'), 'level');
+    if (Object.entries(counts).length > 0) {
+      return Object.entries(counts).map((entry) => formatLevel(...entry)).join(', ');
+    }
+  }),
 
   actions: {
-    toggle: function () {
-      this.toggle();
+    toggle() {
+      this.toggleProperty('isExpanded');
     }
-  },
-
-  countBy: function (objs, name) {
-    return objs.reduce((counts, obj) => {
-      if (!counts[obj[name]]) {
-        counts[obj[name]] = 0;
-      }
-      counts[obj[name]] += 1;
-      return counts;
-    }, {});
   }
 });
+
+function formatLevel(level, count) {
+  return pluralize(count, READABLE_LEVELS[level]);
+}
+
+function countBy(objs, name) {
+  return objs.reduce((counts, obj) => {
+    if (!counts[obj[name]]) {
+      counts[obj[name]] = 0;
+    }
+    counts[obj[name]] += 1;
+    return counts;
+  }, {});
+}

--- a/app/components/build-messages-list.js
+++ b/app/components/build-messages-list.js
@@ -1,38 +1,37 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-import { filter, notEmpty } from '@ember/object/computed';
+import { sort } from '@ember/object/computed';
 import { pluralize } from 'ember-inflector';
 
-const READABLE_LEVELS = {
+const MSGS = {
   'alert': 'alert',
   'error': 'error',
   'warn': 'warning',
+  'info': 'info',
 };
 
 export default Component.extend({
   tagName: '',
-  toggleStatus: null,
-
-  isExpanded: notEmpty('nonInfoMessages'),
+  isExpanded: false,
 
   toggleStatusClass: computed('isExpanded', function () {
     return this.get('isExpanded') ? 'expanded' : 'collapsed';
   }),
 
-  nonInfoMessages: filter('request.messages', (message) =>
-    message.level !== 'info'
+  sortedMessages: sort('request.messages', (lft, rgt) =>
+    sortOrder(lft.level) - sortOrder(rgt.level)
   ),
 
-  maxLevel: computed('nonInfoMessages.[].level', function () {
-    return this.nonInfoMessages.sortBy('level')[0].level;
+  maxLevel: computed('sortedMessages', function () {
+    return this.get('sortedMessages')[0].level;
   }),
 
   iconClass: computed('maxLevel', function () {
     return `icon icon-${this.get('maxLevel')}`;
   }),
 
-  summary: computed('nonInfoMessages', function () {
-    let counts = countBy(this.get('nonInfoMessages'), 'level');
+  summary: computed('sortedMessages', function () {
+    let counts = countBy(this.get('sortedMessages'), 'level');
     if (Object.entries(counts).length > 0) {
       return Object.entries(counts).map((entry) => formatLevel(...entry)).join(', ');
     }
@@ -46,7 +45,11 @@ export default Component.extend({
 });
 
 function formatLevel(level, count) {
-  return pluralize(count, READABLE_LEVELS[level]);
+  return pluralize(count, MSGS[level]);
+}
+
+function sortOrder(level) {
+  return Object.keys(MSGS).indexOf(level);
 }
 
 function countBy(objs, name) {
@@ -58,3 +61,4 @@ function countBy(objs, name) {
     return counts;
   }, {});
 }
+

--- a/app/components/build-messages-list.js
+++ b/app/components/build-messages-list.js
@@ -1,5 +1,83 @@
+import { A } from '@ember/array';
 import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { not } from '@ember/object/computed';
 
 export default Component.extend({
-  tagName: ''
+  tagName: '',
+  toggleStatus: undefined,
+  readableLevels: {
+    'alert': 'alert',
+    'error': 'error',
+    'warn': 'warning',
+  },
+
+  nonInfoMessages: computed('request.messages', function () {
+    return A(this.get('request.messages')).rejectBy('level', 'info');
+  }),
+
+  maxLevel: computed('job.build.request', function () {
+    let msgs = this.get('nonInfoMessages');
+    if (msgs.length > 0) {
+      return msgs.sortBy('level')[0].level;
+    }
+  }),
+
+  iconClass: computed('maxLevel', function () {
+    let level = this.get('maxLevel');
+    return `icon icon-${level}`;
+  }),
+
+  summary: computed('nonInfoMessages', function () {
+    let counts = this.countBy(this.get('nonInfoMessages'), 'level');
+    if (Object.entries(counts).length > 0) {
+      let summary = Object.entries(counts).map((entry) => this.formatLevel(...entry)).join(', ');
+      return `(${summary})`;
+    }
+  }),
+
+  formatLevel: function (level, count) {
+    return [count, this.readableLevel(level, count)].join(' ');
+  },
+
+  readableLevel: function (level, count) {
+    level = this.get('readableLevels')[level];
+    if (count > 1) {
+      level = `${level}s`;
+    }
+    return level;
+  },
+
+  isExpanded: computed('nonInfoMessages', 'toggleStatus', function () {
+    if (this.get('toggleStatus') != undefined) {
+      return this.get('toggleStatus');
+    }
+    return this.get('nonInfoMessages').length > 0;
+  }),
+
+  isCollapsed: not('isExpanded'),
+
+  toggleStatusClass: computed('isExpanded', function () {
+    return this.get('isExpanded') ? 'expanded' : 'collapsed';
+  }),
+
+  toggle: function () {
+    this.set('toggleStatus', !this.get('isExpanded'));
+  },
+
+  actions: {
+    toggle: function () {
+      this.toggle();
+    }
+  },
+
+  countBy: function (objs, name) {
+    return objs.reduce((counts, obj) => {
+      if (!counts[obj[name]]) {
+        counts[obj[name]] = 0;
+      }
+      counts[obj[name]] += 1;
+      return counts;
+    }, {});
+  }
 });

--- a/app/models/request.js
+++ b/app/models/request.js
@@ -1,7 +1,7 @@
 import Model, { attr, belongsTo } from '@ember-data/model';
 import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
-import { alias, empty, uniqBy, equal } from '@ember/object/computed';
+import { empty, uniqBy, equal } from '@ember/object/computed';
 import ObjectProxy from '@ember/object/proxy';
 import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
 import { Promise as EmberPromise } from 'rsvp';
@@ -66,6 +66,13 @@ export default Model.extend({
           }})
           .then(response => ({messages: response.messages}))
       });
+    }
+  }),
+
+  messages: computed('messagesRequest', function () {
+    let response = this.get('messagesRequest');
+    if (response) {
+      return response.get('messages');
     } else {
       return ObjectPromiseProxy.create({
         promise: EmberPromise.resolve([])
@@ -73,5 +80,7 @@ export default Model.extend({
     }
   }),
 
-  messages: alias('messagesRequest.messages'),
+  hasMessages: computed('messagesRequest', function () {
+    return this.get('messagesRequest').get('messages') != undefined;
+  }),
 });

--- a/app/styles/app/modules/build-messages.scss
+++ b/app/styles/app/modules/build-messages.scss
@@ -26,6 +26,8 @@
     .icon-info {
       width: 12px;
       height: 12px;
+      margin-left: 2px;
+      margin-right: 8px;
       path {
         stroke: $turf-green;
         stroke-width: 2;

--- a/app/styles/app/modules/build-messages.scss
+++ b/app/styles/app/modules/build-messages.scss
@@ -6,7 +6,14 @@
   font-size: $font-size-sm;
 
   .header {
+    position: relative;
     padding: 1em;
+    cursor: pointer;
+
+    .icon {
+      width: 18px;
+      height: 18px;
+    }
 
     .icon-alert path,
     .icon-error path {
@@ -17,7 +24,9 @@
     }
 
     .tools {
-      float: right;
+      position: absolute;
+      right: 1em;
+      top: 1em;
 
       .icon-toggle {
         height: 15px;
@@ -28,7 +37,6 @@
           stroke: $cement-grey;
           stroke-width: 1;
         }
-        cursor: pointer;
 
         &.icon-expanded {
           transform: scaleY(-1);

--- a/app/styles/app/modules/build-messages.scss
+++ b/app/styles/app/modules/build-messages.scss
@@ -5,6 +5,51 @@
 
   font-size: $font-size-sm;
 
+  .header {
+    padding: 1em;
+
+    .icon-alert path,
+    .icon-error path {
+      stroke: $brick-red;
+    }
+    .icon-warn path {
+      stroke: $canary-yellow;
+    }
+
+    .tools {
+      float: right;
+
+      .icon-toggle {
+        height: 15px;
+        width: 15px;
+        vertical-align: middle;
+        transform: scale(0.9, 1.1);
+        path {
+          stroke: $cement-grey;
+          stroke-width: 1;
+        }
+        cursor: pointer;
+
+        &.icon-expanded {
+          transform: scaleY(-1);
+        }
+      }
+
+      .icon-help {
+        border: 0px;
+        transform: scale(0.8);
+        path {
+          stroke: $cement-grey;
+          stroke-width: 2;
+        }
+      }
+    }
+  }
+
+  .list {
+    border-top: 1px solid $pebble-grey;
+  }
+
   .yml-message-link {
     display: block;
 
@@ -50,7 +95,6 @@
     .message {
       flex-grow: 1;
       padding-left: 7px;
-      border-left: 1px solid $dry-cement;
       margin-left: 2px;
     }
 

--- a/app/styles/app/modules/build-messages.scss
+++ b/app/styles/app/modules/build-messages.scss
@@ -13,6 +13,7 @@
     .icon {
       width: 18px;
       height: 18px;
+      margin-bottom: 2px;
     }
 
     .icon-alert path,
@@ -21,6 +22,14 @@
     }
     .icon-warn path {
       stroke: $canary-yellow;
+    }
+    .icon-info {
+      width: 12px;
+      height: 12px;
+      path {
+        stroke: $turf-green;
+        stroke-width: 2;
+      }
     }
 
     .tools {
@@ -79,7 +88,7 @@
     }
 
     .icon-info {
-      @include colorSVGFull($oxide-blue, $oxide-blue);
+      @include colorSVGFull($turf-green, $turf-green);
 
       circle {
         fill: none;

--- a/app/styles/app/modules/build-messages.scss
+++ b/app/styles/app/modules/build-messages.scss
@@ -81,17 +81,21 @@
     display: flex;
     align-items: flex-start;
 
-    padding: 6px;
+    padding: 6px 1em;
 
+    .icon-level {
+      width: 14px;
+      height: 14px;
+      margin-left: 2px;
+    }
 
-    svg {
+    .icon-help {
       width: 18px;
       height: 18px;
     }
 
     .icon-info {
       @include colorSVGFull($turf-green, $turf-green);
-
       circle {
         fill: none;
       }
@@ -99,7 +103,6 @@
 
     .icon-warn {
       @include colorSVG($canary-yellow);
-
       color: inherit;
     }
 
@@ -113,8 +116,7 @@
 
     .message {
       flex-grow: 1;
-      padding-left: 7px;
-      margin-left: 2px;
+      margin-left: 6px;
     }
 
     .message-help svg {

--- a/app/templates/components/build-messages-list.hbs
+++ b/app/templates/components/build-messages-list.hbs
@@ -1,7 +1,28 @@
 {{#if this.request.messages.length}}
   <div class="yml-messages">
-    {{#each this.request.messages as |message|}}
-      <BuildMessage @message={{message}} />
-    {{/each}}
+    <div class="header">
+      {{#if this.isCollapsed}}
+        <SvgImage @name={{this.maxLevel}} @class={{this.iconClass}} />
+      {{/if}}
+      Build config validation
+      {{#if this.isCollapsed}}
+        {{this.summary}}
+      {{/if}}
+      <div class="tools">
+        <button {{action 'toggle'}}>
+          <SvgImage @name="icon-dropdown-arrow" @class="icon-toggle icon-{{this.toggleStatusClass}}" />
+        </button>
+        <ExternalLinkTo href="{{config-get 'urls.buildConfigValidation'}}">
+          <SvgImage @name='icon-help' @class='icon-help' />
+        </ExternalLinkTo>
+      </div>
+    </div>
+    {{#if this.isExpanded}}
+      <div class="list">
+        {{#each this.request.messages as |message|}}
+          <BuildMessage @message={{message}} />
+        {{/each}}
+      </div>
+    {{/if}}
   </div>
 {{/if}}

--- a/app/templates/components/build-messages-list.hbs
+++ b/app/templates/components/build-messages-list.hbs
@@ -1,17 +1,16 @@
 {{#if this.request.messages.length}}
   <div class="yml-messages">
-    <div class="header">
-      {{#if this.isCollapsed}}
+    <div class="header" {{action 'toggle'}}>
+      <span class="tooltip-wrapper level-icon">
         <SvgImage @name={{this.maxLevel}} @class={{this.iconClass}} />
-      {{/if}}
+        <EmberTooltip @text={{this.summary}} />
+      </span>
       Build config validation
-      {{#if this.isCollapsed}}
-        {{this.summary}}
-      {{/if}}
+      {{#unless this.isExpanded}}
+        &mdash; {{this.summary}}
+      {{/unless}}
       <div class="tools">
-        <button {{action 'toggle'}}>
-          <SvgImage @name="icon-dropdown-arrow" @class="icon-toggle icon-{{this.toggleStatusClass}}" />
-        </button>
+        <SvgImage @name="icon-dropdown-arrow" @class="icon-toggle icon-{{this.toggleStatusClass}}" />
         <ExternalLinkTo href="{{config-get 'urls.buildConfigValidation'}}">
           <SvgImage @name='icon-help' @class='icon-help' />
         </ExternalLinkTo>

--- a/app/templates/components/build-messages-list.hbs
+++ b/app/templates/components/build-messages-list.hbs
@@ -2,7 +2,7 @@
   <div class="yml-messages">
     <div class="header" {{action 'toggle'}}>
       <span class="tooltip-wrapper level-icon">
-        <SvgImage @name={{this.maxLevel}} @class={{this.iconClass}} />
+        <SvgImage @name="msg-{{this.maxLevel}}"  @class={{this.iconClass}} />
         <EmberTooltip @text={{this.summary}} />
       </span>
       Build config validation

--- a/public/images/messages/msg-alert.svg
+++ b/public/images/messages/msg-alert.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 18.6 18" style="enable-background:new 0 0 18.6 18;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#EDDE3F;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
+</style>
+<polygon class="st0" points="9.6,2.5 3,14.1 16.3,14.1 "/>
+</svg>

--- a/public/images/messages/msg-error.svg
+++ b/public/images/messages/msg-error.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 18.6 18" style="enable-background:new 0 0 18.6 18;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#DB4545;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
+</style>
+<g id="icon-failed_3_">
+	<line class="st0" x1="4.5" y1="4.3" x2="14.1" y2="13.8"/>
+	<line class="st0" x1="14.1" y1="4.3" x2="4.5" y2="13.8"/>
+</g>
+</svg>

--- a/public/images/messages/msg-info.svg
+++ b/public/images/messages/msg-info.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 15 15"><path d="M14.5 1.5L6.499 13.716.5 8.78"/></svg>

--- a/public/images/messages/msg-warn.svg
+++ b/public/images/messages/msg-warn.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 18.6 18" style="enable-background:new 0 0 18.6 18;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#EDDE3F;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;}
+</style>
+<polygon class="st0" points="9.6,2.5 3,14.1 16.3,14.1 "/>
+</svg>

--- a/tests/acceptance/config/yaml-test.js
+++ b/tests/acceptance/config/yaml-test.js
@@ -93,6 +93,7 @@ module('Acceptance | config/yaml', function (hooks) {
 
       await visit(`/travis-ci/travis-web/builds/${this.build.id}`);
       await page.yamlTab.click();
+      await page.yamlMessagesHeader.click();
 
       assert.equal(page.ymlMessages.length, 2, 'expected two yml messages');
 

--- a/tests/pages/build.js
+++ b/tests/pages/build.js
@@ -88,6 +88,10 @@ export default create({
     isDisabled: hasClass('disabled')
   },
 
+  yamlMessagesHeader: {
+    scope: '.yml-messages .header'
+  },
+
   ymlMessages: collection('.yml-message', {
     icon: {
       scope: '.level-icon svg',


### PR DESCRIPTION
The build config validation will be collapsed if only `info` level messages are present, and expanded otherwise.

Expanded: 

![image](https://user-images.githubusercontent.com/2208/66423701-7ed66e00-ea0c-11e9-9174-37e2b13f7167.png)

Collapsed:

![image](https://user-images.githubusercontent.com/2208/66423723-8a299980-ea0c-11e9-9831-9b428308764f.png)
