### PR TITLE
Align build info

### DIFF
--- a/app/styles/app/layouts/jobs.scss
+++ b/app/styles/app/layouts/jobs.scss
@@ -175,7 +175,7 @@
   overflow: hidden;
 
   @media #{$medium-up} {
-    flex: 1 0 40%;
+    flex: 1 0 20%;
     position: relative;
     padding: 0.3em 0.5em 0.5em 0.7em;
     align-self: flex-start;
@@ -226,7 +226,7 @@
 
 .job-env {
   @media #{$medium-up} {
-    flex: 1 0 30%;
+    flex: 1 0 18%;
     position: relative;
     max-width: 23em;
     margin-left: -1em;

--- a/app/templates/components/build-header.hbs
+++ b/app/templates/components/build-header.hbs
@@ -225,19 +225,17 @@
         </span>
       </div>
     </div>
-    <div class="detail-job-env"
-      {{action "expandEnv" on="click"}}
-      {{action "expandEnv" on="mouseEnter"}}
-      {{action "expandEnv" on="mouseLeave"}}
-    >
-      <SvgImage @name="icon-environment" @class="icon" />
-      <span class="label-align" aria-label="Environment variables">
-        {{#if this.environment}}
+    {{#if this.environment}}
+      <div class="detail-job-env"
+        {{action "expandEnv" on="click"}}
+        {{action "expandEnv" on="mouseEnter"}}
+        {{action "expandEnv" on="mouseLeave"}}
+      >
+        <SvgImage @name="icon-environment" @class="icon" />
+        <span class="label-align" aria-label="Environment variables">
           {{this.environment}}
-        {{else}}
-          none
-        {{/if}}
-      </span>
-    </div>
+        </span>
+      </div>
+    {{/if}}
   </div>
 {{/if}}

--- a/app/templates/components/build-header.hbs
+++ b/app/templates/components/build-header.hbs
@@ -225,17 +225,19 @@
         </span>
       </div>
     </div>
-    {{#if this.environment}}
-      <div class="detail-job-env"
-        {{action "expandEnv" on="click"}}
-        {{action "expandEnv" on="mouseEnter"}}
-        {{action "expandEnv" on="mouseLeave"}}
-      >
-        <SvgImage @name="icon-environment" @class="icon" />
-        <span class="label-align" aria-label="Environment variables">
+    <div class="detail-job-env"
+      {{action "expandEnv" on="click"}}
+      {{action "expandEnv" on="mouseEnter"}}
+      {{action "expandEnv" on="mouseLeave"}}
+    >
+      <SvgImage @name="icon-environment" @class="icon" />
+      <span class="label-align" aria-label="Environment variables">
+        {{#if this.environment}}
           {{this.environment}}
-        </span>
-      </div>
-    {{/if}}
+        {{else}}
+          none
+        {{/if}}
+      </span>
+    </div>
   </div>
 {{/if}}

--- a/app/templates/components/jobs-item.hbs
+++ b/app/templates/components/jobs-item.hbs
@@ -18,39 +18,42 @@
     <EmberTooltip @text={{this.job.config.content.os}} />
     <SvgImage @name={{osIcon}} @class="icon" />
   </div>
-  {{#if this.name}}
-    <div class="job-name">
-      <SvgImage @name="job-name-icon" @class="icon" />
+  <div class="job-name">
+    <SvgImage @name="job-name-icon" @class="icon" />
+    {{#if this.name}}
       <span class="label-align" aria-label="Title">
         {{this.name}}
       </span>
-    </div>
-  {{else}}
-    <div class="job-lang">
-      <SvgImage @name="icon-language" @class="icon" />
-      <span class="label-align" aria-label="Language">
-        {{#if this.languages}}
-          {{this.languages}}
-        {{else}}
-          no language set
-        {{/if}}
+    {{else}}
+      <span>
+        no name set
+      </span>
+    {{/if}}
+  </div>
+  <div class="job-lang">
+    <SvgImage @name="icon-language" @class="icon" />
+    <span class="label-align" aria-label="Language">
+      {{#if this.languages}}
+        {{this.languages}}
+      {{else}}
+        no language set
+      {{/if}}
+    </span>
+  </div>
+  {{#if this.environment}}
+    <div class="job-env">
+      <SvgImage @name="icon-environment" @class="icon" />
+      <span class="label-align" aria-label="Environment variables">
+        {{this.environment}}
       </span>
     </div>
-    {{#if this.environment}}
-      <div class="job-env">
-        <SvgImage @name="icon-environment" @class="icon" />
-        <span class="label-align" aria-label="Environment variables">
-          {{this.environment}}
-        </span>
-      </div>
-    {{else}}
-      <div class="job-env is-empty">
-        <SvgImage @name="icon-environment" @class="icon" />
-        <span class="label-align" aria-label="Environment variables">
-          no environment variables set
-        </span>
-      </div>
-    {{/if}}
+  {{else}}
+    <div class="job-env is-empty">
+      <SvgImage @name="icon-environment" @class="icon" />
+      <span class="label-align" aria-label="Environment variables">
+        no environment variables set
+      </span>
+    </div>
   {{/if}}
   <div class="job-duration" title="Started {{pretty-date this.job.startedAt}}">
     <SvgImage @name="icon-clock" @class="icon" />

--- a/tests/integration/components/jobs-item-test.js
+++ b/tests/integration/components/jobs-item-test.js
@@ -48,26 +48,6 @@ module('Integration | Component | jobs item', function (hooks) {
     assert.dom('.job-lang').hasText(/no language set/, 'a message about no language being set should be displayed');
   });
 
-  test('when name is set it replaces both language and env', async function (assert) {
-    const job = {
-      id: 10,
-      state: 'passed',
-      number: '2',
-      config: { content: {
-        rvm: '2.1.2',
-        name: 'that name'
-      } },
-      duration: 100
-    };
-
-    this.job = job;
-    await render(hbs`{{jobs-item job=job}}`);
-
-    assert.dom('.job-name .label-align').hasText('that name', 'name should be displayed');
-    assert.dom('.job-language .label-align').doesNotExist();
-    assert.dom('.job-env .label-align').doesNotExist();
-  });
-
   test('when env is not set, gemfile is displayed in the env section', async function (assert) {
     const job = {
       id: 10,


### PR DESCRIPTION
We have some misalignments in the build jobs table:
![image](https://user-images.githubusercontent.com/52037013/66848166-7f22bc00-ef6c-11e9-89b6-867ec2bb1a8a.png)

While I was investigating the cause, I noticed that in cases where `name` exists, the `language` and `env` are omitted causing this misalignment. This PR is more of a proposal to the problem. Would it make more sense to put in a placeholder instead of omitting the `language` and `env` completely. Was it implemented this way on purpose?

<img width="1086" alt="Screenshot 2019-10-15 at 4 18 05 PM" src="https://user-images.githubusercontent.com/52037013/66848492-1be55980-ef6d-11e9-9e04-814521160bd8.png">

Would love to hear your thoughts, thanks!