### PR TITLE
Swap flex-grow and flex-shrink styles for .job-arch column

### DIFF
--- a/app/styles/app/layouts/jobs.scss
+++ b/app/styles/app/layouts/jobs.scss
@@ -215,7 +215,7 @@
 
   @media #{$medium-up} {
     position: relative;
-    flex: 1 0 6em;
+    flex: 0 1 6em;
     padding: 0.3em 0.3em 0.5em 0.7em;
     align-self: flex-start;
     white-space: nowrap;

--- a/app/styles/app/layouts/jobs.scss
+++ b/app/styles/app/layouts/jobs.scss
@@ -215,7 +215,7 @@
 
   @media #{$medium-up} {
     position: relative;
-    flex: 0 1 6em;
+    flex-basis: 6em;
     padding: 0.3em 0.3em 0.5em 0.7em;
     align-self: flex-start;
     white-space: nowrap;


### PR DESCRIPTION
Currently this is set with `flex-grow: 1` which allows it to grow, but that adds a lot of extra whitespace.

Setting instead the `flex-grow: 0` and `flex-shrink: 1` gives a better experience. It doesn't grow unnecessarily and can shrink a bit at smaller screen widths still (which was already happening).

## Before

![with-grow](https://user-images.githubusercontent.com/984921/66849663-22071600-ef2c-11e9-81b1-95fbf3c1bf22.png)

## After

![with-shrink](https://user-images.githubusercontent.com/984921/66849671-25020680-ef2c-11e9-8811-240794bb227e.png)

