### PR TITLE
Make job architecture more visually distinctive

### DIFF
--- a/app/components/build-header.js
+++ b/app/components/build-header.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
+import jobConfigArch from 'travis/utils/job-config-arch';
 import jobConfigLanguage from 'travis/utils/job-config-language';
 import { not } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
@@ -130,7 +131,8 @@ export default Component.extend({
   }),
 
   arch: computed('jobsConfig.content.arch', function () {
-    return this.get('jobsConfig.content.arch') || 'amd64';
+    let config = this.get('jobsConfig.content');
+    return jobConfigArch(config);
   }),
 
   osIcon: computed('os', function () {

--- a/app/components/jobs-item.js
+++ b/app/components/jobs-item.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
+import jobConfigArch from 'travis/utils/job-config-arch';
 import jobConfigLanguage from 'travis/utils/job-config-language';
 
 export default Component.extend({
@@ -59,6 +60,7 @@ export default Component.extend({
   }),
 
   arch: computed('job.config.content.arch', function () {
-    return this.get('job.config.content.arch') || 'amd64';
+    let config = this.get('job.config.content');
+    return jobConfigArch(config);
   })
 });

--- a/app/utils/job-config-arch.js
+++ b/app/utils/job-config-arch.js
@@ -1,10 +1,6 @@
 import { archConfigKeys } from 'travis/utils/keys-map';
 
-export default function jobConfigArch(config) {
-  if (!config) { return ''; }
-
-  let arch = config.arch, os = config.os;
-
+export default function jobConfigArch({ arch, os } = {}) {
   // Previously it was possible to choose ppc64le arch only by setting `os: linux-ppc64le` in the config.
   // We have introduced a separate `arch` config key, but many customers are still using the old one.
   // We need this hack until we deprecate `os: linux-ppc64le`.
@@ -12,5 +8,5 @@ export default function jobConfigArch(config) {
     return archConfigKeys.ppc64le;
   }
 
-  return arch ? archConfigKeys[arch] : archConfigKeys.amd64;
+  return archConfigKeys[arch || 'amd64'];
 }

--- a/app/utils/job-config-arch.js
+++ b/app/utils/job-config-arch.js
@@ -1,6 +1,8 @@
 import { archConfigKeys } from 'travis/utils/keys-map';
 
-export default function jobConfigArch({ arch, os } = {}) {
+export default function jobConfigArch(config) {
+  const { arch, os } = config || {};
+
   // Previously it was possible to choose ppc64le arch only by setting `os: linux-ppc64le` in the config.
   // We have introduced a separate `arch` config key, but many customers are still using the old one.
   // We need this hack until we deprecate `os: linux-ppc64le`.

--- a/app/utils/job-config-arch.js
+++ b/app/utils/job-config-arch.js
@@ -1,0 +1,16 @@
+import { archConfigKeys } from 'travis/utils/keys-map';
+
+export default function jobConfigArch(config) {
+  if (!config) { return ''; }
+
+  let arch = config.arch, os = config.os;
+
+  // Previously it was possible to choose ppc64le arch only by setting `os: linux-ppc64le` in the config.
+  // We have introduced a separate `arch` config key, but many customers are still using the old one.
+  // We need this hack until we deprecate `os: linux-ppc64le`.
+  if (os === 'linux-ppc64le') {
+    return archConfigKeys.ppc64le;
+  }
+
+  return arch ? archConfigKeys[arch] : archConfigKeys.amd64;
+}

--- a/app/utils/keys-map.js
+++ b/app/utils/keys-map.js
@@ -1,6 +1,6 @@
 import { assign } from '@ember/polyfills';
 
-let configKeys, configKeysMap, languageConfigKeys;
+let configKeys, configKeysMap, languageConfigKeys, archConfigKeys;
 
 languageConfigKeys = {
   android: 'Android',
@@ -56,8 +56,14 @@ configKeys = {
   os: 'OS'
 };
 
+archConfigKeys = {
+  arm64: 'Arm64',
+  amd64: 'AMD64',
+  ppc64le: 'ppc64le'
+};
+
 configKeysMap = assign(configKeys, languageConfigKeys);
 
 export default configKeysMap;
 
-export { languageConfigKeys, configKeys };
+export { languageConfigKeys, configKeys, archConfigKeys };

--- a/tests/integration/components/jobs-item-test.js
+++ b/tests/integration/components/jobs-item-test.js
@@ -19,8 +19,7 @@ module('Integration | Component | jobs item', function (hooks) {
           rvm: '2.1.2',
           jdk: 'openjdk6',
           os: 'linux-ppc64le',
-          env: 'TESTS=unit',
-          arch: 'arm64'
+          env: 'TESTS=unit'
         },
       },
       duration: 100,
@@ -34,7 +33,7 @@ module('Integration | Component | jobs item', function (hooks) {
     assert.dom('.job-lang').hasText('JDK: openjdk6 Ruby: 2.1.2', 'langauges list should be displayed');
     assert.dom('.job-env').hasText('TESTS=unit', 'env should be displayed');
     assert.dom('.job-os').hasClass('linux', 'OS class should be added for OS icon');
-    assert.dom('.job-arch').hasText('arm64', 'arch should be displayed');
+    assert.dom('.job-arch').hasText('ppc64le', 'arch should be displayed');
     assert.dom('.job-duration').hasText('1 min 40 sec', 'duration should be displayed');
     assert.dom('.job-duration').hasAttribute('title', `Started ${prettyDate([startedAt])}`);
   });

--- a/tests/unit/utils/job-config-arch-test.js
+++ b/tests/unit/utils/job-config-arch-test.js
@@ -3,10 +3,6 @@ import jobConfigArch from 'travis/utils/job-config-arch';
 import { module, test } from 'qunit';
 
 module('jobConfigArch', function () {
-  test('an empty config returns an empty string', (assert) => {
-    assert.equal(jobConfigArch({}), '', 'expected an empty config to return an empty string');
-  });
-
   test('a job with an empty arch value returns AMD64', (assert) => {
     assert.equal(jobConfigArch({ arch: null }), 'AMD64');
   });

--- a/tests/unit/utils/job-config-arch-test.js
+++ b/tests/unit/utils/job-config-arch-test.js
@@ -1,0 +1,29 @@
+import jobConfigArch from 'travis/utils/job-config-arch';
+
+import { module, test } from 'qunit';
+
+module('jobConfigArch', function () {
+  test('an empty config returns an empty string', (assert) => {
+    assert.equal(jobConfigArch({}), '', 'expected an empty config to return an empty string');
+  });
+
+  test('a job with an empty arch value returns AMD64', (assert) => {
+    assert.equal(jobConfigArch({ arch: null }), 'AMD64');
+  });
+
+  test('a job with an amd64 arch value returns AMD64', (assert) => {
+    assert.equal(jobConfigArch({ arch: amd64 }), 'AMD64');
+  });
+
+  test('a job with an arm64 arch value returns Arm64', (assert) => {
+    assert.equal(jobConfigArch({ arch: arm64 }), 'Arm64');
+  });
+
+  test('a job with any other arch value returns the original value', (assert) => {
+    assert.equal(jobConfigArch({ arch: 'ppc64le' }), 'ppc64le');
+  });
+
+  test('a job with an linux-ppc64le os value returns ppc64le', (assert) => {
+    assert.equal(jobConfigArch({ os: 'linux-ppc64le' }), 'ppc64le');
+  });
+});

--- a/tests/unit/utils/job-config-arch-test.js
+++ b/tests/unit/utils/job-config-arch-test.js
@@ -12,11 +12,11 @@ module('jobConfigArch', function () {
   });
 
   test('a job with an amd64 arch value returns AMD64', (assert) => {
-    assert.equal(jobConfigArch({ arch: amd64 }), 'AMD64');
+    assert.equal(jobConfigArch({ arch: 'amd64' }), 'AMD64');
   });
 
   test('a job with an arm64 arch value returns Arm64', (assert) => {
-    assert.equal(jobConfigArch({ arch: arm64 }), 'Arm64');
+    assert.equal(jobConfigArch({ arch: 'arm64' }), 'Arm64');
   });
 
   test('a job with any other arch value returns the original value', (assert) => {


### PR DESCRIPTION
After some brainstorming and feedback we decided to change casing for CPU arch labels (because amd64 and arm64 look very similar, especially when you have a long job list)

Also, we need to make a hack to display `ppc64le` arch when `os: linux-ppc64le` in config, because of legacy queue routing logic that is still used by many clients (but will be deprecated soon)