### PR TITLE
Revert preventing first_sync page manual visits

### DIFF
--- a/app/routes/first-sync.js
+++ b/app/routes/first-sync.js
@@ -1,19 +1,8 @@
 import { later } from '@ember/runloop';
 import config from 'travis/config/environment';
 import SimpleLayoutRoute from 'travis/routes/simple-layout';
-import { inject as service } from '@ember/service';
 
 export default SimpleLayoutRoute.extend({
-  auth: service(),
-
-  beforeModel(transition) {
-    const { currentUser: user } = this.auth;
-    const isFirstSync = !!user && user.isSyncing && !user.syncedAt;
-    if (!isFirstSync) {
-      transition.abort();
-      return this.transitionTo('dashboard');
-    }
-  },
 
   activate() {
     const controller = this.controllerFor('firstSync');


### PR DESCRIPTION
Reverting this change as it seem to affect analytics in unexpected way.