### PR TITLE
Remove enterprise dotenv variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,2 @@
 TRAVIS_PRO=false
-TRAVIS_ENTERPRISE=false
 # API_ENDPOINT=https://api.travis-ci.org

--- a/config/dotenv.js
+++ b/config/dotenv.js
@@ -3,7 +3,6 @@ module.exports = function (env) {
     clientAllowedKeys: [
       'API_ENDPOINT',
       'TRAVIS_PRO',
-      'TRAVIS_ENTERPRISE',
     ],
     failOnMissingKey: false,
   };


### PR DESCRIPTION
It turns out that this is less helpful when you're not working on enterprise version. When TRAVIS_ENTERPRISE=false, it behaves as if it is true for some reason. So then you would need to comment it out or remove it to work on non-enterprise version. TRAVIS_PRO doesn't seem to have this problem. So I think it might be best to remove for now