### PR TITLE
tweak build config view

### DIFF
--- a/app/adapters/request.js
+++ b/app/adapters/request.js
@@ -1,7 +1,7 @@
 import V3Adapter from 'travis/adapters/v3';
 
 export default V3Adapter.extend({
-  includes: 'request.builds,request.commit,request.raw_configs',
+  includes: 'request.builds,request.commit,request.config,request.raw_configs',
 
   buildURL: function (modelName, id, snapshot, requestType, query) {
     let prefix = this.urlPrefix();

--- a/app/components/raw-config.js
+++ b/app/components/raw-config.js
@@ -15,6 +15,14 @@ export default Component.extend({
   copied: false,
   baseYmlName: '.travis.yml',
 
+  isExpanded: computed('rawConfig.config', function () {
+    return this.get('rawConfig.config') !== '{}';
+  }),
+
+  toggleStatusClass: computed('isExpanded', function () {
+    return this.isExpanded ? 'expanded' : 'collapsed';
+  }),
+
   buttonLabel: computed('copied', 'rawConfig.source', function () {
     let source = this.get('rawConfig.source');
     return this.copied ? 'Copied!' : `Copy ${fileNameWithoutSha(source)}`;
@@ -59,6 +67,9 @@ export default Component.extend({
     copied() {
       this.set('copied', true);
       later(() => this.set('copied', false), 3000);
+    },
+    toggle() {
+      this.toggleProperty('isExpanded');
     }
   }
 });

--- a/app/components/request-config.js
+++ b/app/components/request-config.js
@@ -1,0 +1,35 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { later } from '@ember/runloop';
+
+export default Component.extend({
+  copied: false,
+  isExpanded: true,
+
+  toggleStatusClass: computed('isExpanded', function () {
+    return this.isExpanded ? 'expanded' : 'collapsed';
+  }),
+
+  buttonLabel: computed('copied', function () {
+    return this.copied ? 'Copied!' : 'Copy build config';
+  }),
+
+  formattedConfig: computed('config', 'slug', function () {
+    const config = this.get('config');
+    try {
+      return JSON.stringify(config, null, 2);
+    } catch (e) {
+      return config;
+    }
+  }),
+
+  actions: {
+    copied() {
+      this.set('copied', true);
+      later(() => this.set('copied', false), 3000);
+    },
+    toggle() {
+      this.toggleProperty('isExpanded');
+    }
+  }
+});

--- a/app/models/request.js
+++ b/app/models/request.js
@@ -27,6 +27,7 @@ export default Model.extend({
   pullRequest: attr('boolean'),
   pullRequestTitle: attr('string'),
   pullRequestNumber: attr('number'),
+  config: attr(),
   raw_configs: attr(),
   uniqRawConfigs: uniqBy('raw_configs', 'source'),
   noYaml: empty('raw_configs'),

--- a/app/styles/app/modules/build-messages.scss
+++ b/app/styles/app/modules/build-messages.scss
@@ -47,9 +47,10 @@
       height: 12px;
       margin-left: 2px;
       margin-right: 8px;
+      opacity: 0.8;
       path {
         stroke: $turf-green;
-        stroke-width: 2;
+        stroke-width: 1;
       }
     }
 
@@ -82,10 +83,6 @@
         }
       }
     }
-  }
-
-  .list {
-    border-top: 1px solid $pebble-grey;
   }
 
   .yml-message-link {

--- a/app/styles/app/modules/yaml.scss
+++ b/app/styles/app/modules/yaml.scss
@@ -54,7 +54,32 @@ pre.codedisplay[class*='language-'] {
   padding: 1em;
 }
 
-.file-name {
+.header {
   padding: 1em;
-  border-bottom: 1px solid $pebble-grey;
+  cursor: pointer;
+
+  .tools {
+    position: absolute;
+    right: 1em;
+    top: 1em;
+
+    .icon-help {
+      margin: 0 3px 3px 0;
+    }
+
+    .icon-toggle {
+      height: 15px;
+      width: 15px;
+      vertical-align: middle;
+      transform: scale(0.9, 1.1);
+      path {
+        stroke: $cement-grey;
+        stroke-width: 1;
+      }
+
+      &.icon-expanded {
+        transform: scaleY(-1);
+      }
+    }
+  }
 }

--- a/app/templates/components/annotated-yaml.hbs
+++ b/app/templates/components/annotated-yaml.hbs
@@ -14,4 +14,5 @@
       The .travis.yml file used for this job is not available
     </div>
   {{/each}}
+  <RequestConfig @config={{@request.config}} />
 </div>

--- a/app/templates/components/build-messages-list.hbs
+++ b/app/templates/components/build-messages-list.hbs
@@ -10,10 +10,10 @@
         &mdash; {{this.summary}}
       {{/unless}}
       <div class="tools">
-        <SvgImage @name="icon-dropdown-arrow" @class="icon-toggle icon-{{this.toggleStatusClass}}" />
         <ExternalLinkTo href="{{config-get 'urls.buildConfigValidation'}}">
           <SvgImage @name='icon-help' @class='icon-help' />
         </ExternalLinkTo>
+        <SvgImage @name="icon-dropdown-arrow" @class="icon-toggle icon-{{this.toggleStatusClass}}" />
       </div>
     </div>
     {{#if this.isExpanded}}

--- a/app/templates/components/request-config.hbs
+++ b/app/templates/components/request-config.hbs
@@ -1,18 +1,9 @@
 <div class="inner-yaml-container">
   <div class="header" {{on 'click' (action 'toggle')}}>
-    {{#if this.fileUrl}}
-      <ExternalLinkTo @href={{this.fileUrl}}>
-        <SvgImage @name="job-name-icon" @class="icon" @width=14 @height=14 />
-        <span class="vertical-align">
-          {{this.filePath}}
-        </span>
-      </ExternalLinkTo>
-    {{else}}
-      <SvgImage @name="job-name-icon" @class="icon" @width=14 @height=14 />
-      <span class="vertical-align">
-        {{this.filePath}}
-      </span>
-    {{/if}}
+    <SvgImage @name="job-name-icon" @class="icon" @width=14 @height=14 />
+    <span class="vertical-align">
+      Build Config
+    </span>
     <div class="tools">
       <SvgImage @name="icon-dropdown-arrow" @class="icon-toggle icon-{{this.toggleStatusClass}}" />
     </div>
@@ -22,13 +13,12 @@
       <CodeBlock
         @language="yaml"
         class="codedisplay line-numbers"
-        id={{this.codeblockId}}
         data-test-yaml="true"
       >{{this.formattedConfig}}</CodeBlock>
       <CopyButton
-        @clipboardText={{this.rawConfig.config}}
+        @clipboardText={{this.config}}
         @title={{this.buttonLabel}}
-        @success={{action "copied" this.rawConfig.source}}
+        @success={{action "copied" this.config}}
       >
         <SvgImage @name="icon-copy" @class="icon" />
         <span>

--- a/tests/acceptance/config/yaml-test.js
+++ b/tests/acceptance/config/yaml-test.js
@@ -123,7 +123,7 @@ module('Acceptance | config/yaml', function (hooks) {
     test('shows all unique raw configs', async function (assert) {
       await visit(`/travis-ci/travis-web/builds/${this.build.id}`);
       await page.yamlTab.click();
-      assert.equal(page.yaml.length, 2, 'expected two yaml code block');
+      assert.equal(page.yaml.length, 3, 'expected three yaml code block');
     });
 
     test('shows only file name for travis yml', async function (assert) {

--- a/tests/pages/build.js
+++ b/tests/pages/build.js
@@ -114,7 +114,7 @@ export default create({
       text: text(),
       id: attribute('id'),
     },
-    source: text('.file-name')
+    source: text('.header')
   }),
 
   jobYamlNote: {


### PR DESCRIPTION
this does:

* allow folding config sources
* fold empty sources by default (api is empty :alot:)
* display resulting build config
* remove the line between the header div and the foldable container (removed this accidentally when trying to remove a duplicate border there when folded, and then found it looked a lot more clean)

needs `travis-api/sf-request-config`: https://github.com/travis-ci/travis-api/pull/980

![image](https://user-images.githubusercontent.com/2208/68058988-2177c900-fcfb-11e9-9e40-37e143465b67.png)
