### PR TITLE
Fix issue where .org test deployments act as if TRAVIS_PRO=true

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -165,7 +165,7 @@ module.exports = function (environment) {
 
   const { TRAVIS_PRO, TRAVIS_ENTERPRISE, SOURCE_ENDPOINT } = process.env;
 
-  if (TRAVIS_PRO && TRAVIS_PRO !== 'false') {
+  if (TRAVIS_PRO) {
     ENV.featureFlags['pro-version'] = true;
     ENV.featureFlags['github-apps'] = true;
     ENV.pro = true;

--- a/config/environment.js
+++ b/config/environment.js
@@ -165,7 +165,7 @@ module.exports = function (environment) {
 
   const { TRAVIS_PRO, TRAVIS_ENTERPRISE, SOURCE_ENDPOINT } = process.env;
 
-  if (TRAVIS_PRO) {
+  if (TRAVIS_PRO && TRAVIS_PRO !== 'false') {
     ENV.featureFlags['pro-version'] = true;
     ENV.featureFlags['github-apps'] = true;
     ENV.pro = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "travis",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "description": "Small description for travis goes here",
   "repository": "https://github.com/travis-ci/travis-web",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "travis",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "private": true,
   "description": "Small description for travis goes here",
   "repository": "https://github.com/travis-ci/travis-web",


### PR DESCRIPTION
Today I noticed an interesting issue. Some .org PR test deployments appear to be behaving as if TRAVIS_PRO=true. The landing page and plans page are 2 places that I know of where you can easily spot a difference. I haven't yet been able to figure out a pattern behind which PR deployments are affected, nor am I really sure why.

For example, compare:
https://travis-ci.org/
https://greenkeeper-ember-resolver-6-0-0.test-deployments.travis-ci.org/

https://travis-ci.org/plans
https://greenkeeper-ember-resolver-6-0-0.test-deployments.travis-ci.org/plans