### PR TITLE
Remove jQuery from build and job tab components

### DIFF
--- a/app/components/build-tabs.js
+++ b/app/components/build-tabs.js
@@ -1,10 +1,17 @@
 import { computed } from '@ember/object';
 import Component from '@ember/component';
 import { isEmpty } from '@ember/utils';
+import { match, not } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
 
 export default Component.extend({
   tagName: 'div',
   classNames: ['travistab'],
+
+  router: service(),
+
+  isConfig: match('router.currentRouteName', /config$/),
+  isLog: not('isConfig'),
 
   messagesMaxLevel: computed('build.request.messages.@each.level', function () {
     const msgs = this.get('build.request.messages');
@@ -16,11 +23,4 @@ export default Component.extend({
   messagesBadgeTooltipText: computed('messagesMaxLevel', function () {
     return `This build's config has ${this.messagesMaxLevel} level validation messages`;
   }),
-
-  didRender() {
-    // Set the log to be default active tab unless something else is active
-    if (isEmpty(this.$('.travistab-nav--secondary').find('.active'))) {
-      this.$('.travistab-nav--secondary li:first-child a').addClass('active');
-    }
-  }
 });

--- a/app/components/job-tabs.js
+++ b/app/components/job-tabs.js
@@ -1,10 +1,17 @@
 import { computed } from '@ember/object';
 import { isEmpty } from '@ember/utils';
 import Component from '@ember/component';
+import { match, not } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
 
 export default Component.extend({
   tagName: 'div',
   classNames: ['travistab'],
+
+  router: service(),
+
+  isConfig: match('router.currentRouteName', /config$/),
+  isLog: not('isConfig'),
 
   messagesMaxLevel: computed('job.build.request.messages.@each.level', function () {
     const msgs = this.get('job.build.request.messages');
@@ -16,11 +23,4 @@ export default Component.extend({
   messagesBadgeTooltipText: computed('messagesMaxLevel', function () {
     return `This build's config has ${this.messagesMaxLevel} level validation messages`;
   }),
-
-  didRender() {
-    // Set the log to be default active tab unless something else is active
-    if (isEmpty(this.$('.travistab-nav--secondary').find('.active'))) {
-      this.$('#tab_log').addClass('active');
-    }
-  }
 });

--- a/app/templates/components/build-tabs.hbs
+++ b/app/templates/components/build-tabs.hbs
@@ -4,8 +4,9 @@
       <LinkTo
         @route="build.index"
         @models={{array this.build.repo build}}
-        data-test-build-matrix-tab="true"
         @title="Look at this build’s jobs"
+        class={{if this.isLog 'active'}}
+        data-test-build-matrix-tab="true"
       >
         Build jobs
       </LinkTo>

--- a/app/templates/components/job-tabs.hbs
+++ b/app/templates/components/job-tabs.hbs
@@ -6,6 +6,7 @@
         @models={{array repo job}}
         @id="tab_log"
         @title="Look at this job's log"
+        class={{if this.isLog 'active'}}
         data-test-job-log-tab="true"
       >
         Job log


### PR DESCRIPTION
Split from https://github.com/travis-ci/travis-web/pull/2203

The `<LinkTo` components handle highlighting automatically on the build.index / build.config / job.index / job.config routes. This functionality covers the case where the log tab should be highlighted on parent pages like https://so-job-tabs-remove-jquery.test-deployments.travis-ci.com/travis-ci/travis-web 