### PR TITLE
Remove jquery from repo-list-item component

### DIFF
--- a/app/components/repos-list-item.js
+++ b/app/components/repos-list-item.js
@@ -2,22 +2,13 @@ import Component from '@ember/component';
 import Polling from 'travis/mixins/polling';
 import colorForState from 'travis/utils/color-for-state';
 import { computed } from '@ember/object';
-import { inject as service } from '@ember/service';
 
 export default Component.extend(Polling, {
   tagName: 'li',
   pollModels: 'repo',
   classNames: ['repo'],
 
-  scroller: service(),
-
   color: computed('repo.currentBuild.state', function () {
     return colorForState(this.get('repo.currentBuild.state'));
   }),
-
-  scrollTop() {
-    if (window && window.pageYOffset) {
-      this.scroller.scrollTo(0, 200);
-    }
-  }
 });

--- a/app/components/repos-list-item.js
+++ b/app/components/repos-list-item.js
@@ -1,23 +1,23 @@
-import $ from 'jquery';
 import Component from '@ember/component';
 import Polling from 'travis/mixins/polling';
 import colorForState from 'travis/utils/color-for-state';
 import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default Component.extend(Polling, {
   tagName: 'li',
   pollModels: 'repo',
   classNames: ['repo'],
 
+  scroller: service(),
+
   color: computed('repo.currentBuild.state', function () {
     return colorForState(this.get('repo.currentBuild.state'));
   }),
 
   scrollTop() {
-    if (window.scrollY > 0) {
-      return $('html, body').animate({
-        scrollTop: 0
-      }, 200);
+    if (window && window.pageYOffset) {
+      this.scroller.scrollTo(0, 200);
     }
   }
 });


### PR DESCRIPTION
Split from https://github.com/travis-ci/travis-web/pull/2203

I changed to using `window.pageYOffset` because `window.scrollY` is not supported by IE. Some info: 
https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollY
https://developer.mozilla.org/en-US/docs/Web/API/Window/pageYOffset