### PR TITLE
Fix ui migration confusion

### DIFF
--- a/app/components/dialogs/migrate-beta.js
+++ b/app/components/dialogs/migrate-beta.js
@@ -27,7 +27,7 @@ export default Component.extend({
       yield this.user.joinMigrateBeta(this.selectedAccounts.without(this.user).toArray());
       this.onClose();
       this.flashes.clear();
-      this.flashes.success('You have been successfully placed on the waitlist for beta!');
+      this.flashes.success('You have successfully joined the beta!');
     } catch (error) {
       this.flashes.clear();
       this.flashes.error('There was an error. Please try again later.', undefined, true);
@@ -66,9 +66,9 @@ export default Component.extend({
 });
 
 function makeOptionFromAccount(account) {
-  const { id, title, isMigrationBetaAccepted, isMigrationBetaRequested, isOrganization, isUser } = account;
+  const { id, title, isMigrationBetaAccepted, isOrganization, isUser } = account;
   const isNotAdmin = isOrganization && !account.get('permissions.admin');
-  const state = isMigrationBetaAccepted ? 'subscribed' : isMigrationBetaRequested ? 'waitlisted' : isNotAdmin ? 'not admin' : '';
-  const disabled = isOrganization && (isMigrationBetaAccepted || isMigrationBetaRequested) || isUser || isNotAdmin;
+  const state = isMigrationBetaAccepted ? 'subscribed' : isNotAdmin ? 'not admin' : '';
+  const disabled = isOrganization && (isMigrationBetaAccepted) || isUser || isNotAdmin;
   return { id, title, state, disabled };
 }

--- a/app/components/dialogs/migrate-beta.js
+++ b/app/components/dialogs/migrate-beta.js
@@ -69,6 +69,6 @@ function makeOptionFromAccount(account) {
   const { id, title, isMigrationBetaAccepted, isOrganization, isUser } = account;
   const isNotAdmin = isOrganization && !account.get('permissions.admin');
   const state = isMigrationBetaAccepted ? 'subscribed' : isNotAdmin ? 'not admin' : '';
-  const disabled = isOrganization && (isMigrationBetaAccepted) || isUser || isNotAdmin;
+  const disabled = isOrganization && isMigrationBetaAccepted || isUser || isNotAdmin;
   return { id, title, state, disabled };
 }

--- a/app/templates/components/dialogs/migrate-beta.hbs
+++ b/app/templates/components/dialogs/migrate-beta.hbs
@@ -59,7 +59,7 @@
           {{#if this.register.isRunning}}
             <LoadingIndicator @white={{true}} @inline={{true}} /> Joining...
           {{else}}
-            Join the waitlist
+            Join the beta
           {{/if}}
         </button>
       </div>

--- a/app/templates/components/owner/migrate.hbs
+++ b/app/templates/components/owner/migrate.hbs
@@ -141,7 +141,7 @@
             {{else}}
               <PaperBlock>
                 <p>
-                  Your account needs to be part of the beta to start migrating public repositories here. Please, sign up for the beta waitlist below.
+                  Your account needs to be part of the beta to start migrating public repositories here. Please, sign up for the beta below.
                 </p>
                 <div>
                   <button


### PR DESCRIPTION
While we removed the "wait" from the waitlist for the migration beta some time ago, I neglected when rolling out that change to remove all references to a waitlist within the UI. As users are immediately accepted, I didn't think much of it at the time. Unfortunately, this has resulted in some confusion, so needs to be addressed.