### PR TITLE
Fix issue where migration requests request would get a 500 error

### DIFF
--- a/app/services/tasks.js
+++ b/app/services/tasks.js
@@ -10,10 +10,21 @@ export default Service.extend({
   store: service(),
   api: service(),
   accounts: service(),
+  raven: service(),
 
   fetchBetaMigrationRequestsTask: task(function* () {
-    const data = yield this.api.get(`/user/${this.accounts.user.id}/beta_migration_requests`);
-    this.store.pushPayload('beta-migration-request', data);
+    const data = yield this.api.get(`/user/${this.accounts.user.id}/beta_migration_requests`, {
+      travisApiVersion: null,
+    }).catch(error => {
+      if (error.status !== 404) {
+        this.raven.logException(error);
+      }
+    });
+
+    if (data) {
+      this.store.pushPayload('beta-migration-request', data);
+    }
+
     return this.store.peekAll('beta-migration-request');
   }).drop()
 


### PR DESCRIPTION
I was doing some testing on staging and noticed a 500 error on beta_migration_requests endpoint when going to /account/subscription. It seems it was due to the `travis-api-version` header being set to 3