### PR TITLE
Move client release header to api service

### DIFF
--- a/app/services/ajax.js
+++ b/app/services/ajax.js
@@ -3,7 +3,6 @@ import Service, { inject as service } from '@ember/service';
 import { warn } from '@ember/debug';
 import serializeQueryParams from 'ember-fetch/utils/serialize-query-params';
 import fetch from 'fetch';
-import config from 'travis/config/environment';
 
 const DEFAULT_ACCEPT = 'application/json; version=2';
 
@@ -22,11 +21,6 @@ export default Service.extend({
 
   setupHeaders(method, options = {}) {
     const { headers = {} } = options;
-
-    // Release
-    if (config.release) {
-      headers['X-Client-Release'] = config.release;
-    }
 
     // Content-Type
     if (!this.isRetrieve(method)) {

--- a/app/services/api.js
+++ b/app/services/api.js
@@ -38,6 +38,11 @@ export default Service.extend({
     const { headers = {} } = options;
     const { token } = this.auth;
 
+    // Release
+    if (config.release) {
+      headers['X-Client-Release'] = config.release;
+    }
+
     // Authorization
     if (token) {
       headers['Authorization'] = `token ${token}`;


### PR DESCRIPTION
This should address an issue where the help page zendesk form is erroring. The X-Client-Release header, I believe should only be relevant to our API, and very few things use the ajax service directly, so I don't think this change should cause problems