### PR TITLE
Fix success image size on help page

### DIFF
--- a/app/styles/app/pages/help.scss
+++ b/app/styles/app/pages/help.scss
@@ -81,7 +81,8 @@
     }
 
     .success-image {
-      margin: 30px 0 40px;
+      margin: 30px auto 40px;
+      max-width: 300px;
     }
 
     .zendesk-request-form {


### PR DESCRIPTION
Issue description:
When user sends a form to Zendesk the success image scales to the page width and looks giant.