### PR TITLE
Fix issue where clicking on fold child closes fold

### DIFF
--- a/app/utils/log-folder.js
+++ b/app/utils/log-folder.js
@@ -13,34 +13,44 @@ export default (function () {
   }
 
   LogFolder.prototype.fold = function (line) {
-    let folder;
-    folder = this.getFolderFromLine(line);
-    if (folder.classList && folder.classList.contains('open')) {
+    const folder = this.getFolderFromLine(line);
+    if (folder && folder.classList && folder.classList.contains('open')) {
       return this.toggle(folder);
     }
   };
 
   LogFolder.prototype.unfold = function (line) {
-    let folder;
-    folder = this.getFolderFromLine(line);
-    if (folder.classList && !folder.classList.contains('open')) {
+    const folder = this.getFolderFromLine(line);
+    if (folder && folder.classList && !folder.classList.contains('open')) {
       return this.toggle(folder);
     }
   };
 
   LogFolder.prototype.toggle = function (folder) {
-    return folder.classList && folder.classList.toggle('open');
+    return folder && folder.classList && folder.classList.toggle('open');
   };
 
   LogFolder.prototype.getFolderFromLine = function (line) {
-    let currentLine = line;
-    while (currentLine.parentNode) {
-      currentLine = currentLine.parentNode;
-      if (currentLine.classList && currentLine.classList.contains('fold')) {
+    let firstFoldLine, currentElem = line, parentElem = line.parentNode;
+
+    while (parentElem) {
+      if (!parentElem.classList || parentElem.classList.contains('log-body-content')) {
         break;
       }
+
+      if (parentElem.classList.contains('fold')) {
+        const { children } = parentElem;
+        if (children.length >= 2 && children[1] === currentElem) {
+          firstFoldLine = parentElem;
+        }
+        break;
+      }
+
+      currentElem = currentElem.parentNode;
+      parentElem = parentElem.parentNode;
     }
-    return currentLine;
+
+    return firstFoldLine;
   };
 
   return LogFolder;


### PR DESCRIPTION
I noticed while doing some testing on staging, the log jquery removal introduced an issue where clicking on a line within a fold closes the fold. It should only be clicking on the first line that toggles a fold. Some URLs where you can test:

https://so-fix-log-fold-issue.test-deployments.travis-ci.com/travis-ci/travis-web/builds/139577193

https://so-logs-remove-jquery.test-deployments.travis-ci.com/travis-ci/travis-web/builds/139577193
https://staging.travis-ci.com/travis-pro/test-repo-staging1/jobs/490940
https://travis-ci.com/travis-ci/travis-web/builds/139577193