### PR TITLE
Start mirage manually instead of via undocumented `autostart` option

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -343,7 +343,6 @@ module.exports = {
         embertest: true
       },
       globals: {
-        server: true,
         triggerCopySuccess: true,
         triggerCopyError: true,
         signInUser: true,

--- a/config/environment.js
+++ b/config/environment.js
@@ -275,10 +275,6 @@ module.exports = function (environment) {
   }
 
   if (environment === 'test') {
-    ENV['ember-cli-mirage'] = {
-      autostart: true,
-    };
-
     // Testem prefers this...
     ENV.locationType = 'none';
 

--- a/tests/acceptance/auth/automatic-sign-out-test.js
+++ b/tests/acceptance/auth/automatic-sign-out-test.js
@@ -5,12 +5,14 @@ import { setupApplicationTest } from 'travis/tests/helpers/setup-application-tes
 import topPage from 'travis/tests/pages/top';
 import signInUser from 'travis/tests/helpers/sign-in-user';
 import { percySnapshot } from 'ember-percy';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | automatic sign out', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    const currentUser = server.create('user');
+    const currentUser = this.server.create('user');
     signInUser(currentUser);
   });
 

--- a/tests/acceptance/auth/first-sync-test.js
+++ b/tests/acceptance/auth/first-sync-test.js
@@ -3,12 +3,14 @@ import { module, skip } from 'qunit';
 import { setupApplicationTest } from 'travis/tests/helpers/setup-application-test';
 import { run } from '@ember/runloop';
 import signInUser from 'travis/tests/helpers/sign-in-user';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | auth/first sync', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    this.currentUser = server.create('user', 'syncing');
+    this.currentUser = this.server.create('user', 'syncing');
     signInUser(this.currentUser);
   });
 

--- a/tests/acceptance/auth/github-apps-installation-redirect-test.js
+++ b/tests/acceptance/auth/github-apps-installation-redirect-test.js
@@ -3,12 +3,14 @@ import { module, skip } from 'qunit';
 import { setupApplicationTest } from 'travis/tests/helpers/setup-application-test';
 import signInUser from 'travis/tests/helpers/sign-in-user';
 import { Response } from 'ember-cli-mirage';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | auth/GitHub Apps installation redirect', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    this.currentUser = server.create('user');
+    this.currentUser = this.server.create('user');
     signInUser(this.currentUser);
   });
 
@@ -17,13 +19,13 @@ module('Acceptance | auth/GitHub Apps installation redirect', function (hooks) {
     let done = assert.async();
     let repetition = 0;
 
-    let installation = server.create('installation');
+    let installation = this.server.create('installation');
 
     installation.createOwner('organization', {
       login: 'the-org'
     });
 
-    server.get('/installation/:id', (schema, {params: {id}}) => {
+    this.server.get('/installation/:id', (schema, {params: {id}}) => {
       if (repetition < 2) {
         repetition++;
         return new Response(404, {}, {});

--- a/tests/acceptance/auth/sign-out-test.js
+++ b/tests/acceptance/auth/sign-out-test.js
@@ -3,12 +3,14 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'travis/tests/helpers/setup-application-test';
 import topPage from 'travis/tests/pages/top';
 import signInUser from 'travis/tests/helpers/sign-in-user';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | auth/sign out', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    const currentUser = server.create('user');
+    const currentUser = this.server.create('user');
     signInUser(currentUser);
   });
 

--- a/tests/acceptance/builds/build-stages-test.js
+++ b/tests/acceptance/builds/build-stages-test.js
@@ -4,9 +4,11 @@ import { setupApplicationTest } from 'travis/tests/helpers/setup-application-tes
 import buildPage from 'travis/tests/pages/build';
 import { prettyDate } from 'travis/helpers/pretty-date';
 import { percySnapshot } from 'ember-percy';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | build stages', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   const jobTime = new Date();
 
@@ -15,22 +17,22 @@ module('Acceptance | build stages', function (hooks) {
   }
 
   test('visiting build with one stage', async function (assert) {
-    let repo =  server.create('repository', { slug: 'travis-ci/travis-web' });
+    let repo =  this.server.create('repository', { slug: 'travis-ci/travis-web' });
 
-    let branch = server.create('branch', { name: 'acceptance-tests' });
-    let gitUser = server.create('git-user', { name: 'Mr T' });
-    let commit = server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
-    let build = server.create('build', { repository: repo, state: 'passed', commit, branch });
+    let branch = this.server.create('branch', { name: 'acceptance-tests' });
+    let gitUser = this.server.create('git-user', { name: 'Mr T' });
+    let commit = this.server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
+    let build = this.server.create('build', { repository: repo, state: 'passed', commit, branch });
 
     let firstStage = build.createStage({ number: 1, name: 'first :two_men_holding_hands:', state: 'passed', started_at: jobTime, finished_at: futureTime(71), allow_failure: true });
 
-    let firstJob = server.create('job', { number: '1234.1', repository: repo, state: 'passed', config: { env: 'JORTS', os: 'linux', language: 'node_js', node_js: 5 }, commit, build, stage: firstStage, started_at: jobTime, finished_at: futureTime(30) });
+    let firstJob = this.server.create('job', { number: '1234.1', repository: repo, state: 'passed', config: { env: 'JORTS', os: 'linux', language: 'node_js', node_js: 5 }, commit, build, stage: firstStage, started_at: jobTime, finished_at: futureTime(30) });
     commit.job = firstJob;
 
     firstJob.save();
     commit.save();
 
-    server.create('job', { number: '1234.2', repository: repo, state: 'failed', allow_failure: true, config: { env: 'JANTS', os: 'osx', language: 'ruby', rvm: 2.2 }, commit, build, stage: firstStage, started_at: jobTime, finished_at: futureTime(40) });
+    this.server.create('job', { number: '1234.2', repository: repo, state: 'failed', allow_failure: true, config: { env: 'JANTS', os: 'osx', language: 'ruby', rvm: 2.2 }, commit, build, stage: firstStage, started_at: jobTime, finished_at: futureTime(40) });
 
     await visit(`/travis-ci/travis-web/builds/${build.id}`);
 
@@ -47,27 +49,27 @@ module('Acceptance | build stages', function (hooks) {
   });
 
   test('visiting build with stages', async function (assert) {
-    let repo =  server.create('repository', { slug: 'travis-ci/travis-web' });
-    server.create('branch', {});
+    let repo =  this.server.create('repository', { slug: 'travis-ci/travis-web' });
+    this.server.create('branch', {});
 
-    let  gitUser = server.create('git-user', { name: 'Mr T' });
-    let commit = server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
+    let  gitUser = this.server.create('git-user', { name: 'Mr T' });
+    let commit = this.server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
 
-    let request = server.create('request');
+    let request = this.server.create('request');
 
-    let build = server.create('build', { repository: repo, state: 'passed', commit_id: commit.id, commit, request });
+    let build = this.server.create('build', { repository: repo, state: 'passed', commit_id: commit.id, commit, request });
 
     let secondStage = build.createStage({ number: 2, name: 'second', state: 'failed', started_at: jobTime, finished_at: futureTime(11) });
     let firstStage = build.createStage({ number: 1, name: 'first :two_men_holding_hands:', state: 'passed', started_at: jobTime, finished_at: futureTime(71), allow_failure: true });
 
-    let firstJob = server.create('job', { number: '1234.1', repository: repo, state: 'passed', config: { env: 'JORTS', os: 'linux', language: 'node_js', node_js: 5 }, commit, build, stage: firstStage, started_at: jobTime, finished_at: futureTime(30) });
+    let firstJob = this.server.create('job', { number: '1234.1', repository: repo, state: 'passed', config: { env: 'JORTS', os: 'linux', language: 'node_js', node_js: 5 }, commit, build, stage: firstStage, started_at: jobTime, finished_at: futureTime(30) });
     commit.job = firstJob;
 
     firstJob.save();
     commit.save();
 
-    server.create('job', { number: '1234.2', repository: repo, state: 'failed', allow_failure: true, config: { env: 'JANTS', os: 'osx', language: 'ruby', rvm: 2.2 }, commit, build, stage: firstStage, started_at: jobTime, finished_at: futureTime(40) });
-    server.create('job', { number: '1234.999', repository: repo, state: 'failed', config: { language: 'ruby' }, commit, build, stage: secondStage, started_at: jobTime, finished_at: futureTime(10) });
+    this.server.create('job', { number: '1234.2', repository: repo, state: 'failed', allow_failure: true, config: { env: 'JANTS', os: 'osx', language: 'ruby', rvm: 2.2 }, commit, build, stage: firstStage, started_at: jobTime, finished_at: futureTime(40) });
+    this.server.create('job', { number: '1234.999', repository: repo, state: 'failed', config: { language: 'ruby' }, commit, build, stage: secondStage, started_at: jobTime, finished_at: futureTime(10) });
 
     await visit(`/travis-ci/travis-web/builds/${build.id}`);
 

--- a/tests/acceptance/builds/cancel-test.js
+++ b/tests/acceptance/builds/cancel-test.js
@@ -3,25 +3,27 @@ import { visit, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'travis/tests/helpers/setup-application-test';
 import signInUser from 'travis/tests/helpers/sign-in-user';
 import getFaviconUri from 'travis/utils/favicon-data-uris';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | builds/cancel', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    const currentUser = server.create('user');
+    const currentUser = this.server.create('user');
     signInUser(currentUser);
   });
 
   test('cancelling build', async function (assert) {
-    let repository =  server.create('repository', { slug: 'travis-ci/travis-web' });
+    let repository =  this.server.create('repository', { slug: 'travis-ci/travis-web' });
 
-    let branch = server.create('branch', { repository, name: 'acceptance-tests', default_branch: true });
-    let  gitUser = server.create('git-user', { name: 'Mr T' });
-    let commit = server.create('commit', { author: gitUser, committer: gitUser, committer_name: 'Mr T', message: 'This is a message' });
-    let build = server.create('build', { number: '5', state: 'started', repository, commit, branch });
-    let job = server.create('job', { number: '1234.1', state: 'started', repository, commit, build });
+    let branch = this.server.create('branch', { repository, name: 'acceptance-tests', default_branch: true });
+    let  gitUser = this.server.create('git-user', { name: 'Mr T' });
+    let commit = this.server.create('commit', { author: gitUser, committer: gitUser, committer_name: 'Mr T', message: 'This is a message' });
+    let build = this.server.create('build', { number: '5', state: 'started', repository, commit, branch });
+    let job = this.server.create('job', { number: '1234.1', state: 'started', repository, commit, build });
 
-    server.create('log', {
+    this.server.create('log', {
       id: job.id
     });
 

--- a/tests/acceptance/builds/current-tab-test.js
+++ b/tests/acceptance/builds/current-tab-test.js
@@ -3,17 +3,19 @@ import { module, test } from 'qunit';
 import { visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'travis/tests/helpers/setup-application-test';
 import signInUser from 'travis/tests/helpers/sign-in-user';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | builds/current tab', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    const currentUser = server.create('user');
+    const currentUser = this.server.create('user');
     signInUser(currentUser);
   });
 
   test('renders most recent repository without builds', async function (assert) {
-    server.create('repository');
+    this.server.create('repository');
 
     await visit('/travis-ci/travis-web');
 
@@ -22,13 +24,13 @@ module('Acceptance | builds/current tab', function (hooks) {
   });
 
   test('renders most recent repository and most recent build when builds present, single-job build shows job status instead', async function (assert) {
-    let repository =  server.create('repository', { slug: 'travis-ci/travis-web' });
+    let repository =  this.server.create('repository', { slug: 'travis-ci/travis-web' });
 
-    const branch = server.create('branch', { name: 'acceptance-tests' });
-    let  gitUser = server.create('git-user', { name: 'Mr T' });
-    let commit = server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
-    let build = server.create('build', { number: '5', state: 'started', repository, branch, commit });
-    let job = server.create('job', { number: '1234.1', state: 'received', build, commit, repository, config: { language: 'Hello' } });
+    const branch = this.server.create('branch', { name: 'acceptance-tests' });
+    let  gitUser = this.server.create('git-user', { name: 'Mr T' });
+    let commit = this.server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
+    let build = this.server.create('build', { number: '5', state: 'started', repository, branch, commit });
+    let job = this.server.create('job', { number: '1234.1', state: 'received', build, commit, repository, config: { language: 'Hello' } });
 
     commit.update('build', build);
     commit.update('job', job);
@@ -45,14 +47,14 @@ module('Acceptance | builds/current tab', function (hooks) {
   });
 
   test('renders the repository and subscribes to private log channel for a private repository', async function (assert) {
-    let repository =  server.create('repository', { slug: 'travis-ci/travis-web', private: true });
+    let repository =  this.server.create('repository', { slug: 'travis-ci/travis-web', private: true });
 
-    const branch = server.create('branch', { name: 'acceptance-tests' });
-    let  gitUser = server.create('git-user', { name: 'Mr T' });
-    let commit = server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
-    let build = server.create('build', { number: '5', state: 'started', repository, branch, commit });
-    let job = server.create('job', { number: '1234.1', state: 'received', build, commit, repository, config: { language: 'Hello' } });
-    server.create('log', { id: job.id, content: 'teh log' });
+    const branch = this.server.create('branch', { name: 'acceptance-tests' });
+    let  gitUser = this.server.create('git-user', { name: 'Mr T' });
+    let commit = this.server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
+    let build = this.server.create('build', { number: '5', state: 'started', repository, branch, commit });
+    let job = this.server.create('job', { number: '1234.1', state: 'received', build, commit, repository, config: { language: 'Hello' } });
+    this.server.create('log', { id: job.id, content: 'teh log' });
 
     commit.update('build', build);
     commit.update('job', job);
@@ -66,12 +68,12 @@ module('Acceptance | builds/current tab', function (hooks) {
   });
 
   test('error message when build jobs array is empty', async function (assert) {
-    let repository =  server.create('repository', { slug: 'travis-ci/travis-web' });
+    let repository =  this.server.create('repository', { slug: 'travis-ci/travis-web' });
 
-    const branch = server.create('branch', { name: 'acceptance-tests' });
-    let  gitUser = server.create('git-user', { name: 'Mr T' });
-    let commit = server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
-    let build = server.create('build', { number: '5', state: 'passed', repository, branch, commit });
+    const branch = this.server.create('branch', { name: 'acceptance-tests' });
+    let  gitUser = this.server.create('git-user', { name: 'Mr T' });
+    let commit = this.server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
+    let build = this.server.create('build', { number: '5', state: 'passed', repository, branch, commit });
 
     commit.update('build', build);
 
@@ -81,7 +83,7 @@ module('Acceptance | builds/current tab', function (hooks) {
   });
 
   test('shows user link to .com if viewing migrated repository on .org', async function (assert) {
-    server.create('repository', { slug: 'travis-ci/travis-web', active: false, migration_status: 'migrated'});
+    this.server.create('repository', { slug: 'travis-ci/travis-web', active: false, migration_status: 'migrated'});
     await visit('/travis-ci/travis-web');
 
     assert.dom('[data-test-not-active-migrated-subtext]').exists();

--- a/tests/acceptance/builds/debug-test.js
+++ b/tests/acceptance/builds/debug-test.js
@@ -3,33 +3,35 @@ import { visit, click } from '@ember/test-helpers';
 import { setupApplicationTest } from 'travis/tests/helpers/setup-application-test';
 import signInUser from 'travis/tests/helpers/sign-in-user';
 import { enableFeature } from 'ember-feature-flags/test-support';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | builds/debug', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    const currentUser = server.create('user');
+    const currentUser = this.server.create('user');
     signInUser(currentUser);
   });
 
   test('debugging single-job build', async function (assert) {
     enableFeature('debug-builds');
 
-    let repository =  server.create('repository', {
+    let repository =  this.server.create('repository', {
       private: true
     });
 
-    server.create('branch', {});
+    this.server.create('branch', {});
 
-    let  gitUser = server.create('git-user', { name: 'Mr T' });
-    let commit = server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
-    let build = server.create('build', { number: '5', repository, state: 'passed', commit });
-    let job = server.create('job', { number: '1234.1', repository, state: 'passed', build, commit });
-    server.create('log', { id: job.id });
+    let  gitUser = this.server.create('git-user', { name: 'Mr T' });
+    let commit = this.server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
+    let build = this.server.create('build', { number: '5', repository, state: 'passed', commit });
+    let job = this.server.create('job', { number: '1234.1', repository, state: 'passed', build, commit });
+    this.server.create('log', { id: job.id });
 
     const requestBodies = [];
 
-    server.post(`/job/${job.id}/debug`, function (schema, request) {
+    this.server.post(`/job/${job.id}/debug`, function (schema, request) {
       const parsedRequestBody = JSON.parse(request.requestBody);
       requestBodies.push(parsedRequestBody);
     });
@@ -44,14 +46,14 @@ module('Acceptance | builds/debug', function (hooks) {
   test('multi-job builds cannot be debugged', async function (assert) {
     enableFeature('debug-builds');
 
-    let repository =  server.create('repository');
-    server.create('branch', {});
+    let repository =  this.server.create('repository');
+    this.server.create('branch', {});
 
-    let  gitUser = server.create('git-user', { name: 'Mr T' });
-    let commit = server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
-    let build = server.create('build', { number: '5', repository, state: 'passed', commit });
-    server.create('job', { number: '1234.1', repository, state: 'passed', build, commit });
-    server.create('job', { number: '1234.2', repository, state: 'passed', build, commit });
+    let  gitUser = this.server.create('git-user', { name: 'Mr T' });
+    let commit = this.server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
+    let build = this.server.create('build', { number: '5', repository, state: 'passed', commit });
+    this.server.create('job', { number: '1234.1', repository, state: 'passed', build, commit });
+    this.server.create('job', { number: '1234.2', repository, state: 'passed', build, commit });
 
     await visit(`/travis-ci/travis-web/builds/${build.id}`);
 

--- a/tests/acceptance/builds/invalid-build-test.js
+++ b/tests/acceptance/builds/invalid-build-test.js
@@ -3,12 +3,14 @@ import Ember from 'ember';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'travis/tests/helpers/setup-application-test';
 import buildPage from 'travis/tests/pages/build';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 let adapterException;
 let loggerError;
 
 module('Acceptance | builds/invalid build', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
     adapterException = Ember.Test.adapter.exception;
@@ -24,11 +26,11 @@ module('Acceptance | builds/invalid build', function (hooks) {
 
   test('viewing invalid build shows error', async function (assert) {
     // create incorrect repository as this is resolved first, errors otherwise
-    server.create('repository', { slug: 'travis-ci/travis-api' });
+    this.server.create('repository', { slug: 'travis-ci/travis-api' });
 
-    const repository = server.create('repository', { slug: 'travis-ci/travis-web' });
+    const repository = this.server.create('repository', { slug: 'travis-ci/travis-web' });
     const incorrectSlug = 'travis-ci/travis-api';
-    const build = server.create('build', { repository });
+    const build = this.server.create('build', { repository });
     await visit(`${incorrectSlug}/builds/${build.id}`);
 
     assert.equal(buildPage.buildNotFoundMessage, 'Oops, we couldn\'t find that build!', 'Shows missing build message');

--- a/tests/acceptance/builds/pull-requests-test.js
+++ b/tests/acceptance/builds/pull-requests-test.js
@@ -4,23 +4,25 @@ import page from 'travis/tests/pages/build-list';
 import topPage from 'travis/tests/pages/top';
 import signInUser from 'travis/tests/helpers/sign-in-user';
 import { percySnapshot } from 'ember-percy';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | builds/pull requests', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    this.currentUser = server.create('user', {
+    this.currentUser = this.server.create('user', {
       name: 'Travis CI',
       login: 'travisci',
     });
 
-    this.branch = server.create('branch', { name: 'wetsuwetenstrong' });
+    this.branch = this.server.create('branch', { name: 'wetsuwetenstrong' });
 
     signInUser(this.currentUser);
   });
 
   test('renders no pull requests messaging when none present', async function (assert) {
-    server.create('repository');
+    this.server.create('repository');
 
     await page.visitPullRequests({ organization: 'travis-ci', repo: 'travis-web' });
 
@@ -28,10 +30,10 @@ module('Acceptance | builds/pull requests', function (hooks) {
   });
 
   test('view and cancel pull requests', async function (assert) {
-    const repository = server.create('repository');
-    const request = server.create('request', { pull_request_mergeable: 'draft' });
+    const repository = this.server.create('repository');
+    const request = this.server.create('request', { pull_request_mergeable: 'draft' });
 
-    const pullRequestBuild = server.create('build', {
+    const pullRequestBuild = this.server.create('build', {
       state: 'started',
       number: '1000',
       finished_at: new Date(),
@@ -45,7 +47,7 @@ module('Acceptance | builds/pull requests', function (hooks) {
       request
     });
 
-    const gitUser = server.create('git-user', {
+    const gitUser = this.server.create('git-user', {
       name: this.currentUser.name
     });
 
@@ -56,7 +58,7 @@ module('Acceptance | builds/pull requests', function (hooks) {
     });
 
     for (let i = 0; i < 10; i++) {
-      let build = server.create('build', {
+      let build = this.server.create('build', {
         state: 'passed',
         number: 1000 - i,
         finished_at: new Date() - i * 1000,
@@ -73,7 +75,7 @@ module('Acceptance | builds/pull requests', function (hooks) {
 
     pullRequestBuild.save();
 
-    server.create('job', {
+    this.server.create('job', {
       number: '1000.1',
       repository,
       state: 'started',

--- a/tests/acceptance/builds/restart-test.js
+++ b/tests/acceptance/builds/restart-test.js
@@ -3,24 +3,26 @@ import { setupApplicationTest } from 'travis/tests/helpers/setup-application-tes
 import buildPage from 'travis/tests/pages/build';
 import topPage from 'travis/tests/pages/top';
 import signInUser from 'travis/tests/helpers/sign-in-user';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | builds/restart', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    const currentUser = server.create('user');
+    const currentUser = this.server.create('user');
     signInUser(currentUser);
   });
 
   test('restarting build', async function (assert) {
-    let repository =  server.create('repository');
-    server.create('branch', {});
+    let repository =  this.server.create('repository');
+    this.server.create('branch', {});
 
-    let  gitUser = server.create('git-user', { name: 'Mr T' });
-    let commit = server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
-    let build = server.create('build', { number: '5', repository, state: 'passed', commit });
-    let job = server.create('job', { number: '1234.1', repository, state: 'passed', build, commit });
-    server.create('log', { id: job.id });
+    let  gitUser = this.server.create('git-user', { name: 'Mr T' });
+    let commit = this.server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
+    let build = this.server.create('build', { number: '5', repository, state: 'passed', commit });
+    let job = this.server.create('job', { number: '1234.1', repository, state: 'passed', build, commit });
+    this.server.create('log', { id: job.id });
 
     await buildPage
       .visit({ owner: 'travis-ci', repo: 'travis-web', build_id: build.id })

--- a/tests/acceptance/builds/view-pull-request-test.js
+++ b/tests/acceptance/builds/view-pull-request-test.js
@@ -3,25 +3,27 @@ import { setupApplicationTest } from 'travis/tests/helpers/setup-application-tes
 import page from 'travis/tests/pages/build';
 import signInUser from 'travis/tests/helpers/sign-in-user';
 import { percySnapshot } from 'ember-percy';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | builds/view pull request', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    const currentUser = server.create('user');
+    const currentUser = this.server.create('user');
     signInUser(currentUser);
   });
 
   test('renders a pull request', async function (assert) {
-    let repository =  server.create('repository', { slug: 'travis-ci/travis-web' });
+    let repository =  this.server.create('repository', { slug: 'travis-ci/travis-web' });
 
     let commitBody =
       'Within the organization there is a gap between words and deeds, between what organizations say they will do, ' +
       'or what they are committed to doing, and what they are doing. – Sara Ahmed';
 
-    const branch = server.create('branch', { name: 'acceptance-tests' });
-    let  gitUser = server.create('git-user', { name: 'Mr T' });
-    let commit = server.create('commit', {
+    const branch = this.server.create('branch', { name: 'acceptance-tests' });
+    let  gitUser = this.server.create('git-user', { name: 'Mr T' });
+    let commit = this.server.create('commit', {
       author: gitUser,
       committer: gitUser,
       committer_name: 'Mr T',
@@ -29,7 +31,7 @@ module('Acceptance | builds/view pull request', function (hooks) {
       message: `This is a message\n${commitBody}`,
       branch_is_default: true
     });
-    let build = server.create('build', {
+    let build = this.server.create('build', {
       number: '5',
       state: 'passed',
       pull_request_number: '10',
@@ -40,7 +42,7 @@ module('Acceptance | builds/view pull request', function (hooks) {
       commit,
       isTag: false
     });
-    let job = server.create('job', { number: '5.1', state: 'passed', build, commit, repository, config: { language: 'Hello' } });
+    let job = this.server.create('job', { number: '5.1', state: 'passed', build, commit, repository, config: { language: 'Hello' } });
 
     commit.update('build', build);
     commit.update('job', job);

--- a/tests/acceptance/dashboard/repositories-test.js
+++ b/tests/acceptance/dashboard/repositories-test.js
@@ -15,12 +15,14 @@ import { prettyDate } from 'travis/helpers/pretty-date';
 import page from 'travis/tests/pages/dashboard';
 import topPage from 'travis/tests/pages/top';
 import generatePusherPayload from 'travis/tests/helpers/generate-pusher-payload';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | dashboard/repositories', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    const currentUser = server.create('user', {
+    const currentUser = this.server.create('user', {
       name: 'User Name',
       login: 'user-login',
     });
@@ -28,8 +30,8 @@ module('Acceptance | dashboard/repositories', function (hooks) {
 
     signInUser(currentUser);
 
-    let build = server.create('build', {
-      branch: server.create('branch', { name: 'some-branch' }),
+    let build = this.server.create('build', {
+      branch: this.server.create('branch', { name: 'some-branch' }),
       event_type: 'push',
       number: 2,
       state: 'failed',
@@ -38,8 +40,8 @@ module('Acceptance | dashboard/repositories', function (hooks) {
       createdBy: currentUser
     });
 
-    server.create('build', {
-      branch: server.create('branch', { name: 'cron-branch' }),
+    this.server.create('build', {
+      branch: this.server.create('branch', { name: 'cron-branch' }),
       event_type: 'cron',
       number: 1,
       state: 'failed',
@@ -48,9 +50,9 @@ module('Acceptance | dashboard/repositories', function (hooks) {
       createdBy: currentUser
     });
 
-    let branch = server.create('branch', {
+    let branch = this.server.create('branch', {
       name: 'master',
-      lastBuild: server.create('build', {
+      lastBuild: this.server.create('build', {
         number: 1,
         event_type: 'api',
         state: 'passed',
@@ -62,15 +64,15 @@ module('Acceptance | dashboard/repositories', function (hooks) {
     let oneYearAgo = new Date(new Date() - 1000 * 60 * 60 * 24 * 365);
     let beforeOneYearAgo = new Date(oneYearAgo.getTime() - 1000 * 60 * 19 - 1000 * 19);
 
-    let permissionBuild = server.create('build', {
+    let permissionBuild = this.server.create('build', {
       id: 1919,
-      branch: server.create('branch', { name: 'another-branch' }),
+      branch: this.server.create('branch', { name: 'another-branch' }),
       event_type: 'push',
       number: 44,
       state: 'passed',
       started_at: beforeOneYearAgo,
       finished_at: oneYearAgo,
-      commit: server.create('commit', {
+      commit: this.server.create('commit', {
         message: 'get used to it',
         sha: 'acab'
       }),
@@ -78,16 +80,16 @@ module('Acceptance | dashboard/repositories', function (hooks) {
     });
     this.permissionBuild = permissionBuild;
 
-    let permissionBranch = server.create('branch', {
+    let permissionBranch = this.server.create('branch', {
       name: 'primary',
-      lastBuild: server.create('build', {
+      lastBuild: this.server.create('build', {
         number: 55,
         event_type: 'push',
         state: 'passed',
         createdBy: currentUser
       })
     });
-    this.repository = server.create('repository', {
+    this.repository = this.server.create('repository', {
       owner: {
         login: 'travis-ci',
         type: 'organization'
@@ -96,7 +98,7 @@ module('Acceptance | dashboard/repositories', function (hooks) {
       currentBuild: build,
       defaultBranch: branch,
     });
-    server.create('repository', {
+    this.server.create('repository', {
       owner: {
         login: 'travis-repos',
         type: 'organization'
@@ -104,7 +106,7 @@ module('Acceptance | dashboard/repositories', function (hooks) {
       name: 'repo-python',
       currentBuild: build,
     });
-    server.create('repository', {
+    this.server.create('repository', {
       owner: {
         login: 'travis-repos',
         type: 'organization'
@@ -113,7 +115,7 @@ module('Acceptance | dashboard/repositories', function (hooks) {
       currentBuild: build,
       private: true
     });
-    this.starredRepo = server.create('repository', {
+    this.starredRepo = this.server.create('repository', {
       owner: {
         login: 'travis-ci',
         type: 'organization'
@@ -181,7 +183,7 @@ module('Acceptance | dashboard/repositories', function (hooks) {
   test('Dashboard pagination works', async function (assert) {
     enableFeature('dashboard');
 
-    server.createList('repository', 12);
+    this.server.createList('repository', 12);
 
     await visit('/dashboard');
 
@@ -255,7 +257,7 @@ module('Acceptance | dashboard/repositories', function (hooks) {
 
     assert.equal(topPage.flashMessage.text, 'The build was successfully restarted.');
 
-    const commit = server.create('commit', {
+    const commit = this.server.create('commit', {
       id: 100,
       sha: 'acab',
       branch: 'primary',
@@ -297,13 +299,13 @@ module('Acceptance | dashboard/repositories', function (hooks) {
     });
 
 
-    let otherUser = server.create('user');
-    let otherBranch = server.create('branch', {
-      lastBuild: server.create('build', {
+    let otherUser = this.server.create('user');
+    let otherBranch = this.server.create('branch', {
+      lastBuild: this.server.create('build', {
         createdBy: otherUser
       })
     });
-    let otherRepository = server.create('repository', {
+    let otherRepository = this.server.create('repository', {
       defaultBranch: otherBranch
     });
 
@@ -313,7 +315,7 @@ module('Acceptance | dashboard/repositories', function (hooks) {
       repository: otherRepository
     });
 
-    let otherCommit = server.create('commit');
+    let otherCommit = this.server.create('commit');
 
     let otherJob = otherBuild.createJob({
       id: otherBuild.id,

--- a/tests/acceptance/enterprise/banner-test.js
+++ b/tests/acceptance/enterprise/banner-test.js
@@ -4,15 +4,17 @@ import { setupApplicationTest } from 'travis/tests/helpers/setup-application-tes
 import { enterpriseBanners } from 'travis/tests/pages/enterprise-banner';
 import signInUser from 'travis/tests/helpers/sign-in-user';
 import { enableFeature } from 'ember-feature-flags/test-support';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | enterprise/banner', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    const currentUser = server.create('user');
+    const currentUser = this.server.create('user');
     signInUser(currentUser);
 
-    server.get('/v3/enterprise_license', (schema, request) => {
+    this.server.get('/v3/enterprise_license', (schema, request) => {
       return {
         'license_id': 'ad12345',
         'seats': '30',

--- a/tests/acceptance/enterprise/beta-features-disabled-test.js
+++ b/tests/acceptance/enterprise/beta-features-disabled-test.js
@@ -3,12 +3,14 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'travis/tests/helpers/setup-application-test';
 import signInUser from 'travis/tests/helpers/sign-in-user';
 import { getContext } from '@ember/test-helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | enterprise/beta features disabled', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
-  hooks.beforeEach(() => {
-    const currentUser = server.create('user');
+  hooks.beforeEach(function () {
+    const currentUser = this.server.create('user');
     signInUser(currentUser);
   });
 

--- a/tests/acceptance/enterprise/navigation-test.js
+++ b/tests/acceptance/enterprise/navigation-test.js
@@ -2,12 +2,14 @@ import { currentURL, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'travis/tests/helpers/setup-application-test';
 import { enableFeature } from 'ember-feature-flags/test-support';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | enterprise/navigation', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    server.get('/v3/enterprise_license', (schema, response) => {
+    this.server.get('/v3/enterprise_license', (schema, response) => {
       return {
         'license_id': 'ad12345',
         'seats': '30',

--- a/tests/acceptance/feature-flags/app-boots-test.js
+++ b/tests/acceptance/feature-flags/app-boots-test.js
@@ -8,17 +8,19 @@ import { Response } from 'ember-cli-mirage';
 import Service from '@ember/service';
 import signInUser from 'travis/tests/helpers/sign-in-user';
 import { stubService } from 'travis/tests/helpers/stub-service';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | feature flags/app boots', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   test('app boots even if call to `/beta_features` fails', async function (assert) {
     assert.expect(2);
-    server.get('/user/:user_id/beta_features', function (schema) {
+    this.server.get('/user/:user_id/beta_features', function (schema) {
       return new Response(500, {}, {});
     });
 
-    const currentUser = server.create('user');
+    const currentUser = this.server.create('user');
     signInUser(currentUser);
 
     const mockSentry = Service.extend({
@@ -29,7 +31,7 @@ module('Acceptance | feature flags/app boots', function (hooks) {
 
     stubService('raven', mockSentry);
 
-    server.create('repository', {
+    this.server.create('repository', {
       owner: {
         login: currentUser.login
       },
@@ -43,11 +45,11 @@ module('Acceptance | feature flags/app boots', function (hooks) {
   test('app does not request feature flags on boot if available in local storage', async function (assert) {
     assert.expect(1);
 
-    server.get('/user/:user_id/beta_features', function (schema) {
+    this.server.get('/user/:user_id/beta_features', function (schema) {
       assert.ok(false);
     });
 
-    const currentUser = server.create('user');
+    const currentUser = this.server.create('user');
     signInUser(currentUser);
 
     window.localStorage.setItem('travis.features', JSON.stringify([{foo: false}, {bar: false}]));

--- a/tests/acceptance/help-page-test.js
+++ b/tests/acceptance/help-page-test.js
@@ -7,6 +7,7 @@ import { enableFeature } from 'ember-feature-flags/test-support';
 import signInUser from 'travis/tests/helpers/sign-in-user';
 import helpPage from 'travis/tests/pages/help';
 import config from 'travis/config/environment';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 import {
   UTC_START_TIME,
@@ -45,6 +46,7 @@ const checkBasicStructure = (assert, isSignedIn) => {
 
 module('Acceptance | help page', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   module('for .org users', function (hooks) {
     hooks.beforeEach(async function () {
@@ -82,7 +84,7 @@ module('Acceptance | help page', function (hooks) {
 
   module('for .com education user', function (hooks) {
     hooks.beforeEach(async function () {
-      this.user = server.create('user', {
+      this.user = this.server.create('user', {
         education: true,
       });
       enableFeature('proVersion');
@@ -106,12 +108,12 @@ module('Acceptance | help page', function (hooks) {
 
   module('for .com trial user', function (hooks) {
     hooks.beforeEach(async function () {
-      this.user = server.create('user');
+      this.user = this.server.create('user');
       enableFeature('proVersion');
     });
 
     test('it has correct structure', async function (assert) {
-      this.trial = server.create('trial', {
+      this.trial = this.server.create('trial', {
         has_active_trial: true,
         builds_remaining: 100,
         owner: this.user,
@@ -131,7 +133,7 @@ module('Acceptance | help page', function (hooks) {
     });
 
     test('form not present after trial', async function (assert) {
-      this.trial = server.create('trial', {
+      this.trial = this.server.create('trial', {
         has_active_trial: true,
         builds_remaining: 0,
         owner: this.user,
@@ -150,7 +152,7 @@ module('Acceptance | help page', function (hooks) {
     });
 
     test('form present when subscribed after trial', async function (assert) {
-      this.trial = server.create('trial', {
+      this.trial = this.server.create('trial', {
         has_active_trial: true,
         builds_remaining: 0,
         owner: this.user,
@@ -162,7 +164,7 @@ module('Acceptance | help page', function (hooks) {
         }
       });
 
-      this.subscription = server.create('subscription', {
+      this.subscription = this.server.create('subscription', {
         owner: this.user,
         status: 'subscribed',
         valid_to: new Date(),
@@ -176,7 +178,7 @@ module('Acceptance | help page', function (hooks) {
     });
 
     test('form present when org subscribed after trial', async function (assert) {
-      this.trial = server.create('trial', {
+      this.trial = this.server.create('trial', {
         has_active_trial: true,
         builds_remaining: 0,
         owner: this.user,
@@ -188,7 +190,7 @@ module('Acceptance | help page', function (hooks) {
         }
       });
 
-      this.organization = server.create('organization', {
+      this.organization = this.server.create('organization', {
         name: 'Org Name',
         type: 'organization',
         login: 'org-login',
@@ -197,7 +199,7 @@ module('Acceptance | help page', function (hooks) {
         }
       });
 
-      this.subscription = server.create('subscription', {
+      this.subscription = this.server.create('subscription', {
         owner: this.organization,
         status: 'subscribed',
         valid_to: new Date(),
@@ -212,7 +214,7 @@ module('Acceptance | help page', function (hooks) {
 
   module('for .com authorised user', function (hooks) {
     hooks.beforeEach(async function () {
-      this.user = server.create('user');
+      this.user = this.server.create('user');
       enableFeature('proVersion');
       await signInUser(this.user);
       await helpPage.visit();
@@ -252,7 +254,7 @@ module('Acceptance | help page', function (hooks) {
 
       hooks.beforeEach(function () {
         this.requestHandler = (request) => JSON.parse(request.requestBody);
-        server.post(`${apiHost}${createRequestEndpoint}`, (schema, request) => {
+        this.server.post(`${apiHost}${createRequestEndpoint}`, (schema, request) => {
           return this.requestHandler(request);
         });
       });

--- a/tests/acceptance/home/broadcasts-test.js
+++ b/tests/acceptance/home/broadcasts-test.js
@@ -5,12 +5,14 @@ import topPage from 'travis/tests/pages/top';
 import signInUser from 'travis/tests/helpers/sign-in-user';
 import { enableFeature } from 'ember-feature-flags/test-support';
 import { percySnapshot } from 'ember-percy';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | broadcasts', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    const currentUser = server.create('user', {
+    const currentUser = this.server.create('user', {
       name: 'User Name',
       login: 'user-login'
     });
@@ -18,7 +20,7 @@ module('Acceptance | broadcasts', function (hooks) {
     signInUser(currentUser);
 
     // create active repo
-    server.create('repository', {
+    this.server.create('repository', {
       slug: 'org-login/repository-name'
     });
   });
@@ -28,14 +30,14 @@ module('Acceptance | broadcasts', function (hooks) {
 
     let date = new Date();
 
-    server.create('broadcast', {
+    this.server.create('broadcast', {
       category: 'warning',
       message: 'A warning',
       created_at: date,
       id: 1883
     });
 
-    server.create('broadcast', {
+    this.server.create('broadcast', {
       category: 'announcement',
       message: 'An announcement',
       created_at: date,
@@ -76,7 +78,7 @@ module('Acceptance | broadcasts', function (hooks) {
   test('the broadcast tower shows an announcement', async function (assert) {
     enableFeature('broadcasts');
 
-    server.create('broadcast', {
+    this.server.create('broadcast', {
       category: 'announcement',
       message: 'Another announcement'
     });
@@ -89,7 +91,7 @@ module('Acceptance | broadcasts', function (hooks) {
   test('a dismissed broadcast does not highlight the tower', async function (assert) {
     enableFeature('broadcasts');
 
-    server.create('broadcast', {
+    this.server.create('broadcast', {
       category: 'announcement',
       message: 'Welcome.',
       id: '2016'

--- a/tests/acceptance/home/sidebar-tabs-test.js
+++ b/tests/acceptance/home/sidebar-tabs-test.js
@@ -7,6 +7,7 @@ import { enableFeature } from 'ember-feature-flags/test-support';
 import { percySnapshot } from 'ember-percy';
 import { prettyDate } from 'travis/helpers/pretty-date';
 import RepositoriesService from 'travis/services/repositories';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 const RepositoriesServiceStub = RepositoriesService.extend({
   requestOwnedRepositories: task(function* () {
@@ -18,9 +19,10 @@ const RepositoriesServiceStub = RepositoriesService.extend({
 
 module('Acceptance | home/sidebar tabs', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    const currentUser = server.create('user', {
+    const currentUser = this.server.create('user', {
       name: 'User Name',
       login: 'user-login'
     });
@@ -28,23 +30,23 @@ module('Acceptance | home/sidebar tabs', function (hooks) {
     signInUser(currentUser);
 
     // create active repo
-    server.create('repository', {
+    this.server.create('repository', {
       slug: 'org-login/repository-name'
     });
 
     // create active repo
-    let testRepo = server.create('repository', {
+    let testRepo = this.server.create('repository', {
       slug: 'org-login/yet-another-repository-name'
     });
     this.repo = testRepo;
 
-    server.create('repository', {
+    this.server.create('repository', {
       slug: 'other/other',
       skipPermissions: true
     });
 
-    let  gitUser = server.create('git-user', { name: 'Mr T' });
-    let commit = server.create('commit', {
+    let  gitUser = this.server.create('git-user', { name: 'Mr T' });
+    let commit = this.server.create('commit', {
       author: gitUser,
       committer: gitUser,
       branch: 'acceptance-tests',
@@ -53,17 +55,17 @@ module('Acceptance | home/sidebar tabs', function (hooks) {
     });
     this.commit = commit;
 
-    let build = server.create('build', {
+    let build = this.server.create('build', {
       repository: testRepo,
       state: 'queued',
       commit,
-      branch: server.create('branch', {
+      branch: this.server.create('branch', {
         name: 'acceptance-tests'
       })
     });
     this.build = build;
 
-    let job = server.create('job', {
+    let job = this.server.create('job', {
       number: '1234.1',
       repository: testRepo,
       state: 'queued',
@@ -97,8 +99,8 @@ module('Acceptance | home/sidebar tabs', function (hooks) {
     // TODO: Currently, we make the same request *30* times, which slows the test down
     // significantly. Need to investigate why.
 
-    server.createList('job', 4, { state: 'started', repository: this.repo, commit: this.commit, build: this.build, started_at: startedAt });
-    server.createList('job', 5, { state: 'created', repository: this.repo, commit: this.commit, build: this.build });
+    this.server.createList('job', 4, { state: 'started', repository: this.repo, commit: this.commit, build: this.build, started_at: startedAt });
+    this.server.createList('job', 5, { state: 'created', repository: this.repo, commit: this.commit, build: this.build });
 
     this.owner.register('service:repositories', RepositoriesServiceStub);
 

--- a/tests/acceptance/home/with-repositories-test.js
+++ b/tests/acceptance/home/with-repositories-test.js
@@ -6,6 +6,7 @@ import jobPage from 'travis/tests/pages/job';
 import generatePusherPayload from 'travis/tests/helpers/generate-pusher-payload';
 import signInUser from 'travis/tests/helpers/sign-in-user';
 import { prettyDate } from 'travis/helpers/pretty-date';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 const repoId = 100;
 
@@ -20,9 +21,10 @@ const repositoryTemplate = {
 
 module('Acceptance | home/with repositories', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    const currentUser = server.create('user', {
+    const currentUser = this.server.create('user', {
       name: 'User Name',
       login: 'user-login'
     });
@@ -30,13 +32,13 @@ module('Acceptance | home/with repositories', function (hooks) {
     signInUser(currentUser);
 
     // create active repo
-    this.repository = server.create('repository', repositoryTemplate);
+    this.repository = this.server.create('repository', repositoryTemplate);
 
     this.branch = this.repository.createBranch({
       name: 'primary',
     });
 
-    server.create('repository', {
+    this.server.create('repository', {
       slug: 'org-login/some-other-repository-name'
     });
 
@@ -47,7 +49,7 @@ module('Acceptance | home/with repositories', function (hooks) {
     this.startedAt = beforeOneYearAgo.toISOString();
     this.finishedAt = oneYearAgo.toISOString();
 
-    server.create('repository', {
+    this.server.create('repository', {
       slug: 'org-login/yet-another-repository-name',
       owner: {
         login: 'org-login'
@@ -61,7 +63,7 @@ module('Acceptance | home/with repositories', function (hooks) {
       finished_at: this.finishedAt
     });
 
-    server.create('repository', {
+    this.server.create('repository', {
       slug: 'other/other',
       skipPermissions: true
     });
@@ -98,9 +100,9 @@ module('Acceptance | home/with repositories', function (hooks) {
 
     assert.equal(sidebarPage.repoTitle, 'org-login / yet-another-repository-name', 'expected the displayed repository to be the one with a running build');
 
-    let createdBy = server.create('user', { login: 'srivera', name: 'Sylvia Rivera' });
+    let createdBy = this.server.create('user', { login: 'srivera', name: 'Sylvia Rivera' });
 
-    const commit = server.create('commit', {
+    const commit = this.server.create('commit', {
       id: 100,
       sha: 'acab',
       branch: 'primary',
@@ -148,7 +150,7 @@ module('Acceptance | home/with repositories', function (hooks) {
     app.pusher.receive('job:received', generatePusherPayload(job, { state: 'received' }));
 
     // This is necessary to have the log fetch not fail and put the log in an error state.
-    server.create('log', { id: job.id, content: ''});
+    this.server.create('log', { id: job.id, content: ''});
 
     build.state = 'started';
     build.finished_at = null;

--- a/tests/acceptance/home/without-repositories-test.js
+++ b/tests/acceptance/home/without-repositories-test.js
@@ -3,12 +3,14 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'travis/tests/helpers/setup-application-test';
 import signInUser from 'travis/tests/helpers/sign-in-user';
 import { percySnapshot } from 'ember-percy';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | home/without repositories', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    const currentUser = server.create('user');
+    const currentUser = this.server.create('user');
     signInUser(currentUser);
   });
 

--- a/tests/acceptance/job/basic-layout-test.js
+++ b/tests/acceptance/job/basic-layout-test.js
@@ -13,9 +13,11 @@ import jobPage from 'travis/tests/pages/job';
 import getFaviconUri from 'travis/utils/favicon-data-uris';
 
 import config from 'travis/config/environment';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | job/basic layout', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
     const { owner } = getContext();
@@ -23,14 +25,14 @@ module('Acceptance | job/basic layout', function (hooks) {
   });
 
   test('visiting job-view', async function (assert) {
-    let repo = server.create('repository', { slug: 'travis-ci/travis-web' }),
-      branch = server.create('branch', { name: 'acceptance-tests' });
+    let repo = this.server.create('repository', { slug: 'travis-ci/travis-web' }),
+      branch = this.server.create('branch', { name: 'acceptance-tests' });
 
-    let  gitUser = server.create('git-user', { name: 'Mr T' });
-    let commit = server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
+    let  gitUser = this.server.create('git-user', { name: 'Mr T' });
+    let commit = this.server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
 
-    let request = server.create('request');
-    server.create('message', {
+    let request = this.server.create('request');
+    this.server.create('message', {
       request,
       level: 'info',
       key: 'group',
@@ -40,19 +42,19 @@ module('Acceptance | job/basic layout', function (hooks) {
       }
     });
 
-    let user = server.create('user', {
+    let user = this.server.create('user', {
       name: 'Mr T',
       avatar_url: '/images/favicon-gray.png'
     });
 
-    let build = server.create('build', { repository: repo, state: 'passed', createdBy: user, commit, branch, request });
-    let job = server.create('job', { number: '1234.1', repository: repo, state: 'passed', build, commit });
+    let build = this.server.create('build', { repository: repo, state: 'passed', createdBy: user, commit, branch, request });
+    let job = this.server.create('job', { number: '1234.1', repository: repo, state: 'passed', build, commit });
     commit.job = job;
 
     job.save();
     commit.save();
 
-    server.create('log', { id: job.id });
+    this.server.create('log', { id: job.id });
 
     await visit('/travis-ci/travis-web/jobs/' + job.id);
     await waitFor('#log > .log-line');
@@ -83,14 +85,14 @@ module('Acceptance | job/basic layout', function (hooks) {
   });
 
   test('visiting pull request job-view', async function (assert) {
-    let repo = server.create('repository', { slug: 'travis-ci/travis-web' }),
-      branch = server.create('branch', { name: 'acceptance-tests' });
+    let repo = this.server.create('repository', { slug: 'travis-ci/travis-web' }),
+      branch = this.server.create('branch', { name: 'acceptance-tests' });
 
-    let  gitUser = server.create('git-user', { name: 'Mr T' });
-    let commit = server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
+    let  gitUser = this.server.create('git-user', { name: 'Mr T' });
+    let commit = this.server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
 
-    let request = server.create('request', { pull_request_mergeable: 'draft' });
-    server.create('message', {
+    let request = this.server.create('request', { pull_request_mergeable: 'draft' });
+    this.server.create('message', {
       request,
       level: 'info',
       key: 'group',
@@ -100,19 +102,19 @@ module('Acceptance | job/basic layout', function (hooks) {
       }
     });
 
-    let user = server.create('user', {
+    let user = this.server.create('user', {
       name: 'Mr T',
       avatar_url: '/images/favicon-gray.png'
     });
 
-    let build = server.create('build', { repository: repo, state: 'passed', createdBy: user, commit, branch, event_type: 'pull_request', pull_request_number: 1, request });
-    let job = server.create('job', { number: '1234.1', repository: repo, state: 'passed', build, commit });
+    let build = this.server.create('build', { repository: repo, state: 'passed', createdBy: user, commit, branch, event_type: 'pull_request', pull_request_number: 1, request });
+    let job = this.server.create('job', { number: '1234.1', repository: repo, state: 'passed', build, commit });
     commit.job = job;
 
     job.save();
     commit.save();
 
-    server.create('log', { id: job.id });
+    this.server.create('log', { id: job.id });
 
     await visit('/travis-ci/travis-web/jobs/' + job.id);
     await waitFor('#log > .log-line');
@@ -144,17 +146,17 @@ module('Acceptance | job/basic layout', function (hooks) {
 
 
   test('visiting a job in created(received) state', async function (assert) {
-    let branch = server.create('branch', { name: 'acceptance-tests' });
-    let repo = server.create('repository', { slug: 'travis-ci/travis-web', defaultBranch: branch });
-    let commit = server.create('commit', {
+    let branch = this.server.create('branch', { name: 'acceptance-tests' });
+    let repo = this.server.create('repository', { slug: 'travis-ci/travis-web', defaultBranch: branch });
+    let commit = this.server.create('commit', {
       id: 100,
       sha: 'abcd',
       branch: 'acceptance-tests',
       message: 'This is a message',
     });
 
-    let request = server.create('request');
-    server.create('message', {
+    let request = this.server.create('request');
+    this.server.create('message', {
       request,
       level: 'info',
       key: 'group',
@@ -164,12 +166,12 @@ module('Acceptance | job/basic layout', function (hooks) {
       }
     });
 
-    let user = server.create('user', {
+    let user = this.server.create('user', {
       name: 'Mr T',
       avatar_url: '/images/favicon-gray.png'
     });
 
-    let build = server.create('build', {
+    let build = this.server.create('build', {
       id: 100,
       number: 15,
       repository: repo,
@@ -181,7 +183,7 @@ module('Acceptance | job/basic layout', function (hooks) {
       createdBy: user
     });
 
-    let job = server.create('job', {
+    let job = this.server.create('job', {
       id: 100,
       number: '1234.1',
       repository: repo,
@@ -190,7 +192,7 @@ module('Acceptance | job/basic layout', function (hooks) {
       commit
     });
 
-    server.create('log', { id: job.id });
+    this.server.create('log', { id: job.id });
 
     await visit('/travis-ci/travis-web/jobs/' + job.id);
 
@@ -269,21 +271,21 @@ module('Acceptance | job/basic layout', function (hooks) {
   });
 
   test('visiting a job with a truncated log', async function (assert) {
-    let repo =  server.create('repository', { slug: 'travis-ci/travis-web' });
-    let branch = server.create('branch', { name: 'acceptance-tests' });
+    let repo =  this.server.create('repository', { slug: 'travis-ci/travis-web' });
+    let branch = this.server.create('branch', { name: 'acceptance-tests' });
 
-    let gitAuthor = server.create('git-user', { name: 'Mr T' });
-    let gitCommitter = server.create('git-user', { name: 'Sylvia Rivera' });
-    let commit = server.create('commit', { author: gitAuthor, committer: gitCommitter, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
-    let build = server.create('build', { repository: repo, state: 'passed', commit, branch });
-    let job = server.create('job', { number: '1234.1', repository: repo, state: 'passed', commit, build });
+    let gitAuthor = this.server.create('git-user', { name: 'Mr T' });
+    let gitCommitter = this.server.create('git-user', { name: 'Sylvia Rivera' });
+    let commit = this.server.create('commit', { author: gitAuthor, committer: gitCommitter, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
+    let build = this.server.create('build', { repository: repo, state: 'passed', commit, branch });
+    let job = this.server.create('job', { number: '1234.1', repository: repo, state: 'passed', commit, build });
     commit.job = job;
 
     job.save();
     commit.save();
 
     const longLog = new Array(config.logLimit + 1).join('🤔\n');
-    server.create('log', { id: job.id, content: longLog });
+    this.server.create('log', { id: job.id, content: longLog });
 
     await jobPage.visit();
 
@@ -298,13 +300,13 @@ module('Acceptance | job/basic layout', function (hooks) {
   });
 
   test('visiting a job with a complex log', async function (assert) {
-    let repo =  server.create('repository', { slug: 'travis-ci/travis-web' }),
-      branch = server.create('branch', { name: 'acceptance-tests' });
+    let repo =  this.server.create('repository', { slug: 'travis-ci/travis-web' }),
+      branch = this.server.create('branch', { name: 'acceptance-tests' });
 
-    let  gitUser = server.create('git-user', { name: 'Mr T' });
-    let commit = server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
-    let build = server.create('build', { repository: repo, state: 'passed', commit, branch });
-    let job = server.create('job', { number: '1234.1', repository: repo, state: 'passed', commit, build });
+    let  gitUser = this.server.create('git-user', { name: 'Mr T' });
+    let commit = this.server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
+    let build = this.server.create('build', { repository: repo, state: 'passed', commit, branch });
+    let job = this.server.create('job', { number: '1234.1', repository: repo, state: 'passed', commit, build });
     commit.job = job;
 
     await job.save();
@@ -338,7 +340,7 @@ module('Acceptance | job/basic layout', function (hooks) {
   ${ESCAPE}[31m-}
   ${ESCAPE}(B[m[32m+},
   `;
-    server.create('log', { id: job.id, content: complexLog });
+    this.server.create('log', { id: job.id, content: complexLog });
 
     await jobPage.visit();
 
@@ -417,13 +419,13 @@ module('Acceptance | job/basic layout', function (hooks) {
   });
 
   test('visiting a job with fold duration', async function (assert) {
-    let repo =  server.create('repository', { slug: 'travis-ci/travis-web' }),
-      branch = server.create('branch', { name: 'acceptance-tests' });
+    let repo =  this.server.create('repository', { slug: 'travis-ci/travis-web' }),
+      branch = this.server.create('branch', { name: 'acceptance-tests' });
 
-    let  gitUser = server.create('git-user', { name: 'Mr T' });
-    let commit = server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
-    let build = server.create('build', { repository: repo, state: 'passed', commit, branch });
-    let job = server.create('job', { number: '1234.1', repository: repo, state: 'passed', commit, build });
+    let  gitUser = this.server.create('git-user', { name: 'Mr T' });
+    let commit = this.server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
+    let build = this.server.create('build', { repository: repo, state: 'passed', commit, branch });
+    let job = this.server.create('job', { number: '1234.1', repository: repo, state: 'passed', commit, build });
     commit.job = job;
 
     job.save();
@@ -437,7 +439,7 @@ module('Acceptance | job/basic layout', function (hooks) {
   travis_time:end:2fde4b10:start=1515663514660495538,finish=1515663517010906954,duration=2350411416
   travis_fold:end:afold
   `;
-    server.create('log', { id: job.id, content: complexLog });
+    this.server.create('log', { id: job.id, content: complexLog });
 
     await jobPage.visit();
 
@@ -455,19 +457,19 @@ module('Acceptance | job/basic layout', function (hooks) {
   test('visiting a job when log-rendering is off', async function (assert) {
     localStorage.setItem('travis.logRendering', false);
 
-    let repo =  server.create('repository', { slug: 'travis-ci/travis-web' }),
-      branch = server.create('branch', { name: 'acceptance-tests' });
+    let repo =  this.server.create('repository', { slug: 'travis-ci/travis-web' }),
+      branch = this.server.create('branch', { name: 'acceptance-tests' });
 
-    let commit = server.create('commit', { branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
-    let build = server.create('build', { repository: repo, state: 'passed', commit, branch });
-    let job = server.create('job', { number: '1234.1', repository: repo, state: 'passed', commit, build });
+    let commit = this.server.create('commit', { branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
+    let build = this.server.create('build', { repository: repo, state: 'passed', commit, branch });
+    let job = this.server.create('job', { number: '1234.1', repository: repo, state: 'passed', commit, build });
     commit.job = job;
 
     await job.save();
     await commit.save();
 
     const log = 'I am a log that won’t render.';
-    server.create('log', { id: job.id, content: log });
+    this.server.create('log', { id: job.id, content: log });
 
     await jobPage.visit();
 

--- a/tests/acceptance/job/build-matrix-test.js
+++ b/tests/acceptance/job/build-matrix-test.js
@@ -3,26 +3,28 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'travis/tests/helpers/setup-application-test';
 import buildPage from 'travis/tests/pages/build';
 import { percySnapshot } from 'ember-percy';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | job/build matrix', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   test('visiting build matrix', async function (assert) {
-    let repo =  server.create('repository', { slug: 'travis-ci/travis-web' });
-    let branch = server.create('branch', { name: 'acceptance-tests' });
+    let repo =  this.server.create('repository', { slug: 'travis-ci/travis-web' });
+    let branch = this.server.create('branch', { name: 'acceptance-tests' });
 
-    let  gitUser = server.create('git-user', { name: 'Mr T' });
-    let commit = server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
-    let build = server.create('build', { repository: repo, state: 'passed', commit_id: commit.id, commit, branch });
+    let  gitUser = this.server.create('git-user', { name: 'Mr T' });
+    let commit = this.server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
+    let build = this.server.create('build', { repository: repo, state: 'passed', commit_id: commit.id, commit, branch });
 
-    let firstJob = server.create('job', { number: '1234.1', repository: repo, state: 'passed', config: { env: 'JORTS', os: 'linux', language: 'node_js', node_js: 5 }, commit, build });
+    let firstJob = this.server.create('job', { number: '1234.1', repository: repo, state: 'passed', config: { env: 'JORTS', os: 'linux', language: 'node_js', node_js: 5 }, commit, build });
     commit.job = firstJob;
 
     firstJob.save();
     commit.save();
 
-    server.create('job', { number: '1234.2', repository: repo, state: 'passed', config: { env: 'JANTS', os: 'osx', language: 'ruby', rvm: 2.2 }, commit, build });
-    server.create('job', { allow_failure: true, number: '1234.999', repository: repo, state: 'failed', config: { language: 'ruby', os: 'jorts' }, commit, build });
+    this.server.create('job', { number: '1234.2', repository: repo, state: 'passed', config: { env: 'JANTS', os: 'osx', language: 'ruby', rvm: 2.2 }, commit, build });
+    this.server.create('job', { allow_failure: true, number: '1234.999', repository: repo, state: 'failed', config: { language: 'ruby', os: 'jorts' }, commit, build });
 
     await visit(`/travis-ci/travis-web/builds/${build.id}`);
 

--- a/tests/acceptance/job/cancel-test.js
+++ b/tests/acceptance/job/cancel-test.js
@@ -3,29 +3,31 @@ import { setupApplicationTest } from 'travis/tests/helpers/setup-application-tes
 import jobPage from 'travis/tests/pages/job';
 import topPage from 'travis/tests/pages/top';
 import signInUser from 'travis/tests/helpers/sign-in-user';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | jobs/cancel', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    const currentUser = server.create('user');
+    const currentUser = this.server.create('user');
     signInUser(currentUser);
   });
 
   test('restarting job', async function (assert) {
-    let repo =  server.create('repository', { slug: 'travis-ci/travis-web' });
-    server.create('branch', {});
+    let repo =  this.server.create('repository', { slug: 'travis-ci/travis-web' });
+    this.server.create('branch', {});
 
-    let  gitUser = server.create('git-user', { name: 'Mr T' });
-    let commit = server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
-    let build = server.create('build', { repository: repo, state: 'running', commit });
-    let job = server.create('job', { number: '1234.1', repository: repo, state: 'running', commit, build });
+    let  gitUser = this.server.create('git-user', { name: 'Mr T' });
+    let commit = this.server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
+    let build = this.server.create('build', { repository: repo, state: 'running', commit });
+    let job = this.server.create('job', { number: '1234.1', repository: repo, state: 'running', commit, build });
     commit.job = job;
 
     job.save();
     commit.save();
 
-    server.create('log', { id: job.id });
+    this.server.create('log', { id: job.id });
 
     await jobPage
       .visit()

--- a/tests/acceptance/job/debug-test.js
+++ b/tests/acceptance/job/debug-test.js
@@ -5,35 +5,37 @@ import topPage from 'travis/tests/pages/top';
 import signInUser from 'travis/tests/helpers/sign-in-user';
 import { enableFeature } from 'ember-feature-flags/test-support';
 import { percySnapshot } from 'ember-percy';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | jobs/debug', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    const currentUser = server.create('user');
+    const currentUser = this.server.create('user');
     signInUser(currentUser);
   });
 
   test('debugging job', async function (assert) {
     enableFeature('debugBuilds');
 
-    let repo =  server.create('repository', { slug: 'travis-ci/travis-web', private: true });
-    let branch = server.create('branch', { name: 'acceptance-tests' });
+    let repo =  this.server.create('repository', { slug: 'travis-ci/travis-web', private: true });
+    let branch = this.server.create('branch', { name: 'acceptance-tests' });
 
-    let  gitUser = server.create('git-user', { name: 'Mr T' });
-    let commit = server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
-    let build = server.create('build', { repository: repo, state: 'failed', commit, branch });
-    let job = server.create('job', { number: '1234.1', repository: repo, state: 'failed', commit, build });
+    let  gitUser = this.server.create('git-user', { name: 'Mr T' });
+    let commit = this.server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
+    let build = this.server.create('build', { repository: repo, state: 'failed', commit, branch });
+    let job = this.server.create('job', { number: '1234.1', repository: repo, state: 'failed', commit, build });
     commit.job = job;
 
     job.save();
     commit.save();
 
-    server.create('log', { id: job.id });
+    this.server.create('log', { id: job.id });
 
     const requestBodies = [];
 
-    server.post(`/job/${job.id}/debug`, function (schema, request) {
+    this.server.post(`/job/${job.id}/debug`, function (schema, request) {
       const parsedRequestBody = JSON.parse(request.requestBody);
       requestBodies.push(parsedRequestBody);
     });

--- a/tests/acceptance/job/delete-log-test.js
+++ b/tests/acceptance/job/delete-log-test.js
@@ -4,33 +4,35 @@ import jobPage from 'travis/tests/pages/job';
 import topPage from 'travis/tests/pages/top';
 import { Response } from 'ember-cli-mirage';
 import signInUser from 'travis/tests/helpers/sign-in-user';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | job/delete log', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    const currentUser = server.create('user');
+    const currentUser = this.server.create('user');
     signInUser(currentUser);
 
-    let repo =  server.create('repository', { slug: 'travis-ci/travis-web' });
-    server.create('branch', {});
+    let repo =  this.server.create('repository', { slug: 'travis-ci/travis-web' });
+    this.server.create('branch', {});
 
-    let  gitUser = server.create('git-user', { name: 'Mr T' });
-    let commit = server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
-    let build = server.create('build', { repository: repo, state: 'running', commit });
-    let job = server.create('job', { number: '1234.1', repository: repo, state: 'running', commit, build });
+    let  gitUser = this.server.create('git-user', { name: 'Mr T' });
+    let commit = this.server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
+    let build = this.server.create('build', { repository: repo, state: 'running', commit });
+    let job = this.server.create('job', { number: '1234.1', repository: repo, state: 'running', commit, build });
     commit.job = job;
 
     job.save();
     commit.save();
 
-    server.create('log', { id: job.id });
+    this.server.create('log', { id: job.id });
   });
 
   test('deleting job log when successful', async function (assert) {
     assert.expect(2);
 
-    server.delete('/job/:id/log', (schema, request) => {
+    this.server.delete('/job/:id/log', (schema, request) => {
       const job = schema.jobs.find(request.params.id);
       if (job) {
         job.destroy();
@@ -47,7 +49,7 @@ module('Acceptance | job/delete log', function (hooks) {
   });
 
   test('deleting job log when error occurs', async function (assert) {
-    server.delete('/job/:id/log', (schema, request) => {
+    this.server.delete('/job/:id/log', (schema, request) => {
       return new Response(500, {}, {});
     });
 

--- a/tests/acceptance/job/invalid-log-test.js
+++ b/tests/acceptance/job/invalid-log-test.js
@@ -3,12 +3,14 @@ import Ember from 'ember';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'travis/tests/helpers/setup-application-test';
 import jobPage from 'travis/tests/pages/job';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 let adapterException;
 let loggerError;
 
 module('Acceptance | job/invalid log', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
     adapterException = Ember.Test.adapter.exception;
@@ -24,11 +26,11 @@ module('Acceptance | job/invalid log', function (hooks) {
 
   test('viewing invalid job shows error', async function (assert) {
     // create incorrect repository as this is resolved first, errors otherwise
-    server.create('repository', { slug: 'travis-ci/travis-api' });
+    this.server.create('repository', { slug: 'travis-ci/travis-api' });
 
-    const repository = server.create('repository', { slug: 'travis-ci/travis-web' });
+    const repository = this.server.create('repository', { slug: 'travis-ci/travis-web' });
     const incorrectSlug = 'travis-ci/travis-api';
-    const job = server.create('job', { repository });
+    const job = this.server.create('job', { repository });
     await visit(`${incorrectSlug}/jobs/${job.id}`);
 
     assert.equal(jobPage.jobNotFoundMessage, 'Oops, we couldn\'t find that job!', 'Shows missing job message');

--- a/tests/acceptance/job/log-error-test.js
+++ b/tests/acceptance/job/log-error-test.js
@@ -5,21 +5,23 @@ import {
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'travis/tests/helpers/setup-application-test';
 import jobPage from 'travis/tests/pages/job';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | job/log error', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   test('handling log error', async function (assert) {
     assert.expect(5);
 
-    let createdBy = server.create('user', { login: 'srivera', name: null });
+    let createdBy = this.server.create('user', { login: 'srivera', name: null });
 
-    let repository =  server.create('repository', { slug: 'travis-ci/travis-web' }),
-      branch = server.create('branch', { name: 'acceptance-tests' });
+    let repository =  this.server.create('repository', { slug: 'travis-ci/travis-web' }),
+      branch = this.server.create('branch', { name: 'acceptance-tests' });
 
-    let commit = server.create('commit', { branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
-    let build = server.create('build', { repository, branch, commit, state: 'passed', createdBy });
-    let job = server.create('job', { repository, commit, build, number: '1234.1', state: 'passed' });
+    let commit = this.server.create('commit', { branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
+    let build = this.server.create('build', { repository, branch, commit, state: 'passed', createdBy });
+    let job = this.server.create('job', { repository, commit, build, number: '1234.1', state: 'passed' });
 
     commit.job = job;
 

--- a/tests/acceptance/job/restart-test.js
+++ b/tests/acceptance/job/restart-test.js
@@ -3,29 +3,31 @@ import { setupApplicationTest } from 'travis/tests/helpers/setup-application-tes
 import jobPage from 'travis/tests/pages/job';
 import topPage from 'travis/tests/pages/top';
 import signInUser from 'travis/tests/helpers/sign-in-user';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | jobs/restart', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    const currentUser = server.create('user');
+    const currentUser = this.server.create('user');
     signInUser(currentUser);
   });
 
   test('restarting job', async function (assert) {
-    let repo =  server.create('repository', { slug: 'travis-ci/travis-web' });
-    server.create('branch', {});
+    let repo =  this.server.create('repository', { slug: 'travis-ci/travis-web' });
+    this.server.create('branch', {});
 
-    let  gitUser = server.create('git-user', { name: 'Mr T' });
-    let commit = server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
-    let build = server.create('build', { repository: repo, state: 'failed', commit });
-    let job = server.create('job', { number: '1234.1', repository: repo, state: 'failed', commit, build });
+    let  gitUser = this.server.create('git-user', { name: 'Mr T' });
+    let commit = this.server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
+    let build = this.server.create('build', { repository: repo, state: 'failed', commit });
+    let job = this.server.create('job', { number: '1234.1', repository: repo, state: 'failed', commit, build });
     commit.job = job;
 
     job.save();
     commit.save();
 
-    server.create('log', { id: job.id });
+    this.server.create('log', { id: job.id });
 
     await jobPage
       .visit()

--- a/tests/acceptance/layouts/cta-test.js
+++ b/tests/acceptance/layouts/cta-test.js
@@ -4,13 +4,15 @@ import existingRepoPage from 'travis/tests/pages/repo-tabs/current';
 import defaultHeader from 'travis/tests/pages/header/default';
 import signInUser from 'travis/tests/helpers/sign-in-user';
 import { enableFeature } from 'ember-feature-flags/test-support';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | layouts/cta', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   test('cta is shown on .org when not on landing page and unauthenticated', async function (assert) {
     enableFeature('landingPageCta');
-    server.create('repository');
+    this.server.create('repository');
     await existingRepoPage.visit();
 
     assert.equal(defaultHeader.cta.text, 'Help make Open Source a better place and start building better software today!', 'Shows correct CTA text');
@@ -18,7 +20,7 @@ module('Acceptance | layouts/cta', function (hooks) {
 
   test('cta is shown for an open-source repository when GitHub Apps is present and not authenticated', async function (assert) {
     enableFeature('github-apps');
-    server.create('repository');
+    this.server.create('repository');
     await existingRepoPage.visit();
 
     assert.equal(defaultHeader.cta.text, 'Join over 500,000 developers testing and building on Travis CI');
@@ -26,9 +28,9 @@ module('Acceptance | layouts/cta', function (hooks) {
 
   test('cta is not shown for an open-source repository when GitHub Apps is present and authenticated', async function (assert) {
     enableFeature('github-apps');
-    server.create('repository');
+    this.server.create('repository');
 
-    const currentUser = server.create('user');
+    const currentUser = this.server.create('user');
     signInUser(currentUser);
 
     await existingRepoPage.visit();

--- a/tests/acceptance/layouts/default-test.js
+++ b/tests/acceptance/layouts/default-test.js
@@ -3,9 +3,11 @@ import { setupApplicationTest } from 'travis/tests/helpers/setup-application-tes
 import defaultHeader from 'travis/tests/pages/header/default';
 import defaultLayout from 'travis/tests/pages/layouts/default';
 import signInUser from 'travis/tests/helpers/sign-in-user';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | layouts/default', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   test('header layout when unauthenticated', async function (assert) {
     await defaultHeader.visit();
@@ -21,7 +23,7 @@ module('Acceptance | layouts/default', function (hooks) {
   });
 
   test('header layout when authenticated', async function (assert) {
-    const currentUser = server.create('user');
+    const currentUser = this.server.create('user');
     signInUser(currentUser);
 
     await defaultHeader.visit();

--- a/tests/acceptance/layouts/pro-test.js
+++ b/tests/acceptance/layouts/pro-test.js
@@ -5,9 +5,11 @@ import proHeader from 'travis/tests/pages/header/pro';
 import proLayout from 'travis/tests/pages/layouts/pro';
 import signInUser from 'travis/tests/helpers/sign-in-user';
 import { enableFeature } from 'ember-feature-flags/test-support';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | layouts/pro', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   test('header layout when unauthenticated', async function (assert) {
     enableFeature('proVersion');
@@ -27,7 +29,7 @@ module('Acceptance | layouts/pro', function (hooks) {
   test('header layout when authenticated', async function (assert) {
     enableFeature('proVersion');
 
-    const currentUser = server.create('user');
+    const currentUser = this.server.create('user');
     signInUser(currentUser);
 
     await visit('/');

--- a/tests/acceptance/owner/insights-test.js
+++ b/tests/acceptance/owner/insights-test.js
@@ -6,12 +6,14 @@ import signInUser from 'travis/tests/helpers/sign-in-user';
 import { INSIGHTS_PRIVACY_OPTIONS } from 'travis/components/insights-privacy-selector';
 import { percySnapshot } from 'ember-percy';
 import { enableFeature } from 'ember-feature-flags/test-support';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | owner insights', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    this.currentUser = server.create('user', {
+    this.currentUser = this.server.create('user', {
       name: 'Aria',
       login: 'bellsareringing',
       permissions: {
@@ -19,7 +21,7 @@ module('Acceptance | owner insights', function (hooks) {
       },
     });
 
-    this.otherUser = server.create('user', {
+    this.otherUser = this.server.create('user', {
       name: 'Mako',
       login: 'keepitwavy',
       permissions: {
@@ -29,7 +31,7 @@ module('Acceptance | owner insights', function (hooks) {
   });
 
   test('the owner insights page shows insights components', async function (assert) {
-    server.createList('insight-metric', 15);
+    this.server.createList('insight-metric', 15);
 
     await insightsPage.visit({ username: this.currentUser.login });
     await settled();

--- a/tests/acceptance/owner/not-found-test.js
+++ b/tests/acceptance/owner/not-found-test.js
@@ -9,12 +9,14 @@ import nonExistentOwnerPage from 'travis/tests/pages/owner/non-existent';
 import { percySnapshot } from 'ember-percy';
 import { enableFeature } from 'ember-feature-flags/test-support';
 import signInUser from 'travis/tests/helpers/sign-in-user';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 let adapterException;
 let loggerError;
 
 module('Acceptance | owner/not found', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
     // Ignore promise rejection.
@@ -31,7 +33,7 @@ module('Acceptance | owner/not found', function (hooks) {
   });
 
   test('visiting /non-existent-owner shows error message when authenticated', async function (assert) {
-    const user = server.create('user');
+    const user = this.server.create('user');
     await signInUser(user);
 
     await visit('/non-existent-owner');

--- a/tests/acceptance/owner/repos-test.js
+++ b/tests/acceptance/owner/repos-test.js
@@ -2,12 +2,14 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'travis/tests/helpers/setup-application-test';
 import ownerPage from 'travis/tests/pages/owner';
 import signInUser from 'travis/tests/helpers/sign-in-user';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | owner repositories', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    let user = server.create('user', {
+    let user = this.server.create('user', {
       name: 'User Name',
       login: 'user-login'
     });
@@ -16,7 +18,7 @@ module('Acceptance | owner repositories', function (hooks) {
     signInUser(user);
 
     // create active repo
-    const firstRepository = server.create('repository', {
+    const firstRepository = this.server.create('repository', {
       slug: 'user-login/repository-name',
       owner: {
         login: user.login
@@ -47,14 +49,14 @@ module('Acceptance | owner repositories', function (hooks) {
     lastBuild.save();
 
     // create active repo
-    server.create('repository', {
+    this.server.create('repository', {
       slug: 'user-login/yet-another-repository-name',
       owner: {
         login: user.login
       }
     });
 
-    server.create('repository', {
+    this.server.create('repository', {
       slug: 'other/other',
       skipPermissions: true
     });

--- a/tests/acceptance/plans-test.js
+++ b/tests/acceptance/plans-test.js
@@ -4,9 +4,11 @@ import { setupApplicationTest } from 'travis/tests/helpers/setup-application-tes
 import { enableFeature } from 'ember-feature-flags/test-support';
 import { percySnapshot } from 'ember-percy';
 import plansPage from 'travis/tests/pages/plans';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | plans page', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(async function () {
     enableFeature('pro-version');
@@ -98,7 +100,7 @@ module('Acceptance | plans page', function (hooks) {
 
     hooks.beforeEach(async function () {
       this.requestHandler = (request) => JSON.parse(request.requestBody);
-      server.post('/leads', (schema, request) => {
+      this.server.post('/leads', (schema, request) => {
         return this.requestHandler(request);
       });
     });

--- a/tests/acceptance/profile/billing-test.js
+++ b/tests/acceptance/profile/billing-test.js
@@ -9,12 +9,14 @@ import Service from '@ember/service';
 import StripeMock from 'travis/tests/helpers/stripe-mock';
 import { stubService, stubConfig } from 'travis/tests/helpers/stub-service';
 import { getContext } from '@ember/test-helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | profile/billing', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    this.user = server.create('user', {
+    this.user = this.server.create('user', {
       name: 'User Name of exceeding length',
       type: 'user',
       login: 'user-login',
@@ -27,14 +29,14 @@ module('Acceptance | profile/billing', function (hooks) {
 
     signInUser(this.user);
 
-    let trial = server.create('trial', {
+    let trial = this.server.create('trial', {
       owner: this.user,
       status: 'new',
       builds_remaining: 10,
     });
     this.trial = trial;
 
-    let plan = server.create('plan', {
+    let plan = this.server.create('plan', {
       name: 'Small Business1',
       builds: 5,
       annual: false,
@@ -43,17 +45,17 @@ module('Acceptance | profile/billing', function (hooks) {
     });
     this.plan = plan;
 
-    server.create('plan', { id: 'travis-ci-one-build', name: 'Bootstrap', builds: 1, price: 6900, currency: 'USD' });
-    this.defaultPlan = server.create('plan', { id: 'travis-ci-two-builds', name: 'Startup', builds: 2, price: 12900, currency: 'USD' });
-    server.create('plan', { id: 'travis-ci-five-builds', name: 'Premium', builds: 5, price: 24900, currency: 'USD' });
-    this.lastPlan = server.create('plan', { id: 'travis-ci-ten-builds', name: 'Small Business', builds: 10, price: 48900, currency: 'USD' });
+    this.server.create('plan', { id: 'travis-ci-one-build', name: 'Bootstrap', builds: 1, price: 6900, currency: 'USD' });
+    this.defaultPlan = this.server.create('plan', { id: 'travis-ci-two-builds', name: 'Startup', builds: 2, price: 12900, currency: 'USD' });
+    this.server.create('plan', { id: 'travis-ci-five-builds', name: 'Premium', builds: 5, price: 24900, currency: 'USD' });
+    this.lastPlan = this.server.create('plan', { id: 'travis-ci-ten-builds', name: 'Small Business', builds: 10, price: 48900, currency: 'USD' });
 
-    server.create('plan', { id: 'travis-ci-one-build-annual', name: 'Bootstrap', builds: 1, price: 75900, currency: 'USD', annual: true });
-    this.defaultAnnualPlan = server.create('plan', { id: 'travis-ci-two-builds-annual', name: 'Startup', builds: 2, price: 141900, currency: 'USD', annual: true });
-    server.create('plan', { id: 'travis-ci-five-builds-annual', name: 'Premium', builds: 5, price: 273900, currency: 'USD', annual: true });
-    server.create('plan', { id: 'travis-ci-ten-builds-annual', name: 'Small Business', builds: 10, price: 537900, currency: 'USD', annual: true });
+    this.server.create('plan', { id: 'travis-ci-one-build-annual', name: 'Bootstrap', builds: 1, price: 75900, currency: 'USD', annual: true });
+    this.defaultAnnualPlan = this.server.create('plan', { id: 'travis-ci-two-builds-annual', name: 'Startup', builds: 2, price: 141900, currency: 'USD', annual: true });
+    this.server.create('plan', { id: 'travis-ci-five-builds-annual', name: 'Premium', builds: 5, price: 273900, currency: 'USD', annual: true });
+    this.server.create('plan', { id: 'travis-ci-ten-builds-annual', name: 'Small Business', builds: 10, price: 537900, currency: 'USD', annual: true });
 
-    let subscription = server.create('subscription', {
+    let subscription = this.server.create('subscription', {
       plan,
       owner: this.user,
       status: 'subscribed',
@@ -83,7 +85,7 @@ module('Acceptance | profile/billing', function (hooks) {
       last_digits: '1919'
     });
 
-    let organization = server.create('organization', {
+    let organization = this.server.create('organization', {
       name: 'Org Name',
       type: 'organization',
       login: 'org-login',
@@ -93,7 +95,7 @@ module('Acceptance | profile/billing', function (hooks) {
     });
     this.organization = organization;
 
-    this.coupons = server.createList('coupon', 3);
+    this.coupons = this.server.createList('coupon', 3);
   });
 
   test('view billing information with invoices', async function (assert) {
@@ -413,7 +415,7 @@ module('Acceptance | profile/billing', function (hooks) {
   });
 
   test('view billing tab with Github trial subscription', async function (assert) {
-    let trial = server.create('trial', {
+    let trial = this.server.create('trial', {
       builds_remaining: 0,
       owner: this.organization,
       status: 'started',
@@ -441,7 +443,7 @@ module('Acceptance | profile/billing', function (hooks) {
   });
 
   test('view billing tab when Github trial subscription has ended', async function (assert) {
-    let trial = server.create('trial', {
+    let trial = this.server.create('trial', {
       builds_remaining: 0,
       owner: this.organization,
       status: 'ended',
@@ -471,7 +473,7 @@ module('Acceptance | profile/billing', function (hooks) {
     this.subscription.source = 'github';
     this.subscription.status = 'canceled';
 
-    server.create('subscription', {
+    this.server.create('subscription', {
       plan: this.defaultPlan,
       owner: this.user,
       status: 'expired',
@@ -703,7 +705,7 @@ module('Acceptance | profile/billing', function (hooks) {
       createSubscription: true
     };
     this.organization.save();
-    let trial = server.create('trial', {
+    let trial = this.server.create('trial', {
       builds_remaining: 100,
       owner: this.organization,
       status: 'new',
@@ -737,7 +739,7 @@ module('Acceptance | profile/billing', function (hooks) {
       createSubscription: true
     };
     this.organization.save();
-    let trial = server.create('trial', {
+    let trial = this.server.create('trial', {
       builds_remaining: 25,
       owner: this.organization,
       status: 'started',
@@ -771,7 +773,7 @@ module('Acceptance | profile/billing', function (hooks) {
       createSubscription: true
     };
     this.organization.save();
-    let trial = server.create('trial', {
+    let trial = this.server.create('trial', {
       builds_remaining: 10,
       owner: this.organization,
       status: 'started',
@@ -807,7 +809,7 @@ module('Acceptance | profile/billing', function (hooks) {
       createSubscription: true
     };
     this.organization.save();
-    let trial = server.create('trial', {
+    let trial = this.server.create('trial', {
       builds_remaining: 0,
       owner: this.organization,
       status: 'ended',

--- a/tests/acceptance/profile/filtering-test.js
+++ b/tests/acceptance/profile/filtering-test.js
@@ -4,12 +4,14 @@ import profilePage from 'travis/tests/pages/profile';
 import signInUser from 'travis/tests/helpers/sign-in-user';
 import { enableFeature } from 'ember-feature-flags/test-support';
 import { percySnapshot } from 'ember-percy';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | profile/filtering', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    const currentUser = server.create('user', {
+    const currentUser = this.server.create('user', {
       name: 'User Name',
       login: 'user-login',
     });
@@ -18,13 +20,13 @@ module('Acceptance | profile/filtering', function (hooks) {
     signInUser(currentUser);
 
     // create organization
-    server.create('organization', {
+    this.server.create('organization', {
       name: 'Org Name',
       login: 'org-login',
     });
 
     // create active repository
-    server.create('repository', {
+    this.server.create('repository', {
       name: 'specific-repository-name',
       owner: {
         login: 'user-login',
@@ -36,7 +38,7 @@ module('Acceptance | profile/filtering', function (hooks) {
     });
 
     // create inactive repository
-    server.create('repository', {
+    this.server.create('repository', {
       name: 'yet-another-repository-name',
       owner: {
         login: 'user-login',
@@ -48,7 +50,7 @@ module('Acceptance | profile/filtering', function (hooks) {
     });
 
     // create repository without admin permissions
-    server.create('repository', {
+    this.server.create('repository', {
       name: 'other-repository-name',
       owner: {
         login: 'user-login',
@@ -60,7 +62,7 @@ module('Acceptance | profile/filtering', function (hooks) {
     });
 
     // create other random repository to ensure correct filtering
-    server.create('repository', {
+    this.server.create('repository', {
       name: 'feminism-is-for-everybody',
       owner: {
         login: 'bellhooks',
@@ -89,14 +91,14 @@ module('Acceptance | profile/filtering', function (hooks) {
   test('paginate and filter GitHub Apps-managed repositories', async function (assert) {
     enableFeature('github-apps');
 
-    server.create('installation', {
+    this.server.create('installation', {
       owner: this.user,
       github_id: 2691
     });
     this.user.save();
 
     for (let i = 0; i < 15; i++) {
-      server.create('repository', {
+      this.server.create('repository', {
         name: `github-apps-public-repository-${(i + '').padStart(3, '0')}`,
         owner: {
           login: 'user-login',

--- a/tests/acceptance/profile/migrate-test.js
+++ b/tests/acceptance/profile/migrate-test.js
@@ -4,18 +4,20 @@ import { setupApplicationTest } from 'travis/tests/helpers/setup-application-tes
 import { enableFeature } from 'ember-feature-flags/test-support';
 import profilePage from 'travis/tests/pages/profile';
 import signInUser from 'travis/tests/helpers/sign-in-user';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | Profile | Migrate', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    this.user = server.create('user', {
+    this.user = this.server.create('user', {
       allow_migration: true,
       login: 'user-login',
       github_id: 1974,
     });
 
-    server.create('installation', {
+    this.server.create('installation', {
       owner: this.user,
       github_id: 2691
     });
@@ -58,7 +60,7 @@ module('Acceptance | Profile | Migrate', function (hooks) {
     module('tab with repositories to migrate', function (hooks) {
 
       hooks.beforeEach(async function () {
-        generateRepositoriesForMigration(server, this.user);
+        generateRepositoriesForMigration(this.server, this.user);
         await profilePage.visit();
         await settled();
         await profilePage.migrate.visit();
@@ -102,7 +104,7 @@ module('Acceptance | Profile | Migrate', function (hooks) {
 });
 
 function generateRepositoriesForMigration(server, user) {
-  server.createList('repository', 10, {
+  this.server.createList('repository', 10, {
     active_on_org: true,
     managed_by_installation: true,
     owner: {

--- a/tests/acceptance/profile/migrate-test.js
+++ b/tests/acceptance/profile/migrate-test.js
@@ -58,7 +58,6 @@ module('Acceptance | Profile | Migrate', function (hooks) {
     });
 
     module('tab with repositories to migrate', function (hooks) {
-
       hooks.beforeEach(async function () {
         generateRepositoriesForMigration(this.server, this.user);
         await profilePage.visit();
@@ -104,7 +103,7 @@ module('Acceptance | Profile | Migrate', function (hooks) {
 });
 
 function generateRepositoriesForMigration(server, user) {
-  this.server.createList('repository', 10, {
+  server.createList('repository', 10, {
     active_on_org: true,
     managed_by_installation: true,
     owner: {

--- a/tests/acceptance/profile/not-found-test.js
+++ b/tests/acceptance/profile/not-found-test.js
@@ -3,12 +3,14 @@ import { setupApplicationTest } from 'travis/tests/helpers/setup-application-tes
 import profilePage from 'travis/tests/pages/profile';
 import signInUser from 'travis/tests/helpers/sign-in-user';
 import { percySnapshot } from 'ember-percy';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | profile/not found', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    const currentUser = server.create('user', {
+    const currentUser = this.server.create('user', {
       name: 'User Name',
       login: 'user-login',
     });

--- a/tests/acceptance/profile/redirect-test.js
+++ b/tests/acceptance/profile/redirect-test.js
@@ -4,14 +4,16 @@ import { setupApplicationTest } from 'travis/tests/helpers/setup-application-tes
 import signInUser from 'travis/tests/helpers/sign-in-user';
 import Service from '@ember/service';
 import { stubService } from 'travis/tests/helpers/stub-service';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | profile/redirect', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    this.user = server.create('user', { login: 'test-user' });
-    this.org = server.create('organization', { login: 'test-org' });
-    server.create('plan', { id: 'travis-ci-one-build', name: 'AM', builds: 1, price: 6900, currency: 'USD' });
+    this.user = this.server.create('user', { login: 'test-user' });
+    this.org = this.server.create('organization', { login: 'test-org' });
+    this.server.create('plan', { id: 'travis-ci-one-build', name: 'AM', builds: 1, price: 6900, currency: 'USD' });
     signInUser(this.user);
 
     let mockStripe = Service.extend({

--- a/tests/acceptance/profile/sync-test.js
+++ b/tests/acceptance/profile/sync-test.js
@@ -3,6 +3,7 @@ import { setupApplicationTest } from 'travis/tests/helpers/setup-application-tes
 import { waitFor } from '@ember/test-helpers';
 import profilePage from 'travis/tests/pages/profile';
 import signInUser from 'travis/tests/helpers/sign-in-user';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 async function finishSyncingUser(user) {
   user.is_syncing = false;
@@ -12,11 +13,12 @@ async function finishSyncingUser(user) {
 
 module('Acceptance | profile/sync', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
     let twoYearsAgo = new Date(new Date().getTime() - 1000 * 60 * 60 * 24 * 365 * 2);
 
-    this.user = server.create('user', {
+    this.user = this.server.create('user', {
       name: 'Miss Major',
       login: 'miss-major',
       synced_at: twoYearsAgo
@@ -33,7 +35,7 @@ module('Acceptance | profile/sync', function (hooks) {
 
     let syncCalled = false;
 
-    server.post(`/user/${this.user.id}/sync`, () => {
+    this.server.post(`/user/${this.user.id}/sync`, () => {
       this.user.is_syncing = true;
       syncCalled = true;
       return this.user.save();

--- a/tests/acceptance/profile/unsubscribe-test.js
+++ b/tests/acceptance/profile/unsubscribe-test.js
@@ -4,20 +4,22 @@ import { setupApplicationTest } from 'travis/tests/helpers/setup-application-tes
 import { percySnapshot } from 'ember-percy';
 import signInUser from 'travis/tests/helpers/sign-in-user';
 import unsubscribePage from 'travis/tests/pages/unsubscribe';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 const { emailUnsubscribe } = unsubscribePage;
 
 module('Acceptance | profile/unsubscribe', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    this.user = server.create('user');
+    this.user = this.server.create('user');
     await signInUser(this.user);
   });
 
   module('for invalid repository', function (hooks) {
     hooks.beforeEach(async function () {
-      this.repo = server.create('repository', {
+      this.repo = this.server.create('repository', {
         owner: {
           login: 'some-user'
         }
@@ -42,7 +44,7 @@ module('Acceptance | profile/unsubscribe', function (hooks) {
   module('for valid repository', function (hooks) {
     module('when subscribed', function (hooks) {
       hooks.beforeEach(async function () {
-        this.repo = server.create('repository', {
+        this.repo = this.server.create('repository', {
           email_subscribed: true,
           owner: {
             login: this.user.login
@@ -84,7 +86,7 @@ module('Acceptance | profile/unsubscribe', function (hooks) {
 
     module('when unsubscribed', function (hooks) {
       hooks.beforeEach(async function () {
-        this.repo = server.create('repository', {
+        this.repo = this.server.create('repository', {
           email_subscribed: false,
           owner: {
             login: this.user.login

--- a/tests/acceptance/profile/update-repositories-test.js
+++ b/tests/acceptance/profile/update-repositories-test.js
@@ -2,12 +2,14 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'travis/tests/helpers/setup-application-test';
 import signInUser from 'travis/tests/helpers/sign-in-user';
 import profilePage from 'travis/tests/pages/profile';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | profile/update-repositories', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    const currentUser = server.create('user', {
+    const currentUser = this.server.create('user', {
       name: 'User Name',
       login: 'user-login',
     });
@@ -15,13 +17,13 @@ module('Acceptance | profile/update-repositories', function (hooks) {
     signInUser(currentUser);
 
     // create organization
-    server.create('organization', {
+    this.server.create('organization', {
       name: 'Org Name',
       login: 'org-login',
     });
 
     // create active repository
-    server.create('repository', {
+    this.server.create('repository', {
       name: 'repository-name',
       owner: {
         login: 'user-login',
@@ -33,7 +35,7 @@ module('Acceptance | profile/update-repositories', function (hooks) {
     });
 
     // create inactive repository
-    server.create('repository', {
+    this.server.create('repository', {
       name: 'yet-another-repository-name',
       owner: {
         login: 'user-login',
@@ -45,7 +47,7 @@ module('Acceptance | profile/update-repositories', function (hooks) {
     });
 
     // create repository without admin permissions
-    server.create('repository', {
+    this.server.create('repository', {
       name: 'other-repository-name',
       owner: {
         login: 'user-login',
@@ -57,7 +59,7 @@ module('Acceptance | profile/update-repositories', function (hooks) {
     });
 
     // create other random repository to ensure correct filtering
-    server.create('repository', {
+    this.server.create('repository', {
       name: 'feminism-is-for-everybody',
       owner: {
         login: 'bellhooks',
@@ -69,7 +71,7 @@ module('Acceptance | profile/update-repositories', function (hooks) {
     });
 
     // create migrated repository
-    server.create('repository', {
+    this.server.create('repository', {
       name: 'already-migrated-repository',
       owner: {
         login: 'user-login',

--- a/tests/acceptance/profile/user-settings-test.js
+++ b/tests/acceptance/profile/user-settings-test.js
@@ -7,16 +7,18 @@ import topPage from 'travis/tests/pages/top';
 import { enableFeature } from 'ember-feature-flags/test-support';
 import { INSIGHTS_VIS_OPTIONS } from 'travis/controllers/account/settings';
 import { percySnapshot } from 'ember-percy';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | user settings', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    const user = server.create('user');
+    const user = this.server.create('user');
     signInUser(user);
     this.user = user;
 
-    server.create('organization', {
+    this.server.create('organization', {
       name: 'Org Name',
       type: 'organization',
       login: 'org-login',
@@ -25,17 +27,17 @@ module('Acceptance | user settings', function (hooks) {
       }
     });
 
-    server.loadFixtures('preferences');
+    this.server.loadFixtures('preferences');
   });
 
   test('changing feature flags', async function (assert) {
-    server.create('feature', {
+    this.server.create('feature', {
       name: 'jorts',
       description: 'Jorts!',
       enabled: true
     });
 
-    const jantsFeature = server.create('feature', {
+    const jantsFeature = this.server.create('feature', {
       name: 'jants',
       description: 'Jants?',
       enabled: false
@@ -62,7 +64,7 @@ module('Acceptance | user settings', function (hooks) {
 
     let patchRequestBody;
 
-    server.patch(`/user/${this.user.id}/beta_feature/${jantsFeature.id}`, function (schema, request) {
+    this.server.patch(`/user/${this.user.id}/beta_feature/${jantsFeature.id}`, function (schema, request) {
       patchRequestBody = JSON.parse(request.requestBody);
       const feature = schema.features.find(jantsFeature.id);
       feature.enabled = true;
@@ -106,7 +108,7 @@ module('Acceptance | user settings', function (hooks) {
   test('Email settings can be toggled', async function (assert) {
     const AMOUNT_OF_REPOS = 3;
 
-    server.createList('repository', AMOUNT_OF_REPOS, {
+    this.server.createList('repository', AMOUNT_OF_REPOS, {
       email_subscribed: false
     });
 
@@ -128,7 +130,7 @@ module('Acceptance | user settings', function (hooks) {
   });
 
   test('User can resubscribe to repository', async function (assert) {
-    server.create('repository', { email_subscribed: false });
+    this.server.create('repository', { email_subscribed: false });
 
     await profilePage.visit({ username: 'testuser' });
     await profilePage.settings.visit();

--- a/tests/acceptance/profile/view-token-test.js
+++ b/tests/acceptance/profile/view-token-test.js
@@ -6,12 +6,14 @@ import signInUser from 'travis/tests/helpers/sign-in-user';
 import {
   triggerCopySuccess
 } from 'ember-cli-clipboard/test-support';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | profile/view token', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
-    const currentUser = server.create('user', {
+    const currentUser = this.server.create('user', {
       name: 'User Name',
       login: 'user-login',
     });
@@ -19,7 +21,7 @@ module('Acceptance | profile/view token', function (hooks) {
     signInUser(currentUser);
 
     // create organization
-    server.create('organization', {
+    this.server.create('organization', {
       name: 'Org Name',
       login: 'org-login',
     });

--- a/tests/acceptance/repo/active_on_org-test.js
+++ b/tests/acceptance/repo/active_on_org-test.js
@@ -11,14 +11,14 @@ module('Acceptance | repo not active', function (hooks) {
   test('view an active_on_org repository when GitHub Apps is present', async function (assert) {
     enableFeature('github-apps');
 
-    const user = server.create('user', {
+    const user = this.server.create('user', {
       name: 'Erika Musterfrau',
       login: 'musterfrau'
     });
 
     signInUser(user);
 
-    server.create('repository', {
+    this.server.create('repository', {
       slug: 'musterfrau/a-repo',
       active: true,
       active_on_org: true,

--- a/tests/acceptance/repo/active_on_org-test.js
+++ b/tests/acceptance/repo/active_on_org-test.js
@@ -4,9 +4,11 @@ import page from 'travis/tests/pages/repo-not-active';
 import signInUser from 'travis/tests/helpers/sign-in-user';
 import { percySnapshot } from 'ember-percy';
 import { enableFeature } from 'ember-feature-flags/test-support';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | repo not active', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   test('view an active_on_org repository when GitHub Apps is present', async function (assert) {
     enableFeature('github-apps');

--- a/tests/acceptance/repo/branches-test.js
+++ b/tests/acceptance/repo/branches-test.js
@@ -5,9 +5,11 @@ import branchesPage from 'travis/tests/pages/branches';
 import signInUser from 'travis/tests/helpers/sign-in-user';
 import { prettyDate } from 'travis/helpers/pretty-date';
 import { percySnapshot } from 'ember-percy';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | repo branches', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
     this.currentUser = this.server.create('user', {

--- a/tests/acceptance/repo/branches-test.js
+++ b/tests/acceptance/repo/branches-test.js
@@ -10,35 +10,35 @@ module('Acceptance | repo branches', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(function () {
-    this.currentUser = server.create('user', {
+    this.currentUser = this.server.create('user', {
       name: 'User Name',
       login: 'user-login',
     });
 
     signInUser(this.currentUser);
 
-    const gitUser = server.create('git-user', {
+    const gitUser = this.server.create('git-user', {
       name: 'User Name'
     });
 
-    const otherUser = server.create('git-user', {
+    const otherUser = this.server.create('git-user', {
       name: 'Marsha P. Johnson'
     });
 
     // create organization
-    server.create('organization', {
+    this.server.create('organization', {
       name: 'Org Name',
       login: 'org-login',
     });
 
-    const repository = server.create('repository', {
+    const repository = this.server.create('repository', {
       name: 'repository-name',
       slug: 'org-login/repository-name'
     });
 
     const repoId = parseInt(repository.id);
 
-    const primaryBranch = server.create('branch', {
+    const primaryBranch = this.server.create('branch', {
       name: 'primary#yes',
       id: `/v3/repo/${repoId}/branch/primary#yes`,
       default_branch: true,
@@ -90,7 +90,7 @@ module('Acceptance | repo branches', function (hooks) {
     lastBuild.save();
     this.lastBuild = lastBuild;
 
-    const activeCreatedBranch = server.create('branch', {
+    const activeCreatedBranch = this.server.create('branch', {
       name: 'created',
       id: `/v3/repo/${repoId}/branch/created`,
       exists_on_github: true,
@@ -98,7 +98,7 @@ module('Acceptance | repo branches', function (hooks) {
       repository,
     });
 
-    server.create('build', {
+    this.server.create('build', {
       state: 'created',
       branch: activeCreatedBranch,
       repository,
@@ -107,7 +107,7 @@ module('Acceptance | repo branches', function (hooks) {
       committer: otherUser
     });
 
-    const activeFailedBranch = server.create('branch', {
+    const activeFailedBranch = this.server.create('branch', {
       name: 'edits',
       id: `/v3/repo/${repoId}/branch/edits`,
       exists_on_github: true,
@@ -115,7 +115,7 @@ module('Acceptance | repo branches', function (hooks) {
       repository,
     });
 
-    server.create('build', {
+    this.server.create('build', {
       state: 'failed',
       finished_at: oneYearAgo,
       branch: activeFailedBranch,
@@ -125,7 +125,7 @@ module('Acceptance | repo branches', function (hooks) {
       committer: otherUser
     });
 
-    const activeOlderFailedBranch = server.create('branch', {
+    const activeOlderFailedBranch = this.server.create('branch', {
       name: 'old-old-edits',
       id: `/v3/repo/${repoId}/branch/old-old-edits`,
       exists_on_github: true,
@@ -133,7 +133,7 @@ module('Acceptance | repo branches', function (hooks) {
       repository,
     });
 
-    server.create('build', {
+    this.server.create('build', {
       state: 'failed',
       finished_at: twoYearsAgo,
       branch: activeOlderFailedBranch,
@@ -145,7 +145,7 @@ module('Acceptance | repo branches', function (hooks) {
       committer: otherUser
     });
 
-    const olderInactiveBranch = server.create('branch', {
+    const olderInactiveBranch = this.server.create('branch', {
       name: 'older-edits',
       id: `/v3/repo/${repoId}/branch/older-edits`,
       exists_on_github: false,
@@ -157,7 +157,7 @@ module('Acceptance | repo branches', function (hooks) {
       finished_at: twoYearsAgo
     });
 
-    const newerInactiveBranch = server.create('branch', {
+    const newerInactiveBranch = this.server.create('branch', {
       name: 'old-edits',
       id: `/v3/repo/${repoId}/branch/old-edits`,
       exists_on_github: false,
@@ -165,7 +165,7 @@ module('Acceptance | repo branches', function (hooks) {
       repository,
     });
 
-    server.create('build', {
+    this.server.create('build', {
       state: 'errored',
       finished_at: oneYearAgo,
       branch: newerInactiveBranch,
@@ -229,11 +229,11 @@ module('Acceptance | repo branches', function (hooks) {
 
   test('view branches tab when no branches present', async function (assert) {
     // destroy state from previous tests
-    server.db.branches.remove();
-    server.db.repositories.remove();
-    server.db.builds.remove();
+    this.server.db.branches.remove();
+    this.server.db.repositories.remove();
+    this.server.db.builds.remove();
 
-    server.create('repository');
+    this.server.create('repository');
 
     await branchesPage.visit({ organization: 'travis-ci', repo: 'travis-web' });
 

--- a/tests/acceptance/repo/build-list-routes-test.js
+++ b/tests/acceptance/repo/build-list-routes-test.js
@@ -9,11 +9,12 @@ import page from 'travis/tests/pages/build-list';
 import generatePusherPayload from 'travis/tests/helpers/generate-pusher-payload';
 import signInUser from 'travis/tests/helpers/sign-in-user';
 import { percySnapshot } from 'ember-percy';
-
 import moment from 'moment';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | repo build list routes', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
     const currentUser = this.server.create('user', {

--- a/tests/acceptance/repo/build-list-routes-test.js
+++ b/tests/acceptance/repo/build-list-routes-test.js
@@ -16,25 +16,25 @@ module('Acceptance | repo build list routes', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(function () {
-    const currentUser = server.create('user', {
+    const currentUser = this.server.create('user', {
       name: 'User Name',
       login: 'user-login'
     });
 
     signInUser(currentUser);
 
-    const gitUser = server.create('git-user', {
+    const gitUser = this.server.create('git-user', {
       name: 'Other User Name'
     });
 
-    const repository = server.create('repository', {
+    const repository = this.server.create('repository', {
       slug: 'org-login/repository-name'
     });
     this.repository = repository;
 
     this.repoId = parseInt(repository.id);
 
-    this.branch = server.create('branch', { name: 'successful-cron-branch' });
+    this.branch = this.server.create('branch', { name: 'successful-cron-branch' });
 
     const oneYearAgo = new Date();
     oneYearAgo.setYear(oneYearAgo.getFullYear() - 1);
@@ -42,9 +42,9 @@ module('Acceptance | repo build list routes', function (hooks) {
 
     const beforeOneYearAgo = new Date(oneYearAgo.getTime() - 1000 * 60 * 5);
 
-    const cronBranch = server.create('branch', { repository, name: 'successful-cron-branch' });
+    const cronBranch = this.server.create('branch', { repository, name: 'successful-cron-branch' });
 
-    const lastBuild = server.create('build', {
+    const lastBuild = this.server.create('build', {
       state: 'passed',
       number: '1918',
       finished_at: oneYearAgo,
@@ -67,7 +67,7 @@ module('Acceptance | repo build list routes', function (hooks) {
     }, commitAttributes));
     lastBuild.save();
 
-    const failedBuild = server.create('build', {
+    const failedBuild = this.server.create('build', {
       state: 'failed',
       event_type: 'push',
       repository,
@@ -82,7 +82,7 @@ module('Acceptance | repo build list routes', function (hooks) {
       default_branch: true
     });
 
-    const erroredBuild = server.create('build', {
+    const erroredBuild = this.server.create('build', {
       state: 'errored',
       event_type: 'push',
       repository,
@@ -105,7 +105,7 @@ module('Acceptance | repo build list routes', function (hooks) {
     }));
     defaultBranchBuild.save();
 
-    const pullRequestCommit = server.create('commit', commitAttributes);
+    const pullRequestCommit = this.server.create('commit', commitAttributes);
     const pullRequestBuild = this.branch.createBuild({
       state: 'started',
       number: '1919',
@@ -165,7 +165,7 @@ module('Acceptance | repo build list routes', function (hooks) {
 
     assert.equal(page.builds[2].name, 'rarely-used', 'expected the old default branch to show');
 
-    const sevenOaksBranch = server.create('branch', {
+    const sevenOaksBranch = this.server.create('branch', {
       name: 'oldest-build-branch'
     });
 
@@ -177,7 +177,7 @@ module('Acceptance | repo build list routes', function (hooks) {
       state: 'passed'
     });
 
-    let us = server.create('git-user', { name: 'us' });
+    let us = this.server.create('git-user', { name: 'us' });
 
     olderBuild.createCommit({
       sha: 'acab',
@@ -194,7 +194,7 @@ module('Acceptance | repo build list routes', function (hooks) {
 
     let build, commit;
 
-    const branch = server.create('branch', {
+    const branch = this.server.create('branch', {
       name: 'no-dapl'
     });
 
@@ -256,7 +256,7 @@ module('Acceptance | repo build list routes', function (hooks) {
   });
 
   test('renders no builds messaging when none present', async function (assert) {
-    server.create('repository');
+    this.server.create('repository');
 
     await page.visitBuildHistory({ organization: 'travis-ci', repo: 'travis-web' });
 

--- a/tests/acceptance/repo/caches-test.js
+++ b/tests/acceptance/repo/caches-test.js
@@ -4,9 +4,11 @@ import { settled } from '@ember/test-helpers';
 import page from 'travis/tests/pages/caches';
 import signInUser from 'travis/tests/helpers/sign-in-user';
 import { percySnapshot } from 'ember-percy';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | repo caches', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
     const oneDayAgo = new Date(new Date().getTime() - 1000 * 60 * 60 * 24);
@@ -14,32 +16,32 @@ module('Acceptance | repo caches', function (hooks) {
     const threeDaysAgo = new Date(new Date().getTime() - 1000 * 60 * 60 * 24 * 3);
     const slug = 'org-login/repository-name';
 
-    const currentUser = server.create('user', {
+    const currentUser = this.server.create('user', {
       name: 'User Name',
       login: 'user-login'
     });
 
     const caches = [];
 
-    caches.push(server.create('cache', {
+    caches.push(this.server.create('cache', {
       branch: 'a-branch-name',
       lastModified: oneDayAgo,
       size: 89407938
     }));
 
-    caches.push(server.create('cache', {
+    caches.push(this.server.create('cache', {
       branch: 'PR.1919',
       lastModified: twoDaysAgo,
       size: 10061087
     }));
 
-    caches.push(server.create('cache', {
+    caches.push(this.server.create('cache', {
       branch: 'PR.1919',
       lastModified: threeDaysAgo,
       size: 10061086
     }));
 
-    this.repository = server.create('repository', { slug, caches });
+    this.repository = this.server.create('repository', { slug, caches });
 
     signInUser(currentUser);
   });
@@ -69,7 +71,7 @@ module('Acceptance | repo caches', function (hooks) {
 
     const branchQueryParams = [];
 
-    server.delete(`/repo/${this.repository.id}/caches`, function (schema, {queryParams}) {
+    this.server.delete(`/repo/${this.repository.id}/caches`, function (schema, {queryParams}) {
       branchQueryParams.push(queryParams.branch || 'empty');
     });
 

--- a/tests/acceptance/repo/not-active-test.js
+++ b/tests/acceptance/repo/not-active-test.js
@@ -3,9 +3,11 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'travis/tests/helpers/setup-application-test';
 import page from 'travis/tests/pages/repo-not-active';
 import signInUser from 'travis/tests/helpers/sign-in-user';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | repo not active', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   test('view inactive repo when not an admin or signed out', async function (assert) {
     this.server.create('repository', {

--- a/tests/acceptance/repo/not-active-test.js
+++ b/tests/acceptance/repo/not-active-test.js
@@ -8,7 +8,7 @@ module('Acceptance | repo not active', function (hooks) {
   setupApplicationTest(hooks);
 
   test('view inactive repo when not an admin or signed out', async function (assert) {
-    server.create('repository', {
+    this.server.create('repository', {
       slug: 'musterfrau/a-repo',
       active: false,
       permissions: {
@@ -24,7 +24,7 @@ module('Acceptance | repo not active', function (hooks) {
   });
 
   test('view inactive repo when admin and activate it', async function (assert) {
-    server.create('repository', {
+    this.server.create('repository', {
       slug: 'musterfrau/a-repo',
       active: false,
       permissions: {
@@ -32,7 +32,7 @@ module('Acceptance | repo not active', function (hooks) {
       }
     });
 
-    const user = server.create('user', {
+    const user = this.server.create('user', {
       name: 'Erika Musterfrau',
       login: 'musterfrau'
     });
@@ -48,7 +48,7 @@ module('Acceptance | repo not active', function (hooks) {
   });
 
   test('migrated repository does not show activation button or settings', async function (assert) {
-    server.create('repository', {
+    this.server.create('repository', {
       slug: 'musterfrau/a-repo',
       active: false,
       migration_status: 'migrated',
@@ -60,7 +60,7 @@ module('Acceptance | repo not active', function (hooks) {
       }
     });
 
-    const user = server.create('user', {
+    const user = this.server.create('user', {
       name: 'Erika Musterfrau',
       login: 'musterfrau'
     });
@@ -73,7 +73,7 @@ module('Acceptance | repo not active', function (hooks) {
   });
 
   test('view inactive repo when admin connected to Github Apps and activate it', async function (assert) {
-    server.create('repository', {
+    this.server.create('repository', {
       slug: 'musterfrau/a-repo',
       active: false,
       permissions: {
@@ -88,7 +88,7 @@ module('Acceptance | repo not active', function (hooks) {
       }
     });
 
-    const user = server.create('user', {
+    const user = this.server.create('user', {
       name: 'Erika Musterfrau',
       login: 'musterfrau'
     });

--- a/tests/acceptance/repo/not-found-test.js
+++ b/tests/acceptance/repo/not-found-test.js
@@ -28,7 +28,7 @@ module('Acceptance | repo/not found', function (hooks) {
   });
 
   test('visiting /non-existent/repository shows error message when authenticated', async function (assert) {
-    const user = server.create('user');
+    const user = this.server.create('user');
     signInUser(user);
 
     await nonExistentRepoPage.visit();

--- a/tests/acceptance/repo/not-found-test.js
+++ b/tests/acceptance/repo/not-found-test.js
@@ -6,12 +6,14 @@ import nonExistentRepoPage from 'travis/tests/pages/repo/non-existent';
 import { percySnapshot } from 'ember-percy';
 import { enableFeature } from 'ember-feature-flags/test-support';
 import signInUser from 'travis/tests/helpers/sign-in-user';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 let adapterException;
 let loggerError;
 
 module('Acceptance | repo/not found', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
     // Ignore promise rejection.

--- a/tests/acceptance/repo/requests-test.js
+++ b/tests/acceptance/repo/requests-test.js
@@ -4,9 +4,11 @@ import { prettyDate } from 'travis/helpers/pretty-date';
 import { percySnapshot } from 'ember-percy';
 
 import requestsPage from 'travis/tests/pages/requests';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | repo | requests', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
     this.repo = this.server.create('repository', { slug: 'travis-ci/travis-web' });

--- a/tests/acceptance/repo/requests-test.js
+++ b/tests/acceptance/repo/requests-test.js
@@ -9,7 +9,7 @@ module('Acceptance | repo | requests', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(function () {
-    this.repo = server.create('repository', { slug: 'travis-ci/travis-web' });
+    this.repo = this.server.create('repository', { slug: 'travis-ci/travis-web' });
   });
 
   test('list requests', async function (assert) {
@@ -21,13 +21,13 @@ module('Acceptance | repo | requests', function (hooks) {
     });
     this.approvedRequest = approvedRequest;
 
-    let approvedCommit = server.create('commit', {
+    let approvedCommit = this.server.create('commit', {
       branch: 'acceptance-tests',
       message: 'A commit message',
       request: approvedRequest
     });
 
-    server.create('build', {
+    this.server.create('build', {
       repository: this.repo,
       state: 'passed',
       commit_id: approvedCommit.id,
@@ -53,13 +53,13 @@ module('Acceptance | repo | requests', function (hooks) {
       event_type: 'pull_request'
     });
 
-    let olderApprovedCommit = server.create('commit', {
+    let olderApprovedCommit = this.server.create('commit', {
       branch: 'acceptance-tests',
       message: 'An older commit message',
       request: olderApprovedRequest
     });
 
-    server.create('build', {
+    this.server.create('build', {
       repository: this.repo,
       state: 'passed',
       commit_id: olderApprovedCommit.id,

--- a/tests/acceptance/repo/settings-test.js
+++ b/tests/acceptance/repo/settings-test.js
@@ -6,11 +6,12 @@ import settingsPage from 'travis/tests/pages/settings';
 import topPage from 'travis/tests/pages/top';
 import signInUser from 'travis/tests/helpers/sign-in-user';
 import { selectChoose, selectSearch } from 'ember-power-select/test-support';
-
 import moment from 'moment';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | repo settings', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(async function () {
     const currentUser = this.server.create('user', {

--- a/tests/acceptance/repo/settings-test.js
+++ b/tests/acceptance/repo/settings-test.js
@@ -13,7 +13,7 @@ module('Acceptance | repo settings', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(async function () {
-    const currentUser = server.create('user', {
+    const currentUser = this.server.create('user', {
       name: 'User Name',
       login: 'user-login',
     });
@@ -21,12 +21,12 @@ module('Acceptance | repo settings', function (hooks) {
     await signInUser(currentUser);
 
     // create organization
-    server.create('organization', {
+    this.server.create('organization', {
       name: 'Org Name',
       login: 'org-login',
     });
 
-    const repository = server.create('repository', {
+    const repository = this.server.create('repository', {
       name: 'repository-name',
       slug: 'org-login/repository-name',
       private: true
@@ -56,21 +56,21 @@ module('Acceptance | repo settings', function (hooks) {
 
     const repoId = parseInt(repository.id);
 
-    const dailyBranch = server.create('branch', {
+    const dailyBranch = this.server.create('branch', {
       name: 'daily-branch',
       id: `/v3/repo/${repoId}/branch/daily-branch`,
       exists_on_github: true,
       repository
     });
 
-    const weeklyBranch = server.create('branch', {
+    const weeklyBranch = this.server.create('branch', {
       name: 'weekly-branch',
       id: `/v3/repo/${repoId}/branch/weekly-branch`,
       exists_on_github: true,
       repository
     });
 
-    this.dailyCron = server.create('cron', {
+    this.dailyCron = this.server.create('cron', {
       interval: 'daily',
       dont_run_if_recent_build_exists: false,
       last_run: moment(),
@@ -79,7 +79,7 @@ module('Acceptance | repo settings', function (hooks) {
       repository
     });
 
-    server.create('cron', {
+    this.server.create('cron', {
       interval: 'weekly',
       dont_run_if_recent_build_exists: true,
       last_run: moment(),
@@ -151,7 +151,7 @@ module('Acceptance | repo settings', function (hooks) {
 
     const settingToRequestBody = {};
 
-    server.patch(`/repo/${this.repository.id}/setting/:setting`, function (schema, request) {
+    this.server.patch(`/repo/${this.repository.id}/setting/:setting`, function (schema, request) {
       settingToRequestBody[request.params.setting] = JSON.parse(request.requestBody);
     });
 
@@ -182,19 +182,19 @@ module('Acceptance | repo settings', function (hooks) {
 
     const deletedIds = [];
 
-    server.delete('/settings/env_vars/:id', function (schema, request) {
+    this.server.delete('/settings/env_vars/:id', function (schema, request) {
       deletedIds.push(request.params.id);
     });
 
     await settingsPage.environmentVariables[0].delete();
 
-    assert.equal(deletedIds.pop(), 'a', 'expected the server to have received a deletion request for the first environment variable');
+    assert.equal(deletedIds.pop(), 'a', 'expected the this.server to have received a deletion request for the first environment variable');
     assert.equal(settingsPage.environmentVariables.length, 1, 'expected only one environment variable to remain');
     assert.equal(settingsPage.environmentVariables[0].name, 'published', 'expected the formerly-second variable to be first');
 
     let requestBodies = [];
 
-    server.post('/settings/env_vars', function (schema, request) {
+    this.server.post('/settings/env_vars', function (schema, request) {
       const parsedRequestBody = JSON.parse(request.requestBody);
       parsedRequestBody.env_var.id = '1919';
       requestBodies.push(parsedRequestBody);
@@ -225,7 +225,7 @@ module('Acceptance | repo settings', function (hooks) {
     // This will save env var with branch
     requestBodies = [];
 
-    server.post('/settings/env_vars', function (schema, request) {
+    this.server.post('/settings/env_vars', function (schema, request) {
       const parsedRequestBody = JSON.parse(request.requestBody);
       parsedRequestBody.env_var.id = '1920';
       requestBodies.push(parsedRequestBody);
@@ -234,7 +234,7 @@ module('Acceptance | repo settings', function (hooks) {
 
     let branchName = 'foo';
 
-    server.create('branch', {
+    this.server.create('branch', {
       name: branchName,
       id: `/v3/repo/${this.repository.id}/branch/food`,
       exists_on_github: true,
@@ -262,7 +262,7 @@ module('Acceptance | repo settings', function (hooks) {
     } });
 
     // This will trigger a client-side error
-    server.post('/settings/env_vars', () => new Response(403, {}, {}));
+    this.server.post('/settings/env_vars', () => new Response(403, {}, {}));
 
     await settingsPage.environmentVariableForm.fillName('willFail');
     await settingsPage.environmentVariableForm.fillValue('true');
@@ -271,14 +271,14 @@ module('Acceptance | repo settings', function (hooks) {
     assert.equal(topPage.flashMessage.text, 'There was an error saving this environment variable.');
 
     // This will cause deletions to fail
-    server.delete('/settings/env_vars/:id', () => new Response(500, {}, {}));
+    this.server.delete('/settings/env_vars/:id', () => new Response(500, {}, {}));
 
     await settingsPage.environmentVariables[1].delete();
 
     assert.equal(settingsPage.environmentVariables.length, 3, 'expected the environment variable to remain');
     assert.equal(topPage.flashMessage.text, 'There was an error deleting this environment variable.');
 
-    server.delete('/settings/env_vars/:id', () => new Response(404, {}, {}));
+    this.server.delete('/settings/env_vars/:id', () => new Response(404, {}, {}));
 
     await settingsPage.environmentVariables[1].delete();
 
@@ -293,7 +293,7 @@ module('Acceptance | repo settings', function (hooks) {
 
     const deletedIds = [];
 
-    server.delete('/cron/:id', function (schema, request) {
+    this.server.delete('/cron/:id', function (schema, request) {
       deletedIds.push(request.params.id);
       schema.db.crons.remove(request.params.id);
       return {};
@@ -301,7 +301,7 @@ module('Acceptance | repo settings', function (hooks) {
 
     await settingsPage.crons[0].delete();
 
-    assert.equal(deletedIds.pop(), this.dailyCron.id, 'expected the server to have received a deletion request for the first cron');
+    assert.equal(deletedIds.pop(), this.dailyCron.id, 'expected the this.server to have received a deletion request for the first cron');
     assert.equal(settingsPage.crons.length, 1, 'expected only one cron to remain');
     done();
   });
@@ -309,7 +309,7 @@ module('Acceptance | repo settings', function (hooks) {
   test('create a new cron', async function (assert) {
     let branchName = 'foo';
 
-    server.create('branch', {
+    this.server.create('branch', {
       name: branchName,
       id: `/v3/repo/${this.repository.id}/branch/food`,
       exists_on_github: true,
@@ -329,13 +329,13 @@ module('Acceptance | repo settings', function (hooks) {
 
     const deletedIds = [];
 
-    server.delete('/settings/ssh_key/:id', function (schema, request) {
+    this.server.delete('/settings/ssh_key/:id', function (schema, request) {
       deletedIds.push(request.params.id);
     });
 
     await settingsPage.sshKey.delete();
 
-    assert.equal(deletedIds.pop(), this.repository.id, 'expected the server to have received a deletion request for the SSH key');
+    assert.equal(deletedIds.pop(), this.repository.id, 'expected the this.server to have received a deletion request for the SSH key');
 
     assert.equal(settingsPage.sshKey.name, 'Default');
     assert.equal(settingsPage.sshKey.fingerprint, 'aa:bb:cc:dd');
@@ -343,15 +343,15 @@ module('Acceptance | repo settings', function (hooks) {
   });
 
   test('add SSH key', async function (assert) {
-    server.schema.db.sshKeys.remove();
+    this.server.schema.db.sshKeys.remove();
 
     const requestBodies = [];
 
-    server.get(`/settings/ssh_key/${this.repository.id}`, function (schema, request) {
+    this.server.get(`/settings/ssh_key/${this.repository.id}`, function (schema, request) {
       return new Response(429, {}, {});
     });
 
-    server.patch(`/settings/ssh_key/${this.repository.id}`, (schema, request) => {
+    this.server.patch(`/settings/ssh_key/${this.repository.id}`, (schema, request) => {
       const newKey = JSON.parse(request.requestBody);
       requestBodies.push(newKey);
       newKey.id = this.repository.id;
@@ -375,7 +375,7 @@ module('Acceptance | repo settings', function (hooks) {
   });
 
   test('the SSH key section is hidden for public repositories', async function (assert) {
-    server.get(`/repos/${this.repository.id}/key`, (s, r) => new Response(404, {}, {}));
+    this.server.get(`/repos/${this.repository.id}/key`, (s, r) => new Response(404, {}, {}));
     this.repository.private = false;
     await settingsPage.visit({ organization: 'org-login', repo: 'repository-name' });
 
@@ -401,7 +401,7 @@ module('Acceptance | repo settings', function (hooks) {
 
     const settingToRequestBody = {};
 
-    server.patch(`/repo/${this.repository.id}/setting/:setting`, function (schema, request) {
+    this.server.patch(`/repo/${this.repository.id}/setting/:setting`, function (schema, request) {
       settingToRequestBody[request.params.setting] = JSON.parse(request.requestBody);
     });
 
@@ -428,7 +428,7 @@ module('Acceptance | repo settings', function (hooks) {
 
     const settingToRequestBody = {};
 
-    server.patch(`/repo/${this.repository.id}/setting/:setting`, function (schema, request) {
+    this.server.patch(`/repo/${this.repository.id}/setting/:setting`, function (schema, request) {
       settingToRequestBody[request.params.setting] = JSON.parse(request.requestBody);
     });
 

--- a/tests/acceptance/repo/show-public-repo-test.js
+++ b/tests/acceptance/repo/show-public-repo-test.js
@@ -8,7 +8,7 @@ module('Acceptance | subscribing pusher to public repo', function (hooks) {
   setupApplicationTest(hooks);
 
   test('viewing public repo results in a repo pusher channel', async function (assert) {
-    const repo = server.create('repository', {
+    const repo = this.server.create('repository', {
       slug: 'musterfrau/a-repo',
       private: false
     });
@@ -24,15 +24,15 @@ module('Acceptance | subscribing pusher to public repo', function (hooks) {
   });
 
   skip('viewing public repo as a signed in collaborator does not trigger subscription', async function (assert) {
-    const user = server.create('user', {
+    const user = this.server.create('user', {
       name: 'Travis CI',
       login: 'travisci',
     });
-    const repository = server.create('repository', {
+    const repository = this.server.create('repository', {
       slug: 'musterfrau/a-repo',
       private: false
     });
-    server.create('permission', { user, repository, push: true });
+    this.server.create('permission', { user, repository, push: true });
 
     signInUser(user);
 
@@ -46,15 +46,15 @@ module('Acceptance | subscribing pusher to public repo', function (hooks) {
   });
 
   test('viewing public repo as a signed in user triggers subscription', async function (assert) {
-    const user = server.create('user', {
+    const user = this.server.create('user', {
       name: 'Travis CI',
       login: 'travisci',
     });
-    const repository = server.create('repository', {
+    const repository = this.server.create('repository', {
       slug: 'musterfrau/a-repo',
       private: false
     });
-    server.schema.permissions.all().destroy();
+    this.server.schema.permissions.all().destroy();
 
     signInUser(user);
 

--- a/tests/acceptance/repo/show-public-repo-test.js
+++ b/tests/acceptance/repo/show-public-repo-test.js
@@ -3,9 +3,11 @@ import { setupApplicationTest } from 'travis/tests/helpers/setup-application-tes
 import { settled, getContext } from '@ember/test-helpers';
 import page from 'travis/tests/pages/repo-not-active';
 import signInUser from 'travis/tests/helpers/sign-in-user';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | subscribing pusher to public repo', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   test('viewing public repo results in a repo pusher channel', async function (assert) {
     const repo = this.server.create('repository', {

--- a/tests/acceptance/repo/show-test.js
+++ b/tests/acceptance/repo/show-test.js
@@ -9,10 +9,10 @@ module('Acceptance | show repo page', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(function () {
-    const currentUser = server.create('user', {login: 'user-login'});
+    const currentUser = this.server.create('user', {login: 'user-login'});
     signInUser(currentUser);
 
-    const repo = server.create('repository', {
+    const repo = this.server.create('repository', {
       name: 'repository-name',
       slug: 'org-login/repository-name',
       owner: {
@@ -32,20 +32,20 @@ module('Acceptance | show repo page', function (hooks) {
       default_branch: false
     });
 
-    let gitUser = server.create('git-user', { name: 'Mr T' });
-    let commit = server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
-    let build = server.create('build', { repository: repo, state: 'passed', commit_id: commit.id, commit, branch, finished_at: new Date() });
+    let gitUser = this.server.create('git-user', { name: 'Mr T' });
+    let commit = this.server.create('commit', { author: gitUser, committer: gitUser, branch: 'acceptance-tests', message: 'This is a message', branch_is_default: true });
+    let build = this.server.create('build', { repository: repo, state: 'passed', commit_id: commit.id, commit, branch, finished_at: new Date() });
 
-    let firstJob = server.create('job', { number: '1234.1', repository: repo, state: 'passed', config: { env: 'JORTS', os: 'linux', language: 'node_js', node_js: 5 }, commit, build });
+    let firstJob = this.server.create('job', { number: '1234.1', repository: repo, state: 'passed', config: { env: 'JORTS', os: 'linux', language: 'node_js', node_js: 5 }, commit, build });
     commit.job = firstJob;
 
     firstJob.save();
     commit.save();
 
-    server.create('job', { number: '1234.2', repository: repo, state: 'passed', config: { env: 'JANTS', os: 'osx', language: 'ruby', rvm: 2.2 }, commit, build });
-    server.create('job', { allow_failure: true, number: '1234.999', repository: repo, state: 'failed', config: { language: 'ruby', os: 'jorts' }, commit, build });
+    this.server.create('job', { number: '1234.2', repository: repo, state: 'passed', config: { env: 'JANTS', os: 'osx', language: 'ruby', rvm: 2.2 }, commit, build });
+    this.server.create('job', { allow_failure: true, number: '1234.999', repository: repo, state: 'failed', config: { language: 'ruby', os: 'jorts' }, commit, build });
 
-    let otherRepository = server.create('repository', {
+    let otherRepository = this.server.create('repository', {
       name: 'other-repository',
       slug: 'org-login/other-repository',
       owner: {
@@ -59,7 +59,7 @@ module('Acceptance | show repo page', function (hooks) {
       default_branch: true
     });
 
-    let otherCommit = server.create('commit', {
+    let otherCommit = this.server.create('commit', {
       author: gitUser,
       committer: gitUser,
       branch: 'other-tests',
@@ -67,7 +67,7 @@ module('Acceptance | show repo page', function (hooks) {
       branch_is_default: true
     });
 
-    let otherBuild = server.create('build', {
+    let otherBuild = this.server.create('build', {
       repository: otherRepository,
       state: 'failed',
       commit_id: commit.id,
@@ -76,7 +76,7 @@ module('Acceptance | show repo page', function (hooks) {
       finished_at: new Date(1919, 4, 1),
     });
 
-    let otherJob = server.create('job', {
+    let otherJob = this.server.create('job', {
       number: '1919.1919',
       repository: otherRepository,
       state: 'failed',

--- a/tests/acceptance/repo/show-test.js
+++ b/tests/acceptance/repo/show-test.js
@@ -4,9 +4,11 @@ import { setupApplicationTest } from 'travis/tests/helpers/setup-application-tes
 import page from 'travis/tests/pages/repo/show';
 import buildPage from 'travis/tests/pages/build';
 import signInUser from 'travis/tests/helpers/sign-in-user';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | show repo page', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
     const currentUser = this.server.create('user', {login: 'user-login'});

--- a/tests/acceptance/repo/trigger-build-test.js
+++ b/tests/acceptance/repo/trigger-build-test.js
@@ -12,12 +12,12 @@ module('Acceptance | repo/trigger build', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(function () {
-    this.currentUser = server.create('user', {
+    this.currentUser = this.server.create('user', {
       name: 'Ada Lovelace',
       login: 'adal',
     });
 
-    this.repo = server.create('repository', {
+    this.repo = this.server.create('repository', {
       name: 'difference-engine',
       slug: 'adal/difference-engine',
       permissions: {
@@ -27,7 +27,7 @@ module('Acceptance | repo/trigger build', function (hooks) {
 
     const repoId = parseInt(this.repo.id);
 
-    const defaultBranch = server.create('branch', {
+    const defaultBranch = this.server.create('branch', {
       name: 'master',
       id: `/v3/repo/${repoId}/branch/master`,
       default_branch: true,
@@ -45,7 +45,7 @@ module('Acceptance | repo/trigger build', function (hooks) {
       sha: 'c0ffee'
     });
 
-    server.create('branch', {
+    this.server.create('branch', {
       name: 'deleted',
       id: `/v3/repo/${repoId}/branch/deleted`,
       default_branch: false,
@@ -114,7 +114,7 @@ module('Acceptance | repo/trigger build', function (hooks) {
   });
 
   test('an error triggering a build is displayed', async function (assert) {
-    server.post('/repo/:repo_id/requests', function (schema, request) {
+    this.server.post('/repo/:repo_id/requests', function (schema, request) {
       return new Response(500, {}, {});
     });
 
@@ -126,7 +126,7 @@ module('Acceptance | repo/trigger build', function (hooks) {
   });
 
   test('a 429 shows a specific error message', async function (assert) {
-    server.post('/repo/:repo_id/requests', function (schema, request) {
+    this.server.post('/repo/:repo_id/requests', function (schema, request) {
       return new Response(429, {}, {});
     });
 

--- a/tests/acceptance/repo/trigger-build-test.js
+++ b/tests/acceptance/repo/trigger-build-test.js
@@ -7,9 +7,11 @@ import { Response } from 'ember-cli-mirage';
 import signInUser from 'travis/tests/helpers/sign-in-user';
 import { enableFeature } from 'ember-feature-flags/test-support';
 import { percySnapshot } from 'ember-percy';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | repo/trigger build', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
     this.currentUser = this.server.create('user', {

--- a/tests/acceptance/repo/view-migrated-test.js
+++ b/tests/acceptance/repo/view-migrated-test.js
@@ -10,14 +10,14 @@ module('Acceptance | repo/view migrated', function (hooks) {
   test('viewing migrated repository on com shows banner', async function (assert) {
     enableFeature('proVersion');
 
-    const user = server.create('user', {
+    const user = this.server.create('user', {
       name: 'Erika Musterfrau',
       login: 'musterfrau'
     });
 
     await signInUser(user);
 
-    const repository = server.create('repository', {
+    const repository = this.server.create('repository', {
       slug: 'musterfrau/a-repo',
       active: true,
       active_on_org: false,
@@ -33,14 +33,14 @@ module('Acceptance | repo/view migrated', function (hooks) {
   });
 
   test('viewing migrated repository on org shows banner', async function (assert) {
-    const user = server.create('user', {
+    const user = this.server.create('user', {
       name: 'Erika Musterfrau',
       login: 'musterfrau'
     });
 
     await signInUser(user);
 
-    const repository = server.create('repository', {
+    const repository = this.server.create('repository', {
       slug: 'musterfrau/a-repo',
       active: false,
       active_on_org: false,

--- a/tests/acceptance/repo/view-migrated-test.js
+++ b/tests/acceptance/repo/view-migrated-test.js
@@ -3,9 +3,11 @@ import { visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'travis/tests/helpers/setup-application-test';
 import { enableFeature } from 'ember-feature-flags/test-support';
 import signInUser from 'travis/tests/helpers/sign-in-user';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | repo/view migrated', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   test('viewing migrated repository on com shows banner', async function (assert) {
     enableFeature('proVersion');

--- a/tests/acceptance/search/flow-test.js
+++ b/tests/acceptance/search/flow-test.js
@@ -3,9 +3,11 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'travis/tests/helpers/setup-application-test';
 import sidebarPage from 'travis/tests/pages/sidebar';
 import signInUser from 'travis/tests/helpers/sign-in-user';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | search/flow', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   test('searching from index page transitions to search page', async function (assert) {
     const currentUser = this.server.create('user');

--- a/tests/acceptance/search/flow-test.js
+++ b/tests/acceptance/search/flow-test.js
@@ -8,10 +8,10 @@ module('Acceptance | search/flow', function (hooks) {
   setupApplicationTest(hooks);
 
   test('searching from index page transitions to search page', async function (assert) {
-    const currentUser = server.create('user');
+    const currentUser = this.server.create('user');
     signInUser(currentUser);
 
-    server.create('repository');
+    this.server.create('repository');
 
     await sidebarPage
       .visit()

--- a/tests/acceptance/search/no-results-test.js
+++ b/tests/acceptance/search/no-results-test.js
@@ -8,7 +8,7 @@ module('Acceptance | search/no results', function (hooks) {
   setupApplicationTest(hooks);
 
   test('visiting /search/no-results', async function (assert) {
-    const currentUser = server.create('user');
+    const currentUser = this.server.create('user');
     signInUser(currentUser);
 
     await visit('/search/no-results');

--- a/tests/acceptance/search/no-results-test.js
+++ b/tests/acceptance/search/no-results-test.js
@@ -3,9 +3,11 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'travis/tests/helpers/setup-application-test';
 import sidebarPage from 'travis/tests/pages/sidebar';
 import signInUser from 'travis/tests/helpers/sign-in-user';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | search/no results', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   test('visiting /search/no-results', async function (assert) {
     const currentUser = this.server.create('user');

--- a/tests/acceptance/sign-in-test.js
+++ b/tests/acceptance/sign-in-test.js
@@ -4,9 +4,11 @@ import { setupApplicationTest } from 'travis/tests/helpers/setup-application-tes
 import Service from '@ember/service';
 import signInUser from 'travis/tests/helpers/sign-in-user';
 import { stubService } from 'travis/tests/helpers/stub-service';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | sign in', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   test('visiting /signin starts auth flow if unauthenticated', async function (assert) {
     assert.expect(2);
@@ -33,7 +35,7 @@ module('Acceptance | sign in', function (hooks) {
   });
 
   test('visiting signin redirects to index if authenticated', async function (assert) {
-    const currentUser = server.create('user', 'withRepository');
+    const currentUser = this.server.create('user', 'withRepository');
 
     signInUser(currentUser);
 

--- a/tests/integration/components/active-repo-count-test.js
+++ b/tests/integration/components/active-repo-count-test.js
@@ -3,9 +3,11 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, settled, waitFor } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { INSIGHTS_INTERVALS } from 'travis/services/insights';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | active-repo-count', function (hooks) {
   setupRenderingTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
     const user = this.server.create('user');
@@ -17,7 +19,7 @@ module('Integration | Component | active-repo-count', function (hooks) {
   });
 
   test('it renders', async function (assert) {
-    server.createList('insight-metric', 1);
+    this.server.createList('insight-metric', 1);
 
     await render(hbs`{{active-repo-count interval=interval owner=ownerData private=private}}`);
     await settled();

--- a/tests/integration/components/add-env-var-test.js
+++ b/tests/integration/components/add-env-var-test.js
@@ -7,12 +7,14 @@ import hbs from 'htmlbars-inline-precompile';
 import DS from 'ember-data';
 import { percySnapshot } from 'ember-percy';
 import { selectChoose, selectSearch } from 'ember-power-select/test-support';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | add env-var', function (hooks) {
   setupRenderingTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    const repository = server.create('repository', {
+    const repository = this.server.create('repository', {
       name: 'repository-name',
       slug: 'org-login/repository-name',
       private: true
@@ -134,7 +136,7 @@ module('Integration | Component | add env-var', function (hooks) {
 
     let branchName = 'foo';
 
-    server.create('branch', {
+    this.server.create('branch', {
       name: branchName,
       id: `/v3/repo/${this.repository.id}/branch/food`,
       exists_on_github: true,
@@ -181,7 +183,7 @@ module('Integration | Component | add env-var', function (hooks) {
 
     let branchName = 'foo';
 
-    server.create('branch', {
+    this.server.create('branch', {
       name: branchName,
       id: `/v3/repo/${this.repository.id}/branch/food`,
       exists_on_github: true,

--- a/tests/integration/components/billing-summary-status-test.js
+++ b/tests/integration/components/billing-summary-status-test.js
@@ -3,9 +3,11 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import profilePage from 'travis/tests/pages/profile';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | billing-summary-status', function (hooks) {
   setupRenderingTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
     this.subscription = {

--- a/tests/integration/components/billing-summary-status-test.js
+++ b/tests/integration/components/billing-summary-status-test.js
@@ -3,11 +3,9 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import profilePage from 'travis/tests/pages/profile';
-import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | billing-summary-status', function (hooks) {
   setupRenderingTest(hooks);
-  setupMirage(hooks);
 
   hooks.beforeEach(function () {
     this.subscription = {

--- a/tests/integration/components/billing/invoices-test.js
+++ b/tests/integration/components/billing/invoices-test.js
@@ -3,13 +3,14 @@ import { setupRenderingTest } from 'ember-qunit';
 import profilePage from 'travis/tests/pages/profile';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | billing-invoices', function (hooks) {
   setupRenderingTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
-
-    const user = server.create('user', {
+    const user = this.server.create('user', {
       name: 'User Name of exceeding length',
       type: 'user',
       login: 'user-login',
@@ -20,7 +21,7 @@ module('Integration | Component | billing-invoices', function (hooks) {
       }
     });
 
-    const plan = server.create('plan', {
+    const plan = this.server.create('plan', {
       name: 'Small Business Plan',
       builds: 5,
       annual: false,
@@ -28,7 +29,7 @@ module('Integration | Component | billing-invoices', function (hooks) {
       price: 6900
     });
 
-    const subscription = server.create('subscription', {
+    const subscription = this.server.create('subscription', {
       plan,
       owner: user,
       status: 'subscribed',

--- a/tests/integration/components/billing/payment-test.js
+++ b/tests/integration/components/billing/payment-test.js
@@ -6,9 +6,11 @@ import StripeMock from 'travis/tests/helpers/stripe-mock';
 import { stubConfig } from 'travis/tests/helpers/stub-service';
 import { getContext } from '@ember/test-helpers';
 import profilePage from 'travis/tests/pages/profile';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | billing-payment', function (hooks) {
   setupRenderingTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
 
@@ -70,7 +72,7 @@ module('Integration | Component | billing-payment', function (hooks) {
 
   test('billing-payment renders correctly', async function (assert) {
 
-    await render(hbs`<Billing::Payment 
+    await render(hbs`<Billing::Payment
       @paymentInfo={{paymentInfo}}
       @newSubscription={{newSubscription}}
       @cancel={{action 'cancel'}}

--- a/tests/integration/components/billing/select-plan-test.js
+++ b/tests/integration/components/billing/select-plan-test.js
@@ -3,9 +3,11 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import profilePage from 'travis/tests/pages/profile';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | billing-select-plan', function (hooks) {
   setupRenderingTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
 
@@ -41,8 +43,8 @@ module('Integration | Component | billing-select-plan', function (hooks) {
 
   test('it renders default selected plan', async function (assert) {
 
-    await render(hbs`<Billing::SelectPlan 
-      @displayedPlans={{displayedPlans}} 
+    await render(hbs`<Billing::SelectPlan
+      @displayedPlans={{displayedPlans}}
       @selectedPlan={{selectedPlan}}
       @showMonthly={{this.showMonthly}}
       @showAnnual={{this.showAnnual}}
@@ -59,8 +61,8 @@ module('Integration | Component | billing-select-plan', function (hooks) {
     this.set('showAnnual', true);
     this.set('showMonthly', false);
 
-    await render(hbs`<Billing::SelectPlan 
-      @displayedPlans={{displayedPlans}} 
+    await render(hbs`<Billing::SelectPlan
+      @displayedPlans={{displayedPlans}}
       @selectedPlan={{selectedPlan}}
       @showMonthly={{this.showMonthly}}
       @showAnnual={{this.showAnnual}}

--- a/tests/integration/components/billing/summary-test.js
+++ b/tests/integration/components/billing/summary-test.js
@@ -4,9 +4,12 @@ import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import profilePage from 'travis/tests/pages/profile';
 import moment from 'moment';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | billing-summary', function (hooks) {
   setupRenderingTest(hooks);
+  setupMirage(hooks);
+
   hooks.beforeEach(function () {
     const plan = {
       id: 1,
@@ -48,7 +51,7 @@ module('Integration | Component | billing-summary', function (hooks) {
   test('it renders active subscription', async function (assert) {
     const date = moment(this.subscription.validTo.getTime()).format('MMMM D, YYYY');
 
-    await render(hbs`<Billing::Summary 
+    await render(hbs`<Billing::Summary
       @subscription={{subscription}}
       @account={{account}}
       @planMessage={{planMessage}}
@@ -73,7 +76,7 @@ module('Integration | Component | billing-summary', function (hooks) {
     });
     this.set('planMessage', 'Expires');
 
-    await render(hbs`<Billing::Summary 
+    await render(hbs`<Billing::Summary
       @subscription={{subscription}}
       @account={{account}}
       @planMessage={{planMessage}}
@@ -98,7 +101,7 @@ module('Integration | Component | billing-summary', function (hooks) {
     });
     this.set('planMessage', 'Expired');
 
-    await render(hbs`<Billing::Summary 
+    await render(hbs`<Billing::Summary
       @subscription={{subscription}}
       @account={{account}}
       @planMessage={{planMessage}}
@@ -121,7 +124,7 @@ module('Integration | Component | billing-summary', function (hooks) {
     });
     this.set('planMessage', 'Expired');
 
-    await render(hbs`<Billing::Summary 
+    await render(hbs`<Billing::Summary
       @subscription={{subscription}}
       @account={{account}}
       @isPending={{isPending}}
@@ -142,7 +145,7 @@ module('Integration | Component | billing-summary', function (hooks) {
     });
     this.set('planMessage', 'Incomplete');
 
-    await render(hbs`<Billing::Summary 
+    await render(hbs`<Billing::Summary
       @subscription={{subscription}}
       @account={{account}}
       @planMessage={{planMessage}}

--- a/tests/integration/components/branch-row-test.js
+++ b/tests/integration/components/branch-row-test.js
@@ -3,9 +3,11 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | branch row', function (hooks) {
   setupRenderingTest(hooks);
+  setupMirage(hooks);
 
   test('it renders data correctly', async function (assert) {
     const branch = EmberObject.create({

--- a/tests/integration/components/build-count-test.js
+++ b/tests/integration/components/build-count-test.js
@@ -3,10 +3,11 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, settled, waitFor } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { INSIGHTS_INTERVALS } from 'travis/services/insights';
-
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | build-count', function (hooks) {
   setupRenderingTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
     const user = this.server.create('user');

--- a/tests/integration/components/build-minutes-test.js
+++ b/tests/integration/components/build-minutes-test.js
@@ -3,9 +3,11 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, settled, waitFor } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { INSIGHTS_INTERVALS } from 'travis/services/insights';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | build-minutes', function (hooks) {
   setupRenderingTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
     const user = this.server.create('user');

--- a/tests/integration/components/build-status-chart-test.js
+++ b/tests/integration/components/build-status-chart-test.js
@@ -3,9 +3,11 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, settled, waitFor } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { INSIGHTS_INTERVALS } from 'travis/services/insights';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | build-status-chart', function (hooks) {
   setupRenderingTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
     const [user1, user2] = this.server.createList('user', 2);

--- a/tests/integration/components/email-unsubscribe-test.js
+++ b/tests/integration/components/email-unsubscribe-test.js
@@ -3,6 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 import {
   EMAIL_UNSUBSCRIBE,
@@ -14,9 +15,10 @@ import {
 
 module('Integration | Component | email-unsubscribe', function (hooks) {
   setupRenderingTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(async function () {
-    const repo = server.create('repository');
+    const repo = this.server.create('repository');
     repo.isCurrentUserACollaborator = true;
 
     const routerStub = Service.extend({

--- a/tests/integration/components/enterprise-banner-test.js
+++ b/tests/integration/components/enterprise-banner-test.js
@@ -2,9 +2,11 @@ import hbs from 'htmlbars-inline-precompile';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, settled } from '@ember/test-helpers';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | enterprise banner', function (hooks) {
   setupRenderingTest(hooks);
+  setupMirage(hooks);
 
   test('renders trial banner unexpired', async function (assert) {
     this.server.get('/v3/enterprise_license', (schema, response) => {

--- a/tests/integration/components/env-var-test.js
+++ b/tests/integration/components/env-var-test.js
@@ -4,9 +4,11 @@ import { setupRenderingTest } from 'ember-qunit';
 import { click, render, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import DS from 'ember-data';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | env-var', function (hooks) {
   setupRenderingTest(hooks);
+  setupMirage(hooks);
 
   test('it renders an env-var with private value', async function (assert) {
     assert.expect(2);

--- a/tests/integration/components/insights-overlay-test.js
+++ b/tests/integration/components/insights-overlay-test.js
@@ -6,9 +6,11 @@ import {
   DEFAULT_INSIGHTS_INTERVAL,
   INSIGHTS_INTERVALS
 } from 'travis/services/insights';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | insights-overlay', function (hooks) {
   setupRenderingTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
     const user = this.server.create('user');

--- a/tests/integration/components/pagination-navigation-test.js
+++ b/tests/integration/components/pagination-navigation-test.js
@@ -2,9 +2,11 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | pagination navigation', function (hooks) {
   setupRenderingTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
     this.owner.lookup('router:main').startRouting(true);

--- a/tests/integration/components/queue-times-test.js
+++ b/tests/integration/components/queue-times-test.js
@@ -3,9 +3,11 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, settled, waitFor } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { INSIGHTS_INTERVALS } from 'travis/services/insights';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | queue-times', function (hooks) {
   setupRenderingTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
     const user = this.server.create('user');

--- a/tests/integration/components/repository-status-toggle-test.js
+++ b/tests/integration/components/repository-status-toggle-test.js
@@ -3,9 +3,11 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { Response } from 'ember-cli-mirage';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('RepositoryStatusToggleComponent', function (hooks) {
   setupRenderingTest(hooks);
+  setupMirage(hooks);
 
   test('it switches state when clicked', async function (assert) {
     this.set('repository', {
@@ -46,7 +48,7 @@ module('RepositoryStatusToggleComponent', function (hooks) {
 
     this.set('repository', repo);
 
-    server.post('/repo/:id/activate', (schema, request) => {
+    this.server.post('/repo/:id/activate', (schema, request) => {
       return new Response(409, {}, {});
     });
 
@@ -77,7 +79,7 @@ module('RepositoryStatusToggleComponent', function (hooks) {
 
     this.set('repository', repo);
 
-    server.post('/repo/:id/activate', (schema, request) => {
+    this.server.post('/repo/:id/activate', (schema, request) => {
       return new Response(404, {}, {});
     });
 

--- a/tests/integration/components/travis-status-test.js
+++ b/tests/integration/components/travis-status-test.js
@@ -4,9 +4,11 @@ import { render, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import config from 'travis/config/environment';
 import { Response } from 'ember-cli-mirage';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | travis-status', function (hooks) {
   setupRenderingTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
     config.statusPageStatusUrl = 'https://pnpcptp8xh9k.statuspage.io/api/v2/status.json';

--- a/tests/integration/components/trigger-custom-build-test.js
+++ b/tests/integration/components/trigger-custom-build-test.js
@@ -2,17 +2,19 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Integration | Component | trigger custom build', function (hooks) {
   setupRenderingTest(hooks);
+  setupMirage(hooks);
 
   test('it renders', async function (assert) {
-    const branch = server.create('branch', {
+    const branch = this.server.create('branch', {
       name: 'master',
       default: true,
       exists_on_github: true
     });
-    const repo = server.create('repo', {
+    const repo = this.server.create('repo', {
       id: 22,
       defaultBranch: branch
     });

--- a/tests/unit/services/gtm-test.js
+++ b/tests/unit/services/gtm-test.js
@@ -4,9 +4,11 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'travis/tests/helpers/setup-application-test';
 import signInUser from 'travis/tests/helpers/sign-in-user';
 import { stubService } from 'travis/tests/helpers/stub-service';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Acceptance | auth/call gtm', function (hooks) {
   setupApplicationTest(hooks);
+  setupMirage(hooks);
 
   let callCounter = 0;
 
@@ -17,7 +19,7 @@ module('Acceptance | auth/call gtm', function (hooks) {
   });
 
   hooks.beforeEach(function () {
-    this.currentUser = server.create('user');
+    this.currentUser = this.server.create('user');
     signInUser(this.currentUser);
     stubService('metrics', gtmServiceStub);
   });

--- a/tests/unit/services/insights-test.js
+++ b/tests/unit/services/insights-test.js
@@ -1,8 +1,10 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { setupMirage } from 'ember-cli-mirage/test-support';
 
 module('Unit | Service | insights', function (hooks) {
   setupTest(hooks);
+  setupMirage(hooks);
 
   hooks.beforeEach(function () {
     this.insightsService = this.owner.lookup('service:insights');
@@ -42,7 +44,7 @@ module('Unit | Service | insights', function (hooks) {
 
   test('active repos', async function (assert) {
     const user = this.server.create('user');
-    server.createList('insight-metric', 1);
+    this.server.createList('insight-metric', 1);
 
     let result = await this.insightsService.getActiveRepos(user, 'week');
     assert.equal(result.data.count, 75);
@@ -65,7 +67,7 @@ module('Unit | Service | insights', function (hooks) {
 
   test('metric sum', async function (assert) {
     const user = this.server.create('user');
-    server.createList('insight-metric', 5);
+    this.server.createList('insight-metric', 5);
     const metricName = 'count_started';
 
     let result = await this.insightsService.getChartData.perform(
@@ -82,7 +84,7 @@ module('Unit | Service | insights', function (hooks) {
 
   test('metric max', async function (assert) {
     const user = this.server.create('user');
-    server.createList('insight-metric', 10);
+    this.server.createList('insight-metric', 10);
     const metricName = 'count_finished';
 
     let result = await this.insightsService.getChartData.perform(
@@ -99,7 +101,7 @@ module('Unit | Service | insights', function (hooks) {
 
   test('metric avg', async function (assert) {
     const user = this.server.create('user');
-    server.createList('insight-metric', 10);
+    this.server.createList('insight-metric', 10);
     const metricName = 'count_passed';
 
     let result = await this.insightsService.getChartData.perform(
@@ -119,7 +121,7 @@ module('Unit | Service | insights', function (hooks) {
 
   test('metric count', async function (assert) {
     const user = this.server.create('user');
-    server.createList('insight-metric', 10);
+    this.server.createList('insight-metric', 10);
     const metricName = 'count_failed';
 
     let result = await this.insightsService.getChartData.perform(
@@ -136,7 +138,7 @@ module('Unit | Service | insights', function (hooks) {
 
   test('metric options', async function (assert) {
     const user = this.server.create('user');
-    server.createList('insight-metric', 10);
+    this.server.createList('insight-metric', 10);
     const metricNames = ['test', 'example'];
 
     let result = await this.insightsService.getChartData.perform(


### PR DESCRIPTION
This option is apparently still working, but [no longer documented](https://www.ember-cli-mirage.com/docs/advanced/environment-options). I think it's better to be explicit about which components access the network.