### PR TITLE
Ensure feature flags are removed on signout

### DIFF
--- a/app/services/auth.js
+++ b/app/services/auth.js
@@ -71,8 +71,10 @@ export default Service.extend({
   redirectUrl: null,
 
   signOut(runTeardown = true) {
-    this.localStorage.clearAuthData();
-    this.sessionStorage.clearAuthData();
+    [this.localStorage, this.sessionStorage].map(storage => {
+      storage.clearAuthData();
+      storage.clearPreferencesData();
+    });
 
     this.setProperties({
       state: STATE.SIGNED_OUT,

--- a/app/services/auth.js
+++ b/app/services/auth.js
@@ -71,7 +71,7 @@ export default Service.extend({
   redirectUrl: null,
 
   signOut(runTeardown = true) {
-    [this.localStorage, this.sessionStorage].map(storage => {
+    [this.localStorage, this.sessionStorage].forEach(storage => {
       storage.clearAuthData();
       storage.clearPreferencesData();
     });

--- a/app/services/storage.js
+++ b/app/services/storage.js
@@ -68,6 +68,10 @@ export default Service.extend({
     this.removeItem('travis.auth.become');
   },
 
+  clearPreferencesData() {
+    this.removeItem('travis.features');
+  },
+
   clearBillingData() {
     this.storage.removeItem('travis.billing_step');
     this.storage.removeItem('travis.billing_plan');


### PR DESCRIPTION
Feature flags are cached for performance reasons in local storage. Currently, when you log out, these are not cleared. If you're logged in in another browser window, these flags will never be updated, as we assume they haven't changed, so you'll have to repeat the action.

With this PR, this data is cleared, meaning that when you make an update in one browser window and log out, you'll get the desired settings upon your next login.