### PR TITLE
Fix repo setting fetching for unauthorized users

### DIFF
--- a/app/mixins/components/with-config-validation.js
+++ b/app/mixins/components/with-config-validation.js
@@ -1,14 +1,17 @@
 import Mixin from '@ember/object/mixin';
-import { gt, reads } from '@ember/object/computed';
+import { and, gt, reads } from '@ember/object/computed';
 import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default Mixin.create({
+  auth: service(),
+
   messages: null,
   repo: null,
 
   hasMessages: gt('messages.length', 0),
 
-  isConfigValidationEnabled: reads('repo.settings.config_validation'),
+  isConfigValidationEnabled: and('auth.signedIn', 'repo.settings.config_validation'),
 
   showConfigValidation: reads('isConfigValidationEnabled'),
 

--- a/app/models/repo.js
+++ b/app/models/repo.js
@@ -102,6 +102,7 @@ const Repo = VcsEntity.extend({
   }),
 
   fetchSettings: task(function* () {
+    if (!this.auth.signedIn) return;
     try {
       const response = yield this.api.get(`/repo/${this.id}/settings`);
       return this._convertV3SettingsToV2(response.settings);

--- a/app/models/repo.js
+++ b/app/models/repo.js
@@ -102,7 +102,7 @@ const Repo = VcsEntity.extend({
   }),
 
   fetchSettings: task(function* () {
-    if (!this.auth.signedIn) return;
+    if (!this.auth.signedIn) return {};
     try {
       const response = yield this.api.get(`/repo/${this.id}/settings`);
       return this._convertV3SettingsToV2(response.settings);


### PR DESCRIPTION
This change prevents `fetchSettings` from spamming API when user is unauthenticated