### PR TITLE
Address issue where build os icon is not aligned with other icons/text

### DIFF
--- a/app/styles/app/modules/build-header.scss
+++ b/app/styles/app/modules/build-header.scss
@@ -41,6 +41,8 @@
 
     .detail-job-os {
       grid-area: os;
+      display: flex;
+      align-items: center;
     }
 
     .detail-job-name {


### PR DESCRIPTION
It was reported that the apple logo at the bottom left of the build info box looked misaligned. For example:

https://travis-ci.com/travis-ci/dpl/jobs/280674895

Compare that with

https://so-realign-build-os-icon.test-deployments.travis-ci.com/travis-ci/dpl/jobs/280674895