### PR TITLE
[TVJ] hide behind flag

### DIFF
--- a/app/routes/travisci-vs-jenkins.js
+++ b/app/routes/travisci-vs-jenkins.js
@@ -8,7 +8,7 @@ export default TravisRoute.extend(TailwindBaseMixin, {
   features: service(),
 
   redirect() {
-    if (!this.get('features.proVersion')) {
+    if (!this.get('features.proVersion') || !this.get('features.devJenkinsPage')) {
       return this.transitionTo('/');
     }
   }

--- a/tests/acceptance/marketing/travisci-vs-jenkins-test.js
+++ b/tests/acceptance/marketing/travisci-vs-jenkins-test.js
@@ -87,6 +87,7 @@ module('Acceptance | travis vs jenkins page', function (hooks) {
   module('pro version', function (hooks) {
     hooks.beforeEach(async function () {
       enableFeature('pro-version');
+      enableFeature('dev-jenkins-page');
       await visit(PAGE_URL);
     });
 


### PR DESCRIPTION
Part of https://github.com/travis-ci/travis-web/pull/2293

With the back and forth going on about this page, I'd like to hide it behind a feature flag, and merge the epic branch into master. There are some UI kit changes in the epic branch that would be nice to have for bb integration work.