### PR TITLE
[BB] update vcs localstorage flags logic

### DIFF
--- a/app/services/feature-flags.js
+++ b/app/services/feature-flags.js
@@ -17,13 +17,19 @@ export default Service.extend({
   },
 
   _setEnableAssemblaLogin() {
-    const enableAssemblaLogin = window.localStorage['enableAssemblaLogin'] == 'true';
-    enableAssemblaLogin ? this.features.enable('enable-assembla-login') : this.features.disable('enable-assembla-login');
+    const { enableAssemblaLogin } = window.localStorage;
+    if (enableAssemblaLogin == 'true')
+      this.features.enable('enable-assembla-login');
+    else if (enableAssemblaLogin == 'false')
+      this.features.disable('enable-assembla-login');
   },
 
   _setEnableBitbucketLogin() {
-    const enableBitbucketLogin = window.localStorage['enableBitbucketLogin'] == 'true';
-    enableBitbucketLogin ? this.features.enable('enable-bitbucket-login') : this.features.disable('enable-bitbucket-login');
+    const { enableBitbucketLogin } = window.localStorage;
+    if (enableBitbucketLogin == 'true')
+      this.features.enable('enable-bitbucket-login');
+    else if (enableBitbucketLogin == 'false')
+      this.features.disable('enable-bitbucket-login');
   },
 
   _setFlagState(flag) {


### PR DESCRIPTION
Currently, the bitbucket and assembla feature flags cannot be meaningfully set via env var, because of the way the setting of the flags from localstorage works. With the current logic, unless the correct localstorage key is set to 'true', the flag is disabled upon init of the `feature-flags` service. So even if you enable it via env var, it becomes immediately disabled on initial page load. I've updated the logic to only disable if the relevant localstorage key is set to 'false'.

Ultimately, I would like to remove this stuff entirely. It's not really necessary now that we can set the flags via env var, and it doesn't really belong in the feature flags service. But since Artur Kremens team uses these localstorage flags for testing, we should possibly wait or communicate/coordinate such a change.

I would also like to at some point rename the relevant feature flags (`enable-assembla-login` and `enable-bitbucket-login`).  None of our other flags have `enable` at the front, and I think it's a bit redundant.

But for now, I have only implemented the minimum change. When you get a chance, please let me know what you think!