### PR TITLE
hide global env from jobs list

### DIFF
--- a/app/templates/build/index.hbs
+++ b/app/templates/build/index.hbs
@@ -12,10 +12,15 @@
     {{else}}
       <JobsList
         @jobs={{build.requiredJobs}}
+        @build={{build}}
         @repo={{build.repo}}
         @required={{true}}
       />
-      <JobsList @jobs={{build.allowedFailureJobs}} @repo={{build.repo}} />
+      <JobsList
+        @jobs={{build.allowedFailureJobs}}
+        @build={{build}}
+        @repo={{build.repo}}
+      />
     {{/if}}
   {{/if}}
 {{/let}}

--- a/app/templates/components/jobs-list.hbs
+++ b/app/templates/components/jobs-list.hbs
@@ -42,7 +42,7 @@
   {{/unless}}
   <ul class="jobs-list">
     {{#each this.filteredJobs as |job|}}
-      <JobsItem @job={{job}} @repo={{this.repo}} />
+      <JobsItem @job={{job}} @build={{this.build}} @repo={{this.repo}} />
     {{/each}}
   </ul>
   {{#if this.stageAllowFailuresText}}


### PR DESCRIPTION
`job.config.env` will include global env vars going foward. this makes displaying all env vars on the jobs list noisy and hard to parse.

this example build has one global env var `JOBS=1` which we want to hide from the env vars on the jobs list: https://travis-ci.org/svenfuchs/test/builds/658768955

before:

![image](https://user-images.githubusercontent.com/2208/76020282-64ed7880-5f23-11ea-914f-84f54eb7b488.png)

after:

![image](https://user-images.githubusercontent.com/2208/76020229-52733f00-5f23-11ea-8929-36e1c9a9e40a.png)
