### PR TITLE
Remove provider icon from my builds list

### DIFF
--- a/app/templates/components/my-build.hbs
+++ b/app/templates/components/my-build.hbs
@@ -18,7 +18,6 @@
           class="inner-underline"
         >
           {{this.build.repo.owner.login}}
-          <SvgImage @name={{vcs-icon this.build.repo.vcsType}} />
         </LinkTo>
       </div>
       <div class="row-content" data-test-repo-name>


### PR DESCRIPTION
When we removed the provider icon from the dashboard repositories list we forgot to remove it from my builds. So, fixed 🚀 