### PR TITLE
fix insights alignment

### DIFF
--- a/app/components/insights-overlay.js
+++ b/app/components/insights-overlay.js
@@ -35,6 +35,7 @@ export default Component.extend({
       }
     );
   }),
+
   buildData: reads('requestData.lastSuccessful.value'),
   isLoading: reads('requestData.isRunning'),
   isNotLoading: not('isLoading'),

--- a/app/styles/app/layouts/insights.scss
+++ b/app/styles/app/layouts/insights.scss
@@ -18,7 +18,7 @@ $med-small-up: "only screen and (min-width: 38em)";
   &-left {
     display: flex;
     flex-flow: column nowrap;
-    align-items: baseline;
+    align-items: center;
     padding-top: 10px;
 
     @media #{$med-small-up} {
@@ -46,7 +46,7 @@ $med-small-up: "only screen and (min-width: 38em)";
   .insights-privacy-selector {
     display: flex;
     flex-flow: row wrap;
-    align-items: baseline;
+    align-items: center;
 
     &__title {
       margin-right: 5px;


### PR DESCRIPTION
For: https://travisci.assembla.com/spaces/VCS/tickets/realtime_cardwall?ticket=137

A fix is on staging, have a look with firefox, should align properly https://staging.travis-ci.com/bitbucket/OlaTestAssembla?tab=insights&timeInterval=week