### PR TITLE
abstract the config tab route and model

### DIFF
--- a/app/components/build-layout.js
+++ b/app/components/build-layout.js
@@ -1,16 +1,18 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-import { alias } from '@ember/object/computed';
+import { reads } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
 
 export default Component.extend({
-  job: alias('build.jobs.firstObject'),
+  router: service(),
+  routeName: reads('router.currentRouteName'),
 
   noJobsError: computed('build.jobs.[]', function () {
     let jobs = this.get('build.jobs');
     return jobs.get('length') === 0;
   }),
 
-  loading: alias('build.isLoading'),
+  loading: reads('build.isLoading'),
 
   jobsLoaded: computed(
     'build.jobs.@each.{isConfigLoaded,isLoaded}',
@@ -21,5 +23,5 @@ export default Component.extend({
       jobs.forEach((j) => j.get('config'));
       return jobs.isEvery('isLoaded') && jobs.isEvery('isConfigLoaded') && stagesAreLoaded;
     }
-  )
+  ),
 });

--- a/app/components/job-tabs.js
+++ b/app/components/job-tabs.js
@@ -8,10 +8,10 @@ export default Component.extend(WithConfigValidation, {
   classNames: ['travistab'],
 
   router: service(),
+  modelName: reads('model.constructor.modelName'),
 
   isConfig: match('router.currentRouteName', /config$/),
   isLog: not('isConfig'),
 
-  messages: reads('job.build.request.messages')
-
+  messages: reads('request.messages')
 });

--- a/app/templates/components/build-layout.hbs
+++ b/app/templates/components/build-layout.hbs
@@ -19,10 +19,17 @@
       {{else}}
         <LoadingIndicator @center={{true}} />
       {{/if}}
-    {{else}}
+    {{else if this.isLog}}
       <JobInfrastructureNotification @job={{this.job}} />
-      <JobTabs @job={{this.job}} @repo={{this.repo}} />
+      <JobTabs
+        @route="build"
+        @model={{this.build}}
+        @request={{this.request}}
+        @repo={{this.repo}}
+      />
       <JobLog data-test-job-log="true" @job={{this.job}} />
+    {{else}}
+      <JobTabs @route="build" @model={{this.build}} @repo={{this.repo}} />
     {{/if}}
   {{else}}
     <NoBuilds />

--- a/app/templates/components/job-tabs.hbs
+++ b/app/templates/components/job-tabs.hbs
@@ -2,10 +2,10 @@
   <ul>
     <li>
       <LinkTo
-        @route="job.index"
-        @models={{array this.repo this.job}}
+        @route="{{this.route}}.index"
+        @models={{array this.repo this.model}}
         @id="tab_log"
-        @title="Look at this job's log"
+        @title="Look at this {{this.modelName}}'s log"
         class={{if this.isLog 'active'}}
         data-test-job-log-tab="true"
       >
@@ -14,11 +14,10 @@
     </li>
     <li>
       <LinkTo
-        @route="job.config"
-        @models={{array this.repo this.job}}
-        @title="Look at this job's config"
-        @disabled={{this.job.build.request.noYaml}}
-        data-test-build-yaml-tab="true"
+        @route="{{route}}.config"
+        @models={{array this.repo this.model}}
+        @title="Look at this {{this.modelName}}'s config"
+        data-test-job-config-tab="true"
       >
         {{#if this.job.build.request.noYaml}}
           <EmberTooltip @text="Try a more recent job to see the config" />
@@ -36,6 +35,6 @@
     </li>
   </ul>
 </nav>
-<div class="travistab-body job-tabs">
+<div class="travistab-body {{this.route}}-tabs">
   {{outlet}}
 </div>

--- a/app/templates/job.hbs
+++ b/app/templates/job.hbs
@@ -7,7 +7,12 @@
       @repo={{this.repo}}
     />
     <JobInfrastructureNotification @job={{this.job}} />
-    <JobTabs @job={{this.job}} @repo={{this.repo}} />
+    <JobTabs
+      @route="job"
+      @model={{this.job}}
+      @request={{this.job.build.request}}
+      @repo={{this.repo}}
+    />
   {{else}}
     <div id="job">
       <LoadingIndicator />


### PR DESCRIPTION
this makes it so that on the build view, when clicking "Build Config" we stay on the build route,  and do not go to the jobs route.