### PR TITLE
add repo/config

### DIFF
--- a/app/components/request/configs.js
+++ b/app/components/request/configs.js
@@ -111,7 +111,7 @@ export default Component.extend(CanTriggerBuild, TriggerBuild, {
       mode: this.mergeMode,
       config: this.config,
       data: {
-        branch: this.branch,
+        branch: this.refType === 'branch' ? this.branch : null,
         commit_message: this.message
       },
       type: 'api'

--- a/app/components/request/configs.js
+++ b/app/components/request/configs.js
@@ -33,7 +33,7 @@ export default Component.extend(CanTriggerBuild, TriggerBuild, {
   loading: reads('preview.loading'),
 
   refType: 'sha',
-  sha: truncated('originalSha', 10),
+  sha: reads('originalSha'),
   branch: reads('originalBranch'),
   message: reads('request.commit.message'),
   config: reads('request.apiConfig.config'),

--- a/app/components/request/configs.js
+++ b/app/components/request/configs.js
@@ -18,6 +18,12 @@ export default Component.extend(CanTriggerBuild, TriggerBuild, {
 
   preview: service('request-config'),
   features: service(),
+
+  status: 'closed',
+  closed: equal('status', 'closed'),
+  customizing: equal('status', 'customize'),
+  previewing: equal('status', 'preview'),
+  replacing: equal('mergeMode', 'replace'),
   showNewConfigView: reads('features.showNewConfigView'),
 
   repo: reads('request.repo'),
@@ -27,7 +33,7 @@ export default Component.extend(CanTriggerBuild, TriggerBuild, {
   loading: reads('preview.loading'),
 
   refType: 'sha',
-  sha: reads('originalSha'),
+  sha: truncated('originalSha', 10),
   branch: reads('originalBranch'),
   message: reads('request.commit.message'),
   config: reads('request.apiConfig.config'),

--- a/app/controllers/repo/config.js
+++ b/app/controllers/repo/config.js
@@ -1,0 +1,6 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+  queryParams: ['status'],
+  status: 'customize'
+});

--- a/app/router.js
+++ b/app/router.js
@@ -61,6 +61,7 @@ Router.map(function () {
     this.route('build', { path: '/builds/:build_id', resetNamespace: true }, function () {
       this.route('config');
     });
+    this.route('config');
     this.route('job', { path: '/jobs/:job_id', resetNamespace: true }, function () {
       this.route('config');
     });

--- a/app/routes/repo/config.js
+++ b/app/routes/repo/config.js
@@ -1,0 +1,5 @@
+import TravisRoute from 'travis/routes/basic';
+
+export default TravisRoute.extend({
+  titleToken: 'Trigger Build',
+});

--- a/app/styles/app/modules/request/buttons.scss
+++ b/app/styles/app/modules/request/buttons.scss
@@ -1,3 +1,11 @@
+.repo-config .request-configs .request-configs-buttons {
+  top: -45px;
+
+  .request-configs-button-cancel {
+    display: none;
+  }
+}
+
 .request-configs .request-configs-buttons {
   position: absolute;
   top: 1px;

--- a/app/styles/app/modules/request/configs.scss
+++ b/app/styles/app/modules/request/configs.scss
@@ -1,3 +1,8 @@
+.repo-config {
+  position: relative;
+  margin-top: 3em;
+}
+
 .request-configs {
   .request-configs-matrix-notice {
     border: 1px solid $dry-cement;

--- a/app/templates/build/config.hbs
+++ b/app/templates/build/config.hbs
@@ -1,4 +1,5 @@
 <Request::Configs
+  @repo={{this.model.repo}}
   @request={{this.model}}
   @status={{this.status}}
 />

--- a/app/templates/components/request/configs.hbs
+++ b/app/templates/components/request/configs.hbs
@@ -66,6 +66,26 @@
     />
   {{/unless}}
 
+  {{#unless this.replacing}}
+    <h4>
+      Build {{pluralize this.rawConfigs.length 'Config' without-count=true}}
+    </h4>
+
+    {{#each this.rawConfigs as |config|}}
+      <Request::RawConfig
+        @source={{config.source}}
+        @config={{get config 'config'}}
+        @loading={{this.loading}}
+        @build={{@request.build}}
+        @slug={{@request.repo.slug}}
+      />
+    {{/each}}
+
+    <Request::Config
+      @config={{this.request.config}}
+    />
+  {{/unless}}
+
 {{else}}
   <Request::Messages
     @request={{this.request}}

--- a/app/templates/components/request/configs.hbs
+++ b/app/templates/components/request/configs.hbs
@@ -51,22 +51,6 @@
   {{/if}}
 
   {{#unless (or this.replacing this.previewing)}}
-    {{#each this.rawConfigs as |config|}}
-      <Request::RawConfig
-        @source={{config.source}}
-        @config={{get config 'config'}}
-        @loading={{this.loading}}
-        @build={{@request.build}}
-        @slug={{@request.repo.slug}}
-      />
-    {{/each}}
-
-    <Request::Config
-      @config={{this.request.config}}
-    />
-  {{/unless}}
-
-  {{#unless this.replacing}}
     <h4>
       Build {{pluralize this.rawConfigs.length 'Config' without-count=true}}
     </h4>

--- a/app/templates/job/config.hbs
+++ b/app/templates/job/config.hbs
@@ -5,6 +5,7 @@
   </PaperBlock>
 {{/if}}
 <Request::Configs
+  @repo={{this.model.repo}}
   @request={{this.model}}
   @status={{this.status}}
 />

--- a/app/templates/repo/config.hbs
+++ b/app/templates/repo/config.hbs
@@ -1,0 +1,6 @@
+<div class="repo-config">
+  <Request::Configs
+    @repo={{this.model}}
+    @status={{this.status}}
+  />
+</div>


### PR DESCRIPTION
based on https://github.com/travis-ci/travis-web/pull/2403

with this in place the same trigger build/customize/preview functionality is available on the route `/repo/:slug/config`, except it won't default on the current build request's data (sha, branch, etc)

please disregard CI failures. those are fixed in https://github.com/travis-ci/travis-web/pull/2406