### PR TITLE
BB Landing page - Scroll to top on page load

### DIFF
--- a/app/components/scroll-here.js
+++ b/app/components/scroll-here.js
@@ -4,8 +4,11 @@ import { inject as service } from '@ember/service';
 export default Component.extend({
   scroller: service(),
 
+  immediate: false,
+
   didInsertElement() {
     this._super(...arguments);
-    this.scroller.scrollToElement(this.element);
+    const duration = this.immediate ? 1 : 1000;
+    this.scroller.scrollToElement(this.element, { duration });
   }
 });

--- a/app/templates/integration.hbs
+++ b/app/templates/integration.hbs
@@ -1,3 +1,4 @@
+<ScrollHere />
 <Layouts::Striped
   @useTailwind={{true}}
   @isTopBarWhite={{true}}

--- a/app/templates/integration.hbs
+++ b/app/templates/integration.hbs
@@ -1,4 +1,4 @@
-<ScrollHere />
+<ScrollHere @immediate={{true}} />
 <Layouts::Striped
   @useTailwind={{true}}
   @isTopBarWhite={{true}}


### PR DESCRIPTION
Addresses an issue noted by Petra. To Reproduce:

1. Make sure you are signed out
2. Go to `/`
3. Scroll down to the Learn More button in the bitbucket section. The issue is more noticeable the further you scroll
4. Click the Learn More button
5. It will correctly lead to `/integration/bitbucket`, but you will be partially scrolled down on the page

Compare:
https://travis-ci.com/
https://so-fix-bb-landing-scroll.test-deployments.travis-ci.com/

Although, I'm not sure this is much better. Let me know what you think