### PR TITLE
Remove line from middle of case study button

### DIFF
--- a/app/templates/travisci-vs-jenkins/index.hbs
+++ b/app/templates/travisci-vs-jenkins/index.hbs
@@ -329,7 +329,7 @@
               DevOps lead, IBM Cloud Kubernetes Service Team
             </UiKit::Text>
 
-            <UiKit::Link @href={{this.caseStudyUrl}} data-test-tvj-page-testimonial-link="true">
+            <UiKit::Link @href={{this.caseStudyUrl}} @variant={{null}} data-test-tvj-page-testimonial-link="true">
               <UiKit::Button @color='blue' @invert={{true}}>
                 <UiKit::Grid @display='flex' @align='center'>
                   Read the case study


### PR DESCRIPTION
Minor thing I noticed today: A faint line in the middle of the Case Study button at the bottom of the jenkins page. Compare:

https://travis-ci.com/travisci-vs-jenkins
https://so-adjust-case-study-button.test-deployments.travis-ci.com/travisci-vs-jenkins