### PR TITLE
Fix build status image update issue

### DIFF
--- a/app/components/repository-layout.js
+++ b/app/components/repository-layout.js
@@ -10,12 +10,18 @@ export default Component.extend({
   isShowingTriggerBuildModal: false,
   isShowingStatusBadgeModal: false,
 
-  statusImageUrl: computed('repo.slug', 'repo.private', 'repo.defaultBranch.name', function () {
-    const branchName = this.get('repo.defaultBranch.name');
-    const repo = this.get('repo');
+  statusImageUrl: computed(
+    'repo.slug',
+    'repo.private',
+    'repo.defaultBranch.name',
+    'repo.defaultBranch.lastBuild.state',
+    function () {
+      const branchName = this.get('repo.defaultBranch.name');
+      const repo = this.get('repo');
 
-    return this.get('statusImages').imageUrl(repo, branchName);
-  }),
+      return this.get('statusImages').imageUrl(repo, branchName);
+    }
+  ),
 
   repoUrl: computed('repo.{ownerName,vcsName,vcsType}', function () {
     const owner = this.get('repo.ownerName');

--- a/app/services/status-images.js
+++ b/app/services/status-images.js
@@ -26,15 +26,17 @@ export default Service.extend({
       prefix = config.apiEndpoint;
     }
 
-    let slug = repo.get('slug');
+    const slug = repo.get('slug');
+    const state = repo.get('defaultBranch.lastBuild.state') || 'unknown';
+    const url = `${prefix}/${slug}.svg?status=${state}`;
 
     // In Enterprise you can toggle public mode, where even "public" repositories are hidden
     // in which cases we need to generate a token for all images
     if (!config.publicMode || repo.get('private')) {
       const token = this.auth.assetToken;
-      return `${prefix}/${slug}.svg?token=${token}${branch ? `&branch=${branch}` : ''}`;
+      return `${url}&token=${token}${branch ? `&branch=${branch}` : ''}`;
     } else {
-      return `${prefix}/${slug}.svg${branch ? `?branch=${encodeURIComponent(branch)}` : ''}`;
+      return `${url}${branch ? `&branch=${encodeURIComponent(branch)}` : ''}`;
     }
   },
 

--- a/tests/acceptance/repo/show-test.js
+++ b/tests/acceptance/repo/show-test.js
@@ -101,7 +101,7 @@ module('Acceptance | show repo page', function (hooks) {
 
     const url = new URL(page.statusBadge.src);
     const expectedPath = `${url.pathname}?${url.searchParams}`;
-    assert.equal(expectedPath, '/org-login/repository-name.svg?branch=feminist%23yes');
+    assert.equal(expectedPath, '/org-login/repository-name.svg?status=passed&branch=feminist%23yes');
 
     assert.equal(page.statusBadge.title, 'Latest push build on default branch: passed');
   });

--- a/tests/unit/services/status-images-test.js
+++ b/tests/unit/services/status-images-test.js
@@ -31,106 +31,106 @@ module('Unit | Service | status images', function (hooks) {
     const service = this.owner.lookup('service:status-images');
     this.repo.set('private', true);
     const url = service.imageUrl(this.repo);
-    assert.equal(url, `${root}/travis-ci/travis-web.svg?token=token-abc-123`);
+    assert.equal(url, `${root}/travis-ci/travis-web.svg?status=unknown&token=token-abc-123`);
   });
 
   test('it generates an image url with a token for a repo when publicMode is false', function (assert) {
     const service = this.owner.lookup('service:status-images');
     config.publicMode = false;
     const url = service.imageUrl(this.repo);
-    assert.equal(url, `${root}/travis-ci/travis-web.svg?token=token-abc-123`);
+    assert.equal(url, `${root}/travis-ci/travis-web.svg?status=unknown&token=token-abc-123`);
     config.publicMode = true;
   });
 
   test('it generates an image url with a repo', function (assert) {
     const service = this.owner.lookup('service:status-images');
     const url = service.imageUrl(this.repo);
-    assert.equal(url, `${root}/travis-ci/travis-web.svg`);
+    assert.equal(url, `${root}/travis-ci/travis-web.svg?status=unknown`);
   });
 
   test('it generates an image url with a repo and a branch', function (assert) {
     const service = this.owner.lookup('service:status-images');
     const url = service.imageUrl(this.repo, branch);
-    assert.equal(url, `${root}/travis-ci/travis-web.svg?branch=primary`);
+    assert.equal(url, `${root}/travis-ci/travis-web.svg?status=unknown&branch=primary`);
   });
 
   test('it generates an image url with a private repo and a branc', function (assert) {
     let service = this.owner.lookup('service:status-images');
     this.repo.set('private', true);
     const url = service.imageUrl(this.repo, branch);
-    assert.equal(url, `${root}/travis-ci/travis-web.svg?token=token-abc-123&branch=primary`);
+    assert.equal(url, `${root}/travis-ci/travis-web.svg?status=unknown&token=token-abc-123&branch=primary`);
   });
 
   test('it generates a Markdown image string with a repo', function (assert) {
     const service = this.owner.lookup('service:status-images');
     const markdown = service.markdownImageString(this.repo);
-    assert.equal(markdown, `[![Build Status](${root}/travis-ci/travis-web.svg)](${secureRoot}/travis-ci/travis-web)`);
+    assert.equal(markdown, `[![Build Status](${root}/travis-ci/travis-web.svg?status=unknown)](${secureRoot}/travis-ci/travis-web)`);
   });
 
   test('it generates a Markdown image string with a repo and a branch', function (assert) {
     const service = this.owner.lookup('service:status-images');
     const markdown = service.markdownImageString(this.repo, branch);
-    assert.equal(markdown, `[![Build Status](${root}/travis-ci/travis-web.svg?branch=primary)](${secureRoot}/travis-ci/travis-web)`);
+    assert.equal(markdown, `[![Build Status](${root}/travis-ci/travis-web.svg?status=unknown&branch=primary)](${secureRoot}/travis-ci/travis-web)`);
   });
 
   test('it generates a Textile image string with a repo', function (assert) {
     const service = this.owner.lookup('service:status-images');
     const textile = service.textileImageString(this.repo);
-    assert.equal(textile, `!${root}/travis-ci/travis-web.svg!:${secureRoot}/travis-ci/travis-web`);
+    assert.equal(textile, `!${root}/travis-ci/travis-web.svg?status=unknown!:${secureRoot}/travis-ci/travis-web`);
   });
 
   test('it generates a Textile image string with a repo and a branch', function (assert) {
     const service = this.owner.lookup('service:status-images');
     const textile = service.textileImageString(this.repo, branch);
-    assert.equal(textile, `!${root}/travis-ci/travis-web.svg?branch=primary!:${secureRoot}/travis-ci/travis-web`);
+    assert.equal(textile, `!${root}/travis-ci/travis-web.svg?status=unknown&branch=primary!:${secureRoot}/travis-ci/travis-web`);
   });
 
   test('it generates an Rdoc image string with a repo', function (assert) {
     const service = this.owner.lookup('service:status-images');
     const rdoc = service.rdocImageString(this.repo);
-    assert.equal(rdoc, `{<img src="${root}/travis-ci/travis-web.svg" alt="Build Status" />}[${secureRoot}/travis-ci/travis-web]`);
+    assert.equal(rdoc, `{<img src="${root}/travis-ci/travis-web.svg?status=unknown" alt="Build Status" />}[${secureRoot}/travis-ci/travis-web]`);
   });
 
   test('it generates an Rdoc image string with a repo and a branch', function (assert) {
     const service = this.owner.lookup('service:status-images');
     const rdoc = service.rdocImageString(this.repo, branch);
-    assert.equal(rdoc, `{<img src="${root}/travis-ci/travis-web.svg?branch=primary" alt="Build Status" />}[${secureRoot}/travis-ci/travis-web]`);
+    assert.equal(rdoc, `{<img src="${root}/travis-ci/travis-web.svg?status=unknown&branch=primary" alt="Build Status" />}[${secureRoot}/travis-ci/travis-web]`);
   });
 
   test('it generates an Asciidoc image string with a repo', function (assert) {
     const service = this.owner.lookup('service:status-images');
     const asciidoc = service.asciidocImageString(this.repo);
-    assert.equal(asciidoc, `image:${root}/travis-ci/travis-web.svg["Build Status", link="${secureRoot}/travis-ci/travis-web"]`);
+    assert.equal(asciidoc, `image:${root}/travis-ci/travis-web.svg?status=unknown["Build Status", link="${secureRoot}/travis-ci/travis-web"]`);
   });
 
   test('it generates an Asciidoc image string with a repo and a branch', function (assert) {
     const service = this.owner.lookup('service:status-images');
     const asciidoc = service.asciidocImageString(this.repo, branch);
-    assert.equal(asciidoc, `image:${root}/travis-ci/travis-web.svg?branch=primary["Build Status", link="${secureRoot}/travis-ci/travis-web"]`);
+    assert.equal(asciidoc, `image:${root}/travis-ci/travis-web.svg?status=unknown&branch=primary["Build Status", link="${secureRoot}/travis-ci/travis-web"]`);
   });
 
   test('it generates an RST image string with a repo', function (assert) {
     const service = this.owner.lookup('service:status-images');
     const rst = service.rstImageString(this.repo);
-    assert.equal(rst, `.. image:: ${root}/travis-ci/travis-web.svg\n    :target: ${secureRoot}/travis-ci/travis-web`);
+    assert.equal(rst, `.. image:: ${root}/travis-ci/travis-web.svg?status=unknown\n    :target: ${secureRoot}/travis-ci/travis-web`);
   });
 
   test('it generates an RST image string with a repo and a branch', function (assert) {
     const service = this.owner.lookup('service:status-images');
     const rst = service.rstImageString(this.repo, branch);
-    assert.equal(rst, `.. image:: ${root}/travis-ci/travis-web.svg?branch=primary\n    :target: ${secureRoot}/travis-ci/travis-web`);
+    assert.equal(rst, `.. image:: ${root}/travis-ci/travis-web.svg?status=unknown&branch=primary\n    :target: ${secureRoot}/travis-ci/travis-web`);
   });
 
   test('it generates a Pod image string with a repo', function (assert) {
     const service = this.owner.lookup('service:status-images');
     const pod = service.podImageString(this.repo);
-    assert.equal(pod, `=for html <a href="${secureRoot}/travis-ci/travis-web"><img src="${root}/travis-ci/travis-web.svg"></a>`);
+    assert.equal(pod, `=for html <a href="${secureRoot}/travis-ci/travis-web"><img src="${root}/travis-ci/travis-web.svg?status=unknown"></a>`);
   });
 
   test('it generates a Pod image string with a repo and a branch', function (assert) {
     const service = this.owner.lookup('service:status-images');
     const pod = service.podImageString(this.repo, branch);
-    assert.equal(pod, `=for html <a href="${secureRoot}/travis-ci/travis-web"><img src="${root}/travis-ci/travis-web.svg?branch=primary"></a>`);
+    assert.equal(pod, `=for html <a href="${secureRoot}/travis-ci/travis-web"><img src="${root}/travis-ci/travis-web.svg?status=unknown&branch=primary"></a>`);
   });
 
   test('it generates CCTray url with a repo', function (assert) {


### PR DESCRIPTION
For https://travisci.assembla.com/spaces/VCS/tickets/145/details

I've been testing like this:
1. Create a new repo on provider with simple tests. A basic ember project works well, and to make this faster I've just been forking one that I already have.
2. Activate repo on travis if needed
3. Go to the repo page and trigger a build. Watch as the build completes, observing the status button.
4. Flip through tabs on completion

This regularly reproduces the issue on prod for me. I think it may be a caching thing. Compare:
https://travis-ci.com/
https://so-fix-build-status-img.test-deployments.travis-ci.com/

Just realized an issue this causes though. Looking more into it.