### PR TITLE
Fix build status image update issue

### DIFF
--- a/app/components/repo-status-badge.js
+++ b/app/components/repo-status-badge.js
@@ -1,0 +1,31 @@
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
+import { computed } from '@ember/object';
+import { or, reads } from '@ember/object/computed';
+
+export default Component.extend({
+  tagName: '',
+  statusImages: service(),
+
+  repo: null,
+  defaultBuildStateLabel: 'unknown',
+  onClick() {},
+
+  lastBuildState: or('repo.defaultBranch.lastBuild.state', 'defaultBuildStateLabel'),
+  defaultBranch: reads('repo.defaultBranch.name'),
+
+  statusImageUrl: computed(
+    'repo.slug',
+    'repo.private',
+    'defaultBranch',
+    'lastBuildState',
+    function () {
+      const { defaultBranch, lastBuildState = 'unknown', repo } = this;
+
+      const url = this.statusImages.imageUrl(repo, defaultBranch);
+      const divider = (url.indexOf('?') >= 0) ? '&' : '?';
+
+      return `${url}${divider}status=${lastBuildState}`;
+    }
+  ),
+});

--- a/app/components/repo-status-badge.js
+++ b/app/components/repo-status-badge.js
@@ -1,17 +1,16 @@
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
-import { or, reads } from '@ember/object/computed';
+import { reads } from '@ember/object/computed';
 
 export default Component.extend({
   tagName: '',
   statusImages: service(),
 
   repo: null,
-  defaultBuildStateLabel: 'unknown',
   onClick() {},
 
-  lastBuildState: or('repo.defaultBranch.lastBuild.state', 'defaultBuildStateLabel'),
+  lastBuildState: reads('repo.defaultBranch.lastBuild.state'),
   defaultBranch: reads('repo.defaultBranch.name'),
 
   statusImageUrl: computed(

--- a/app/components/repo-status-badge.js
+++ b/app/components/repo-status-badge.js
@@ -22,7 +22,7 @@ export default Component.extend({
       const { defaultBranch, lastBuildState = 'unknown', repo } = this;
 
       const url = this.statusImages.imageUrl(repo, defaultBranch);
-      const divider = (url.indexOf('?') >= 0) ? '&' : '?';
+      const divider = url.includes('?') ? '&' : '?';
 
       return `${url}${divider}status=${lastBuildState}`;
     }

--- a/app/components/repository-layout.js
+++ b/app/components/repository-layout.js
@@ -3,19 +3,11 @@ import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 export default Component.extend({
-  statusImages: service(),
   externalLinks: service(),
   features: service(),
 
   isShowingTriggerBuildModal: false,
   isShowingStatusBadgeModal: false,
-
-  statusImageUrl: computed('repo.slug', 'repo.private', 'repo.defaultBranch.name', function () {
-    const branchName = this.get('repo.defaultBranch.name');
-    const repo = this.get('repo');
-
-    return this.get('statusImages').imageUrl(repo, branchName);
-  }),
 
   repoUrl: computed('repo.{ownerName,vcsName,vcsType}', function () {
     const owner = this.get('repo.ownerName');

--- a/app/templates/components/header-links.hbs
+++ b/app/templates/components/header-links.hbs
@@ -110,13 +110,14 @@
             </LinkTo>
           </li>
           <li>
-            <ExternalLinkTo
-              @href={{this.config.urls.enterprise}}
+            <LinkTo
+              @route="plans"
+              @query={{hash anchor="enterprise-section"}}
               @title="Travis CI for Enterprise"
               class="navigation-anchor"
             >
               Enterprise
-            </ExternalLinkTo>
+            </LinkTo>
           </li>
         {{/if}}
       {{/if}}

--- a/app/templates/components/repo-status-badge.hbs
+++ b/app/templates/components/repo-status-badge.hbs
@@ -3,6 +3,7 @@
     title="Latest push build on default branch: {{this.lastBuildState}}"
     name="status-images"
     class="pointer open-popup"
+    data-test-status-image-popup="true"
     {{on 'click' this.onClick}}
   >
     <img src={{this.statusImageUrl}} alt="build:{{this.lastBuildState}}" />

--- a/app/templates/components/repo-status-badge.hbs
+++ b/app/templates/components/repo-status-badge.hbs
@@ -1,0 +1,10 @@
+<div class="repo-badge inline-block vertical-align">
+  <a
+    title="Latest push build on default branch: {{this.lastBuildState}}"
+    name="status-images"
+    class="pointer open-popup"
+    {{on 'click' this.onClick}}
+  >
+    <img src={{this.statusImageUrl}} alt="build:{{this.lastBuildState}}" />
+  </a>
+</div>

--- a/app/templates/components/repo-status-badge.hbs
+++ b/app/templates/components/repo-status-badge.hbs
@@ -4,7 +4,7 @@
     name="status-images"
     class="pointer open-popup"
     data-test-status-image-popup="true"
-    {{on 'click' this.onClick}}
+    {{on 'click' @onClick}}
   >
     <img src={{this.statusImageUrl}} alt="build:{{this.lastBuildState}}" />
   </a>

--- a/app/templates/components/repository-layout.hbs
+++ b/app/templates/components/repository-layout.hbs
@@ -22,17 +22,7 @@
       >
         <SvgImage @name={{vcs-icon this.repo.vcsType}} />
       </ExternalLinkTo>
-      <div class="repo-badge inline-block vertical-align">
-        <a
-          id="status-image-popup"
-          title="Latest push build on default branch: {{this.repo.defaultBranch.lastBuild.state}}"
-          name="status-images"
-          class="pointer open-popup"
-          onclick={{action "toggleStatusBadgeModal"}}
-        >
-          <img src={{this.statusImageUrl}} alt="build:{{this.repo.defaultBranch.lastBuild.state}}" />
-        </a>
-      </div>
+      <RepoStatusBadge @repo={{this.repo}} @onClick={{action 'toggleStatusBadgeModal'}} />
     </div>
   </header>
   <main class="repo-main">

--- a/tests/acceptance/repo/show-test.js
+++ b/tests/acceptance/repo/show-test.js
@@ -101,7 +101,7 @@ module('Acceptance | show repo page', function (hooks) {
 
     const url = new URL(page.statusBadge.src);
     const expectedPath = `${url.pathname}?${url.searchParams}`;
-    assert.equal(expectedPath, '/org-login/repository-name.svg?branch=feminist%23yes');
+    assert.equal(expectedPath, '/org-login/repository-name.svg?branch=feminist%23yes&status=passed');
 
     assert.equal(page.statusBadge.title, 'Latest push build on default branch: passed');
   });

--- a/tests/pages/repo/show.js
+++ b/tests/pages/repo/show.js
@@ -9,7 +9,7 @@ export default create({
   visit: visitable(':organization/:repo'),
 
   statusBadge: {
-    scope: '#status-image-popup',
+    scope: '[data-test-status-image-popup]',
     src: attribute('src', 'img'),
     title: attribute('title'),
   },


### PR DESCRIPTION
For https://travisci.assembla.com/spaces/VCS/tickets/145/details

I've been testing like this:
1. Create a new repo on provider with simple tests. A basic ember project works well, and to make this faster I've just been forking one that I already have.
2. Activate repo on travis if needed
3. Go to the repo page and trigger a build. Watch as the build completes, observing the status button.
4. Flip through tabs on completion

This regularly reproduces the issue on prod for me. I suspect it may be a caching thing, so I added a status-based query param to the image displayed on `travis-web`. Compare:
https://travis-ci.com/
https://so-fix-build-status-img-2.test-deployments.travis-ci.com/

I've seen this for both github and bitbucket, but if you want to test with bb, I would test on staging, which i did deploy to recently
https://staging.travis-ci.com/
For some reason, bitbucket status images seem generally broken on test deployments, the API is returning 403 for them for some reason. This doesn't seem to happen on prod and stag though.

This is an alternative to this PR https://github.com/travis-ci/travis-web/pull/2414 which I will probably close in favor of this one. I realized that my solution on 2414 would change the URL being given to users, not just the URL being used to display the badge on our site, which I don't think we necessarily want.