### PR TITLE
align loading indicator

### DIFF
--- a/app/templates/components/dashboard-row.hbs
+++ b/app/templates/components/dashboard-row.hbs
@@ -174,7 +174,7 @@
             There are no builds for this repo yet
           </p>
           {{#if this.isTriggering}}
-            <LoadingIndicator />
+            <LoadingIndicator @inline={{true}}/>
           {{else}}
             <button
               class="button--blue"


### PR DESCRIPTION
For: https://travisci.assembla.com/spaces/VCS/tickets/161-align-loader-properly-on-a---39-trigger-a-build--39--button/details

To test, on the dashboard, using a repo that does not have any builds yet, click the 'Trigger a build' button on master/production and compare to test deployment.
