### PR TITLE
Use existing components for radio button

### DIFF
--- a/app/styles/app/modules/request/form.scss
+++ b/app/styles/app/modules/request/form.scss
@@ -26,8 +26,12 @@
       left: 20px !important;
   }
 
-  .travis-form__field-component {
-    box-shadow: inset 0 0 1px 1px $dry-cement !important;
+  .travis-form__field .travis-form__field-component {
+    box-shadow: inset 0 0 1px 1px $dry-cement;
+  }
+
+  .travis-form__field .travis-form__field-checkbox {
+    box-shadow: none;
   }
 
   .request-configs-fields-container {

--- a/app/templates/components/request/config-form.hbs
+++ b/app/templates/components/request/config-form.hbs
@@ -90,41 +90,62 @@
       <h4 class="request-configs-heading">
         Merge mode
       </h4>
-      <RadioButton
-        @value="deep_merge_append"
-        @groupValue={{mergeMode}}
-        @changed={{action "change" "mergeMode"}}
+
+      <form.field
+        @disableFrame={{true}}
+        @value={{eq @mergeMode 'deep_merge_append'}}
+        @onChange={{action 'change' 'mergeMode' 'deep_merge_append'}}
+        class="inline-block mr-6"
+        as |field|
       >
-        Deep Merge &amp; Append
-      </RadioButton>
-      <RadioButton
-        @value="deep_merge_prepend"
-        @groupValue={{mergeMode}}
-        @changed={{action "change" "mergeMode"}}
+        <field.checkbox>
+          Deep Merge &amp; Append
+        </field.checkbox>
+      </form.field>
+      <form.field
+        @disableFrame={{true}}
+        @value={{eq @mergeMode 'deep_merge_prepend'}}
+        @onChange={{action 'change' 'mergeMode' 'deep_merge_prepend'}}
+        class="inline-block mr-6"
+        as |field|
       >
-        Deep Merge &amp; Prepend
-      </RadioButton>
-      <RadioButton
-        @value="deep_merge"
-        @groupValue={{mergeMode}}
-        @changed={{action "change" "mergeMode"}}
+        <field.checkbox>
+          Deep Merge &amp; Prepend
+        </field.checkbox>
+      </form.field>
+      <form.field
+        @disableFrame={{true}}
+        @value={{eq @mergeMode 'deep_merge'}}
+        @onChange={{action 'change' 'mergeMode' 'deep_merge'}}
+        class="inline-block mr-6"
+        as |field|
       >
-        Deep Merge
-      </RadioButton>
-      <RadioButton
-        @value="merge"
-        @groupValue={{mergeMode}}
-        @changed={{action "change" "mergeMode"}}
+        <field.checkbox>
+          Deep Merge
+        </field.checkbox>
+      </form.field>
+      <form.field
+        @disableFrame={{true}}
+        @value={{eq @mergeMode 'merge'}}
+        @onChange={{action 'change' 'mergeMode' 'merge'}}
+        class="inline-block mr-6"
+        as |field|
       >
-        Merge
-      </RadioButton>
-      <RadioButton
-        @value="replace"
-        @groupValue={{mergeMode}}
-        @changed={{action "change" "mergeMode"}}
+        <field.checkbox>
+          Merge
+        </field.checkbox>
+      </form.field>
+      <form.field
+        @disableFrame={{true}}
+        @value={{eq @mergeMode 'replace'}}
+        @onChange={{action 'change' 'mergeMode' 'replace'}}
+        class="inline-block mr-10"
+        as |field|
       >
-        Replace
-      </RadioButton>
+        <field.checkbox>
+          Replace
+        </field.checkbox>
+      </form.field>
 
       <ExternalLinkTo class="hint" href="{{config-get 'urls.triggerBuildMergeModes'}}">
         <SvgImage @name='icon-help' @class='icon-help' />

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "ember-prism": "^0.5.0",
     "ember-qunit": "^4.6.0",
     "ember-qunit-nice-errors": "1.2.0",
-    "ember-radio-button": "^2.0.1",
     "ember-resolver": "^5.0.1",
     "ember-source": "~3.12.0",
     "ember-stripe-elements": "git+https://github.com/code-corps/ember-stripe-elements.git#develop",


### PR DESCRIPTION
Hi @svenfuchs , I came up with a possible update for the request config stuff that would use existing `travis-form` components to make radio buttons. I tried to keep the change as small as possible. Let me know what you think when you get a chance :smile: 