### PR TITLE
always display request messages, alternative style

### DIFF
--- a/app/components/job-log.js
+++ b/app/components/job-log.js
@@ -9,6 +9,7 @@ export default Component.extend({
 
   _oldJob: null,
 
+  request: reads('job.build.request'),
   job: null,
   log: reads('job.log'),
 

--- a/app/components/request/raw-config.js
+++ b/app/components/request/raw-config.js
@@ -66,10 +66,6 @@ export default Component.extend({
     },
     toggle() {
       this.toggleProperty('expanded');
-    },
-    noop(e) {
-      console.log('noop', e);
-      e.stopPropagation();
     }
   }
 });

--- a/app/controllers/build/index.js
+++ b/app/controllers/build/index.js
@@ -1,12 +1,14 @@
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
-import { alias } from '@ember/object/computed';
+import { alias, reads } from '@ember/object/computed';
 
 export default Controller.extend({
   repositories: service(),
 
   latestCurrentBuild: alias('repositories.accessible.firstObject.currentBuild'),
+
+  request: reads('build.request'),
 
   build: computed('model', 'latestCurrentBuild', function () {
     let model = this.model;

--- a/app/routes/build.js
+++ b/app/routes/build.js
@@ -36,7 +36,6 @@ export default TravisRoute.extend({
   afterModel(model) {
     const slug = this.modelFor('repo').get('slug');
     this.ensureBuildOwnership(model, slug);
-    return model.get('request').then(request => request && request.fetchMessages.perform());
   },
 
   ensureBuildOwnership(build, urlSlug) {

--- a/app/routes/build/config.js
+++ b/app/routes/build/config.js
@@ -6,8 +6,4 @@ export default TravisRoute.extend({
   model() {
     return this.modelFor('build').get('request');
   },
-
-  afterModel(request) {
-    return request.fetchMessages.perform();
-  }
 });

--- a/app/routes/job.js
+++ b/app/routes/job.js
@@ -48,9 +48,6 @@ export default TravisRoute.extend({
   afterModel(job) {
     const slug = this.modelFor('repo').get('slug');
     this.ensureJobOwnership(job, slug);
-    return job
-      .get('build.request')
-      .then(request => request && request.fetchMessages.perform());
   },
 
   ensureJobOwnership(job, urlSlug) {

--- a/app/routes/job/config.js
+++ b/app/routes/job/config.js
@@ -9,8 +9,4 @@ export default TravisRoute.extend({
       return this.store.findRecord('request', requestId);
     });
   },
-
-  afterModel(request) {
-    return request.fetchMessages.perform();
-  }
 });

--- a/app/routes/repo/index.js
+++ b/app/routes/repo/index.js
@@ -5,12 +5,6 @@ export default TravisRoute.extend({
   features: service(),
   tabStates: service(),
 
-  afterModel(repo) {
-    try {
-      return repo.get('currentBuild.request').then(request => request && request.fetchMessages.perform());
-    } catch (error) {}
-  },
-
   setupController(controller, model) {
     this._super(...arguments);
     this.controllerFor('repo').activate('current');

--- a/app/styles/app/data.scss
+++ b/app/styles/app/data.scss
@@ -50,4 +50,22 @@ $requestStatusMap: (
   approved: passed,
   rejected: failed,
   pending: created
-)
+);
+
+$configValidation: (
+  info: (
+    color: $turf-green,
+    gradient: $turf-green,
+    color-bg: $seed-green
+  ),
+  warn: (
+    color: $dozer-yellow,
+    gradient: $canary-yellow,
+    color-bg: $haze-yellow
+  ),
+  error: (
+    color: $brick-red,
+    gradient: $brick-red,
+    color-bg: $quartz-red
+  )
+);

--- a/app/styles/app/modules/request/config.scss
+++ b/app/styles/app/modules/request/config.scss
@@ -3,7 +3,7 @@
   border: 1px solid $pebble-grey;
   margin-bottom: 1.2em;
 
-  .copy-button{
+  .copy-button {
     display: inline-block;
 
     button  {

--- a/app/styles/app/modules/request/configs.scss
+++ b/app/styles/app/modules/request/configs.scss
@@ -35,9 +35,9 @@
 }
 
 .request-configs-trigger-build-notice {
-  margin: 1em 0;
+  margin: 2em 0;
   padding: 1em;
-  border: 1px solid $pebble-grey;
+  border: 1px solid $dry-cement;
 
   .request-configs-icon {
     position: relative;

--- a/app/styles/app/modules/request/messages.scss
+++ b/app/styles/app/modules/request/messages.scss
@@ -20,6 +20,10 @@
 .request-messages {
   @include travisBorder;
 
+  @each $level, $colors in $configValidation {
+    @include colorBg(map-get($colors, gradient), "request-message-#{$level}", 6px);
+  }
+
   margin: 1.2em 0;
 
   font-size: $font-size-sm;
@@ -54,7 +58,16 @@
       }
     }
     .icon-help {
-      margin-right: 12px;
+      margin-right: 6px;
+      opacity: 0.85;
+      width: 16px;
+      height: 16px;
+      margin-right: 6px;
+      border: 0;
+      path {
+        stroke: $cement-grey;
+        stroke-width: 2;
+      }
     }
 
     .request-messages-summary > div {

--- a/app/templates/build/index.hbs
+++ b/app/templates/build/index.hbs
@@ -1,3 +1,7 @@
+<Request::Messages
+  @request={{this.request}}
+  @messages={{this.request.messages}}
+/>
 {{#let this.build as |build|}}
   {{#if build.isMatrix}}
     {{#if build.stages}}

--- a/app/templates/build/index.hbs
+++ b/app/templates/build/index.hbs
@@ -1,9 +1,9 @@
-<Request::Messages
-  @request={{this.request}}
-  @messages={{this.request.messages}}
-/>
 {{#let this.build as |build|}}
   {{#if build.isMatrix}}
+    <Request::Messages
+      @request={{this.request}}
+      @messages={{this.request.messages}}
+    />
     {{#if build.stages}}
       {{#each build.sortedStages as |stage|}}
         <JobsList

--- a/app/templates/components/build-layout.hbs
+++ b/app/templates/components/build-layout.hbs
@@ -25,7 +25,10 @@
         @repo={{this.repo}}
         @build={{this.build}}
       />
-      <JobLog data-test-job-log="true" @job={{this.job}} />
+      <JobLog
+        data-test-job-log="true"
+        @job={{this.job}}
+        />
     {{else}}
       <JobTabs
         @repo={{this.repo}}

--- a/app/templates/components/job-log.hbs
+++ b/app/templates/components/job-log.hbs
@@ -1,3 +1,8 @@
+<Request::Messages
+  @request={{this.request}}
+  @messages={{this.request.messages}}
+/>
+
 {{#if this.error}}
   <p class="notice-banner--red">
     There was an error while trying to fetch the log.

--- a/app/templates/components/request/configs.hbs
+++ b/app/templates/components/request/configs.hbs
@@ -10,18 +10,17 @@
     />
   {{/if}}
 
-  {{#unless this.closed}}
-    <Request::ConfigsTriggerBuildNotice
-      @configs={{this.rawConfigs.length}}
-      @status={{this.status}}
-    />
-  {{/unless}}
-
   {{#unless this.customizing}}
     <Request::Messages
       @request={{this.request}}
       @messages={{this.request.messages}}
-      @viewMessage={{action (mut this.viewingMessage)}}
+    />
+  {{/unless}}
+
+  {{#unless this.closed}}
+    <Request::ConfigsTriggerBuildNotice
+      @configs={{this.rawConfigs.length}}
+      @status={{this.status}}
     />
   {{/unless}}
 

--- a/app/templates/components/request/messages.hbs
+++ b/app/templates/components/request/messages.hbs
@@ -1,5 +1,5 @@
 {{#if this.showConfigValidation}}
-  <div class="request-messages" data-test-configs-messages="true">
+  <div class="request-messages request-message-{{this.maxLevel}}" data-test-configs-messages="true">
     <div class="header" {{action 'toggle'}} data-test-configs-messages-toggle="true">
       <span class="tooltip-wrapper level-icon">
         <SvgImage @name="msg-{{this.maxLevel}}"  @class={{this.iconClass}} />


### PR DESCRIPTION
idea from: https://travis-ci.community/t/failing-the-build-when-the-config-validation-contains-errors/7764/3

based on https://github.com/travis-ci/travis-web/pull/2399

Matrix view (info messages)

![image](https://user-images.githubusercontent.com/2208/78363001-52ff0400-75bb-11ea-82be-3316053da97f.png)

Job/log view (info messages)

![image](https://user-images.githubusercontent.com/2208/78363066-6f02a580-75bb-11ea-8e49-1c6589ae42aa.png)

Config view (warning messages)

![image](https://user-images.githubusercontent.com/2208/78363143-90639180-75bb-11ea-8b80-28a63c1792e4.png)
