### PR TITLE
Adjust flaky percy snapshots

### DIFF
--- a/tests/integration/components/add-ssh-key-test.js
+++ b/tests/integration/components/add-ssh-key-test.js
@@ -10,7 +10,6 @@ import {
 } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import DS from 'ember-data';
-import { percySnapshot } from 'ember-percy';
 
 module('Integration | Component | add ssh-key', function (hooks) {
   setupRenderingTest(hooks);
@@ -46,8 +45,6 @@ module('Integration | Component | add ssh-key', function (hooks) {
     assert.equal(sshKey.get('value'), 'bar', 'value should be set');
     assert.equal(sshKey.get('id'), 1, 'ssh key id should still be repo id');
 
-    percySnapshot(assert);
-
     var done = assert.async();
     done();
   });
@@ -80,8 +77,6 @@ module('Integration | Component | add ssh-key', function (hooks) {
     await click('.form-submit');
 
     assert.dom('.form-error-message').exists('there is an error message if value is blank');
-
-    percySnapshot(assert);
 
     fillIn('.ssh-value', 'bar');
     await triggerEvent('.ssh-value', 'change');

--- a/tests/integration/components/ssh-key-test.js
+++ b/tests/integration/components/ssh-key-test.js
@@ -4,7 +4,6 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, click } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { percySnapshot } from 'ember-percy';
 
 module('Integration | Component | ssh-key', function (hooks) {
   setupRenderingTest(hooks);
@@ -26,7 +25,6 @@ module('Integration | Component | ssh-key', function (hooks) {
 
     assert.dom('.ssh-key-name span').hasText('Default', 'should display that no custom key is set');
     assert.dom('.ssh-key-value span').hasText('fingerprint', 'should display default key fingerprint');
-    percySnapshot(assert);
   });
 
   test('it renders the custom ssh key if custom key is set', async function (assert) {
@@ -62,7 +60,6 @@ module('Integration | Component | ssh-key', function (hooks) {
     await click('.ssh-key-action button');
 
     assert.ok(key.get('isDeleted'), 'key should be deleted');
-    percySnapshot(assert);
 
     var done = assert.async();
     done();


### PR DESCRIPTION
A couple of percy snapshots are incorrectly flagged as changed fairly often. I thought about trying 
 to await settled or something like that for them, but then realized that I'm not sure we want or need snapshots inside of component integration tests. I think it makes more sense to utilize them in acceptance tests. So I removed them.