### PR TITLE
Fix community SVG display

### DIFF
--- a/public/images/svg/community.svg
+++ b/public/images/svg/community.svg
@@ -2,7 +2,6 @@
 <svg width="443" height="270" viewBox="0 0 443 270" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <defs>
     <style type="text/css">
-      .fake{fill:url(#SVGID_0_);} <!-- Fixes an issue where flat color would show rather than gradient on .st3 -->
       .st0{fill:none;}
       .st1{fill:none;stroke:#0068FF;stroke-width:2;stroke-miterlimit:10;}
       .st2{fill:#32D282;}


### PR DESCRIPTION
For https://travisci.assembla.com/spaces/Web/tickets/304/details

Some background info: ID collisions between elements within different SVGs has caused various issues with the display of gradients, colors, etc within SVGs. In the past this was handled with ID changes and other tricks within individual SVGs. More recently, a more universal approach was implemented by changing SVGO settings in `ember-cli-build.js` (namely,  auto-generated ID prefixes was enabled). This now automatically handles these issues for the most part, but seems like it didn't work well with an old fix within the help page "community" svg. Removing the old fix seems to resolve all issues.

I looked to see if there were any other SVGs having a similar issue, but it appears not.

To test, deploy to staging and compare with https://travis-ci.com/help