### PR TITLE
added Canary Islands to the list of countries

### DIFF
--- a/app/utils/countries.js
+++ b/app/utils/countries.js
@@ -204,6 +204,7 @@ const countriesMap = {
   ZA: 'South Africa',
   GS: 'South Georgia And Sandwich Isl.',
   ES: 'Spain',
+  IC: 'Spain – Canary Islands',
   LK: 'Sri Lanka',
   SD: 'Sudan',
   SR: 'Suriname',


### PR DESCRIPTION
The accounts department requested to add Canary Islands in the list of countries, it comes under Spain, however not part of the EU so not VAT should be associated with it.

https://github.com/travis-pro/billing-v2/issues/525