### PR TITLE
Remove heroku redis urls

### DIFF
--- a/config/deployment/deploy-local.sh
+++ b/config/deployment/deploy-local.sh
@@ -2,8 +2,6 @@
 
 export CLEANED_BRANCH_SUBDOMAIN=`git name-rev --name-only HEAD | tr '.' '-' | tr '/' '-' | tr '[:upper:]' '[:lower:]'`
 
-eval $(./config/deployment/store-redis-urls.sh)
-
 if [[ $TRAVIS_PULL_REQUEST_BRANCH = *staging* ]]
 then
   echo "Staging branch is not allowed to be deployed locally"

--- a/config/deployment/deploy-pull-request.sh
+++ b/config/deployment/deploy-pull-request.sh
@@ -1,7 +1,5 @@
 export CLEANED_BRANCH_SUBDOMAIN=`echo $TRAVIS_PULL_REQUEST_BRANCH | tr '.' '-' | tr '/' '-' | tr '[:upper:]' '[:lower:]'`
 
-eval $(./config/deployment/store-redis-urls.sh)
-
 if [[ $TRAVIS_PULL_REQUEST_BRANCH = *staging* ]]
 then
   API_ENDPOINT=https://api-staging.travis-ci.org ember deploy org-staging-pull-request --activate

--- a/config/deployment/deploy-test-master.sh
+++ b/config/deployment/deploy-test-master.sh
@@ -1,7 +1,5 @@
 export CLEANED_BRANCH_SUBDOMAIN=ember-$EMBER_VERSION
 export DISABLE_SENTRY=true
 
-eval $(./config/deployment/store-redis-urls.sh)
-
 ember deploy org-$EMBER_VERSION --activate
 TRAVIS_PRO=true ember deploy com-$EMBER_VERSION --activate

--- a/config/deployment/store-redis-urls.sh
+++ b/config/deployment/store-redis-urls.sh
@@ -1,2 +1,0 @@
-echo export ORG_PRODUCTION_REDIS_URL=`heroku config:get REDIS_URL -a travis-web-production-next`
-echo export COM_PRODUCTION_REDIS_URL=`heroku config:get REDIS_URL -a travis-pro-web-production-next`


### PR DESCRIPTION
Travis web PR deployments are using hobby-dev instance of redis on heroku. URL of these instances aren't constant which causes errors in travis-web-next app. 
I've prepared redis instance with static IP and would like to set redis urls via travis job env vars.