### PR TITLE
Add permissions hash handling for build request

### DIFF
--- a/app/models/build.js
+++ b/app/models/build.js
@@ -13,6 +13,8 @@ export default Model.extend(DurationCalculations, {
 
   branchName: alias('branch.name'),
 
+  permissions: attr(),
+
   state: attr(),
   number: attr('number'),
   message: attr('string'),

--- a/app/serializers/build_v2_fallback.js
+++ b/app/serializers/build_v2_fallback.js
@@ -37,7 +37,11 @@ export default V2FallbackSerializer.extend({
   normalize: function (modelClass, resourceHash) {
     // TODO: remove this after switching to V3 entirely
     let type = resourceHash['@type'];
+    let permissionsHash = resourceHash['@permissions'];
     let commit = resourceHash.commit;
+    if (permissionsHash) {
+      resourceHash.permissions = permissionsHash;
+    }
     if (!type && commit && commit.hasOwnProperty('branch_is_default')) {
       let build = resourceHash.build,
         commit = resourceHash.commit;


### PR DESCRIPTION
This change promotes `@permissions` hash received from API on `/builds/:id` endpoint to the build model. Therefore, it's now possible to refer to build permissions object like this:
```js
build.permissions.restart === true
```
or alias via computed properties:
```js
isRestartable: bool('build.permissions.restart')
```