### PR TITLE
Change default provider handling

### DIFF
--- a/app/controllers/signin.js
+++ b/app/controllers/signin.js
@@ -9,8 +9,6 @@ export default Controller.extend({
   accounts: reads('auth.accounts'),
   hasAccounts: gt('accounts.length', 0),
 
-  showOtherProviders: reads('multiVcs.enabled'),
-
   actions: {
     signIn(provider) {
       this.auth.signInWith(provider);

--- a/app/services/multi-vcs.js
+++ b/app/services/multi-vcs.js
@@ -31,7 +31,8 @@ export default Service.extend({
   },
 
   isProviderBeta(provider) {
-    return vcsConfigByUrlPrefix(provider).isBeta;
+    const config = provider && vcsConfigByUrlPrefix(provider) || defaultVcsConfig;
+    return config.isBeta;
   },
 
   currentProviderConfig: computed('auth.currentUser.vcsType', function () {

--- a/app/templates/components/landing-default-page.hbs
+++ b/app/templates/components/landing-default-page.hbs
@@ -26,12 +26,14 @@
 
           {{#if this.multiVcs.enabled}}
             <div>
-              <button class="hero-button org multi-vcs" {{on 'click' (action this.signIn 'github')}}>
-                <SvgImage @name="icon-repooctocat" />
-                <span class="label-align">
-                  Sign up with Github
-                </span>
-              </button>
+              {{#if this.multiVcs.enableGithubLogin}}
+                <button class="hero-button org multi-vcs" {{on 'click' (action this.signIn 'github')}}>
+                  <SvgImage @name="icon-repooctocat" />
+                  <span class="label-align">
+                    Sign up with Github
+                  </span>
+                </button>
+              {{/if}}
               {{#if this.multiVcs.enableAssemblaLogin}}
                 <button class="hero-button org multi-vcs" {{on 'click' (action this.signIn 'assembla')}}>
                   <SvgImage @name="icon-assembla" />

--- a/app/templates/components/multi-signin-button.hbs
+++ b/app/templates/components/multi-signin-button.hbs
@@ -24,13 +24,15 @@
       @duration={{this.animation.durations.quick}}
     >
       <div class="multi-signin-button__vcs-options absolute w-64 shadow-sm">
-        <button
-          class="multi-signin-button__vcs-button w-full cursor-pointer flex justify-center items-center"
-          {{on 'click' (action this.signInWith 'github')}}
-        >
-          With Github
-          <SvgImage @name={{vcs-icon 'GithubUser'}} @class="fill-current w-5 h-5 ml-2" />
-        </button>
+        {{#if this.multiVcs.enableGithubLogin}}
+          <button
+            class="multi-signin-button__vcs-button w-full cursor-pointer flex justify-center items-center"
+            {{on 'click' (action this.signInWith 'github')}}
+          >
+            With Github
+            <SvgImage @name={{vcs-icon 'GithubUser'}} @class="fill-current w-5 h-5 ml-2" />
+          </button>
+        {{/if}}
         {{#if this.multiVcs.enableBitbucketLogin}}
           <button
             class="multi-signin-button__vcs-button w-full cursor-pointer flex justify-center items-center"

--- a/app/templates/signin.hbs
+++ b/app/templates/signin.hbs
@@ -50,12 +50,10 @@
         </UiKit::Text>
       {{/if}}
 
-      <UiKit::ButtonSignin />
-      {{#if this.showOtherProviders}}
-        <UiKit::ButtonSignin @provider='bitbucket' />
-        <UiKit::ButtonSignin @provider='gitlab' />
-        <UiKit::ButtonSignin @provider='assembla' />
-      {{/if}}
+      <UiKit::ButtonSignin @provider='github' />
+      <UiKit::ButtonSignin @provider='bitbucket' />
+      <UiKit::ButtonSignin @provider='gitlab' />
+      <UiKit::ButtonSignin @provider='assembla' />
 
       {{#unless this.hasAccounts}}
         <UiKit::Text @margin={{hash y=6}}>

--- a/config/providers.js
+++ b/config/providers.js
@@ -3,6 +3,11 @@
 
 const deepFreeze = require('deep-freeze');
 
+const {
+  GITHUB_ORGS_OAUTH_ACCESS_SETTINGS_URL,
+  DEFAULT_PROVIDER
+} = process && process.env || {};
+
 const VCS_TYPES = {
   ASSEMBLA: {
     ORG: 'AssemblaOrganization',
@@ -29,6 +34,8 @@ const VCS_TYPES = {
 // keys sorted alphabetically
 module.exports = deepFreeze({
   assembla: {
+    isDefault: DEFAULT_PROVIDER === 'assembla',
+    isBeta: true,
     vcsTypes: [VCS_TYPES.ASSEMBLA.ORG, VCS_TYPES.ASSEMBLA.REPO, VCS_TYPES.ASSEMBLA.USER],
     endpoint: 'https://:portfolio.assembla.com',
     icon: 'icon-assembla',
@@ -55,6 +62,8 @@ module.exports = deepFreeze({
   },
 
   bitbucket: {
+    isDefault: DEFAULT_PROVIDER === 'bitbucket',
+    isBeta: true,
     vcsTypes: [VCS_TYPES.BITBUCKET.ORG, VCS_TYPES.BITBUCKET.REPO, VCS_TYPES.BITBUCKET.USER],
     endpoint: 'https://bitbucket.org',
     icon: 'icon-bitbucket',
@@ -81,6 +90,8 @@ module.exports = deepFreeze({
   },
 
   gitlab: {
+    isDefault: DEFAULT_PROVIDER === 'gitlab',
+    isBeta: true,
     vcsTypes: [VCS_TYPES.GITLAB.ORG, VCS_TYPES.GITLAB.REPO, VCS_TYPES.GITLAB.USER],
     endpoint: 'https://gitlab.com',
     icon: 'icon-gitlab',
@@ -107,8 +118,9 @@ module.exports = deepFreeze({
   },
 
   github: {
+    isDefault: DEFAULT_PROVIDER === 'github' || !DEFAULT_PROVIDER,
+    isBeta: false,
     vcsTypes: [VCS_TYPES.GITHUB.ORG, VCS_TYPES.GITHUB.REPO, VCS_TYPES.GITHUB.USER],
-    isDefault: true,
     endpoint: 'https://github.com',
     icon: 'icon-repooctocat',
     name: 'GitHub',
@@ -121,7 +133,7 @@ module.exports = deepFreeze({
       profile: '/:owner',
       repo: '/:owner/:repo',
       tag: '/:owner/:repo/releases/tag/:tag',
-      accessSettings: process.env.GITHUB_ORGS_OAUTH_ACCESS_SETTINGS_URL,
+      accessSettings: GITHUB_ORGS_OAUTH_ACCESS_SETTINGS_URL,
     },
     vocabulary: {
       organization: 'Organization',

--- a/tests/acceptance/layouts/plans-test.js
+++ b/tests/acceptance/layouts/plans-test.js
@@ -26,7 +26,7 @@ module('Acceptance | layouts/plans page', function (hooks) {
     assert.ok(proHeader.loginLinkPresent, 'Pro header has login button');
     assert.equal(footer.sections[2].title, '©Travis CI, GmbH', 'Shows company info section');
     assert.equal(footer.sections[3].title, 'Help', 'Shows help info section');
-    assert.equal(footer.sections[4].title, 'Legal', 'Shows legal info section');
+    assert.equal(footer.sections[4].title, 'Company', 'Shows legal info section');
   });
 
   test('plans page redirects unless pro enabled', async function (assert) {


### PR DESCRIPTION
I have ended up with a slightly different solution rather than just disabling Github via env variable. With the new solution you should be able to re-define default provider via `DEFAULT_PROVIDER` environment variable. Default provider will always be enabled. Other providers are optional and if they aren't explicitly enabled via feature flag, they won't be available for login.