### PR TITLE
Recognize `matlab` as language key

### DIFF
--- a/app/utils/keys-map.js
+++ b/app/utils/keys-map.js
@@ -26,6 +26,7 @@ languageConfigKeys = {
   julia: 'Julia',
   lein: 'Lein',
   mono: 'Mono',
+  matlab: 'MATLAB',
   nix: 'Nix',
   node_js: 'Node.js',
   objective_c: 'Objective-C',


### PR DESCRIPTION
To correspond to 
https://github.com/travis-ci/travis-build/pull/1880
https://github.com/travis-ci/travis-yml/pull/192