### PR TITLE
Fix for addon purchase process

### DIFF
--- a/app/components/billing/select-addon.js
+++ b/app/components/billing/select-addon.js
@@ -33,6 +33,10 @@ export default Component.extend({
     selectAndSubmit(form) {
       this.set('selectedAddon', this.selectedAddon);
       later(() => form.submit(), 500);
+    },
+    cancel() {
+      this.set('selectedAddon', null);
+      this.set('showAddonsSelector', false);
     }
   }
 });

--- a/app/templates/components/billing/select-addon.hbs
+++ b/app/templates/components/billing/select-addon.hbs
@@ -40,7 +40,7 @@
         </button>
       </div>
       <div class='billing-subscription__buttons--addons'>
-        <button {{on 'click' (fn (mut this.showAddonsSelector) false)}} class='button--white-and-teal button--hover' data-test-buy-addons-cancel='true'>
+        <button onclick={{action 'cancel'}} class='button--white-and-teal button--hover' data-test-buy-addons-cancel='true'>
           Cancel
         </button>
       </div>


### PR DESCRIPTION
if user tries to change plan after canceling addon purchase, previously selected addon is displayed on the order summary page