### PR TITLE
Remove 'macOS' text for a hybrid plan on the plan page

### DIFF
--- a/app/templates/components/billing/summary-v2.hbs
+++ b/app/templates/components/billing/summary-v2.hbs
@@ -85,9 +85,15 @@
                   {{pluralize this.subscription.plan.concurrencyLimit "concurrent job"}}
                 </p>
               {{/if}}
-              <p>
-                Linux, Windows, macOS, FreeBSD builds
-              </p>
+              {{#if (eq this.subscription.plan.planType 'hybrid')}}
+                <p>
+                  Linux, Windows, FreeBSD builds
+                </p>
+                {{else}}
+                <p>
+                  Linux, Windows, macOS, FreeBSD builds
+                </p>
+               {{/if}}
             </div>
           </div>
         </div>


### PR DESCRIPTION
Remove 'macOS' text for a hybrid plan on the plan page