### PR TITLE
Hide Plan Usage tab from users without credits

### DIFF
--- a/app/components/profile-nav.js
+++ b/app/components/profile-nav.js
@@ -68,6 +68,7 @@ export default Component.extend({
     const isEnterprise = this.features.get('enterpriseVersion');
     return !isEnterprise && !isAssemblaUser && !!billingEndpoint;
   }),
+  showPlanUsageTab: and('showSubscriptionTab', 'model.hasCredits'),
 
   didRender() {
     const allowance = this.model.allowance;

--- a/app/models/owner.js
+++ b/app/models/owner.js
@@ -9,7 +9,9 @@ import {
   match,
   notEmpty,
   or,
-  reads
+  reads,
+  empty,
+  not
 } from '@ember/object/computed';
 import config from 'travis/config/environment';
 import dynamicQuery from 'travis/utils/dynamic-query';
@@ -199,6 +201,12 @@ export default VcsEntity.extend({
       }
       return this.accountv2Subscriptions.get('lastObject');
     }),
+
+  isV2SubscriptionEmpty: empty('v2subscription'),
+  hasV2Subscription: not('isV2SubscriptionEmpty'),
+  hasCredits: computed('hasV2Subscription', 'v2subscription', function () {
+    return this.hasV2Subscription ? this.v2subscription.get('hasCredits') : false;
+  }),
 
   trial: computed('accounts.trials.@each.{created_at,owner,hasTrial}', 'login', function () {
     let trials = this.get('accounts.trials') || [];

--- a/app/templates/components/profile-nav.hbs
+++ b/app/templates/components/profile-nav.hbs
@@ -126,7 +126,7 @@
               </LinkTo>
             </li>
           {{/if}}
-          {{#if this.showSubscriptionTab}}
+          {{#if this.showPlanUsageTab}}
             <li data-test-plan-usage-tab>
               <LinkTo @route="account.plan_usage">
                 Plan usage
@@ -161,7 +161,7 @@
               </LinkTo>
             </li>
           {{/if}}
-          {{#if this.showSubscriptionTab}}
+          {{#if this.showPlanUsageTab}}
             <li data-test-plan-usage-tab>
               <LinkTo @route="organization.plan_usage" @model={{this.model}}>
                 Plan usage

--- a/tests/acceptance/profile/plan-usage-test.js
+++ b/tests/acceptance/profile/plan-usage-test.js
@@ -49,7 +49,8 @@ module('Acceptance | profile/plan usage', function (hooks) {
       status: 'subscribed',
       valid_to: new Date(),
       addons: [
-        {name: 'User license addon', type: 'user_license', current_usage: {addon_usage: 1}}
+        {name: 'User license addon', type: 'user_license', current_usage: {addon_usage: 1}},
+        {name: 'Private credit addon', type: 'credit_private', current_usage: {addon_usage: 60}}
       ]
     });
 


### PR DESCRIPTION
Hide Plan Usage tab from users without credits. Related assembla issue [BSFY-6](https://travisci.assembla.com/spaces/Bugfix-Service-FY-2022/tickets/realtime_cardwall?ticket=6)