### PR TITLE
Hid autorefill switch for free plans (#2644)

### DIFF
--- a/app/components/billing/auto-refill.js
+++ b/app/components/billing/auto-refill.js
@@ -41,7 +41,8 @@ export default Component.extend({
   show: computed('subscription', function () {
     let isOrganization = this.subscription.owner.get('isOrganization');
     let isAdmin = this.subscription.owner.get('permissions').admin;
-    return !(this.subscription.plan.get('isFree') || this.subscription.get('isManual') || (isOrganization && !isAdmin));
+    return !(this.subscription.plan.get('id') === 'free_tier_plan' || this.subscription.plan.get('id') === 'starter_plan'
+        || this.subscription.get('isManual') || isOrganization && !isAdmin);
   }),
 
   toggleAutoRefill: task(function* (value) {


### PR DESCRIPTION
* Hid autorefill switch for free plans

* Additional fix

* Revert unnecessary changes

* Revert unnecessary changes

* Deleted trailing spaces

* Break too long line into two lines

* Fix

Co-authored-by: Ivan Dmytrenko <dmytrenko.i.t@gmail.com>