### PR TITLE
Removed header/footer menus from login/sign-up pages on .com

### DIFF
--- a/app/components/page-footer.js
+++ b/app/components/page-footer.js
@@ -5,6 +5,7 @@ import { inject as service } from '@ember/service';
 import config from 'travis/config/environment';
 
 export default Component.extend({
+  router: service(),
   features: service(),
 
   config,

--- a/app/components/top-bar.js
+++ b/app/components/top-bar.js
@@ -13,6 +13,7 @@ export default Component.extend(InViewportMixin, {
   externalLinks: service(),
   features: service(),
   flashes: service(),
+  router: service(),
 
   tagName: 'header',
   classNames: ['top'],

--- a/app/templates/components/page-footer.hbs
+++ b/app/templates/components/page-footer.hbs
@@ -5,143 +5,145 @@
     </div>
   </div>
   <div class="footer-elem"></div>
-  {{#unless this.features.enterpriseVersion}}
-    <div class="footer-elem">
-      <h3 class="footer-title">
-        &copy;Travis CI, GmbH
-      </h3>
-      <address>
-        Rigaer Straße 8<br />
-        10247 Berlin, Germany
-      </address>
-      <ul>
-        <li>
-          <ExternalLinkTo
-            data-test-footer-jobs-link="true"
-            @href={{this.config.urls.jobs}}
-            @title="Jobs at Travis CI"
-          >
-            Work with Travis CI
-          </ExternalLinkTo>
-        </li>
-        <li>
-          <ExternalLinkTo
-            data-test-footer-blog-link="true"
-            @href={{this.config.urls.blog}}
-            @title="Travis CI Blog"
-          >
-            Blog
-          </ExternalLinkTo>
-        </li>
-        <li>
-          <ExternalLinkTo
-            data-test-footer-support-link="true"
-            @href={{this.config.urls.support}}
-            @title="Email Travis CI support"
-          >
-            Email
-          </ExternalLinkTo>
-        </li>
-        <li>
-          <ExternalLinkTo
-            data-test-footer-twitter-link="true"
-            @href={{this.config.urls.twitter}}
-            @title="Travis CI on Twitter"
-          >
-            Twitter
-          </ExternalLinkTo>
-        </li>
-      </ul>
-    </div>
-  {{/unless}}
-  <div class="footer-elem">
-    <h3 class="footer-title">
-      Help
-    </h3>
-    <ul>
-      <li>
-        <ExternalLinkTo
-          @href={{this.config.urls.docs}}
-          @title="Travis CI Docs"
-        >
-          Documentation
-        </ExternalLinkTo>
-      </li>
-      {{#unless this.features.enterpriseVersion}}
-        <li>
-          <ExternalLinkTo
-            data-test-footer-community-link="true"
-            @href={{this.config.urls.community}}
-            @title="Travis CI Community"
-          >
-            Community
-          </ExternalLinkTo>
-        </li>
-        <li>
-          <ExternalLinkTo
-            data-test-footer-changelog-link="true"
-            @href={{this.config.urls.changelog}}
-            @title="Travis CI Changelog"
-          >
-            Changelog
-          </ExternalLinkTo>
-        </li>
-        {{#if this.features.proVersion}}
+  {{#unless (and (or (eq this.router.currentRouteName 'signin') (eq this.router.currentRouteName 'signup') ) this.features.proVersion)}}
+    {{#unless this.features.enterpriseVersion}}
+      <div class="footer-elem">
+        <h3 class="footer-title">
+          &copy;Travis CI, GmbH
+        </h3>
+        <address>
+          Rigaer Straße 8<br />
+          10247 Berlin, Germany
+        </address>
+        <ul>
           <li>
-            <LinkTo
-              data-test-footer-plans-link="true"
-              @route='plans'
-              @title="Travis CI Plans"
+            <ExternalLinkTo
+              data-test-footer-jobs-link="true"
+              @href={{this.config.urls.jobs}}
+              @title="Jobs at Travis CI"
             >
-              Plans and Pricing
-            </LinkTo>
+              Work with Travis CI
+            </ExternalLinkTo>
           </li>
-        {{/if}}
-        <li>
-          <ExternalLinkTo
-            data-test-footer-travis-vs-jenkins-link="true"
-            @href={{this.config.urls.travisVsJenkins}}
-            @title="Travis CI vs Jenkins"
-          >
-            Travis CI vs Jenkins
-          </ExternalLinkTo>
-        </li>
-      {{/unless}}
-    </ul>
-  </div>
-  {{#unless this.features.enterpriseVersion}}
+          <li>
+            <ExternalLinkTo
+              data-test-footer-blog-link="true"
+              @href={{this.config.urls.blog}}
+              @title="Travis CI Blog"
+            >
+              Blog
+            </ExternalLinkTo>
+          </li>
+          <li>
+            <ExternalLinkTo
+              data-test-footer-support-link="true"
+              @href={{this.config.urls.support}}
+              @title="Email Travis CI support"
+            >
+              Email
+            </ExternalLinkTo>
+          </li>
+          <li>
+            <ExternalLinkTo
+              data-test-footer-twitter-link="true"
+              @href={{this.config.urls.twitter}}
+              @title="Travis CI on Twitter"
+            >
+              Twitter
+            </ExternalLinkTo>
+          </li>
+        </ul>
+      </div>
+    {{/unless}}
     <div class="footer-elem">
       <h3 class="footer-title">
-        Company
+        Help
       </h3>
       <ul>
         <li>
           <ExternalLinkTo
-            @href={{this.config.urls.imprint}}
-            @title="Imprint"
+            @href={{this.config.urls.docs}}
+            @title="Travis CI Docs"
           >
-            Imprint
+            Documentation
           </ExternalLinkTo>
         </li>
-        <li>
-          <ExternalLinkTo
-            @href={{this.config.urls.legal}}
-            @title="Legal"
-          >
-            Legal
-          </ExternalLinkTo>
-        </li>
+        {{#unless this.features.enterpriseVersion}}
+          <li>
+            <ExternalLinkTo
+              data-test-footer-community-link="true"
+              @href={{this.config.urls.community}}
+              @title="Travis CI Community"
+            >
+              Community
+            </ExternalLinkTo>
+          </li>
+          <li>
+            <ExternalLinkTo
+              data-test-footer-changelog-link="true"
+              @href={{this.config.urls.changelog}}
+              @title="Travis CI Changelog"
+            >
+              Changelog
+            </ExternalLinkTo>
+          </li>
+          {{#if this.features.proVersion}}
+            <li>
+              <LinkTo
+                data-test-footer-plans-link="true"
+                @route='plans'
+                @title="Travis CI Plans"
+              >
+                Plans and Pricing
+              </LinkTo>
+            </li>
+          {{/if}}
+          <li>
+            <ExternalLinkTo
+              data-test-footer-travis-vs-jenkins-link="true"
+              @href={{this.config.urls.travisVsJenkins}}
+              @title="Travis CI vs Jenkins"
+            >
+              Travis CI vs Jenkins
+            </ExternalLinkTo>
+          </li>
+        {{/unless}}
       </ul>
     </div>
-    <div class="footer-elem">
-      <h3 class="footer-title">
-        Travis CI Status
-      </h3>
-      <ul>
-        <li>
-          <TravisStatus @showDescription={{false}} />
-        </li>
-      </ul>
-    </div>
+    {{#unless this.features.enterpriseVersion}}
+      <div class="footer-elem">
+        <h3 class="footer-title">
+          Company
+        </h3>
+        <ul>
+          <li>
+            <ExternalLinkTo
+              @href={{this.config.urls.imprint}}
+              @title="Imprint"
+            >
+              Imprint
+            </ExternalLinkTo>
+          </li>
+          <li>
+            <ExternalLinkTo
+              @href={{this.config.urls.legal}}
+              @title="Legal"
+            >
+              Legal
+            </ExternalLinkTo>
+          </li>
+        </ul>
+      </div>
+      <div class="footer-elem">
+        <h3 class="footer-title">
+          Travis CI Status
+        </h3>
+        <ul>
+          <li>
+            <TravisStatus @showDescription={{false}} />
+          </li>
+        </ul>
+      </div>
+    {{/unless}}
   {{/unless}}
 </div>

--- a/app/templates/components/top-bar.hbs
+++ b/app/templates/components/top-bar.hbs
@@ -7,7 +7,9 @@
     />
   </h1>
   <HeaderBroadcasts @showBroadcasts={{this.showBroadcasts}} />
-  <HeaderLinks @isOpen={{this.isNavigationOpen}} />
+  {{#unless (and (or (eq this.router.currentRouteName 'signin') (eq this.router.currentRouteName 'signup') ) this.features.proVersion)}}
+    <HeaderLinks @isOpen={{this.isNavigationOpen}} />
+  {{/unless}}
   <ProfileMenu />
 </div>
 {{#if this.isUnconfirmed}}


### PR DESCRIPTION
Removed Header and Footer menus on Login and Sign-up pages only for .com

Screenshots from Local server.
<img width="1223" alt="Screenshot 2022-05-12 at 10 47 52 AM" src="https://user-images.githubusercontent.com/104836571/168039428-58ce382d-0ed7-4fbe-b34b-5363bddd105c.png">
<img width="1150" alt="Screenshot 2022-05-12 at 10 48 03 AM" src="https://user-images.githubusercontent.com/104836571/168039499-9ac27097-d3e7-47bc-9d30-508d51d5d623.png">


