### PR TITLE
PDTQ-163 - [Pricing] travis-web - everywhere on plans page format number of credits to be more readable

### DIFF
--- a/app/helpers/format-number.js
+++ b/app/helpers/format-number.js
@@ -1,12 +1,16 @@
 import { helper } from '@ember/component/helper';
 
-export function formatCurrency(value) {
+export function formatNumber(value) {
   const parsedValue = Number(value);
   if (isNaN(parsedValue)) {
     return value;
   }
 
-  return parsedValue.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  const browserLanguage = navigator.languages && navigator.languages.length ? navigator.languages[0] : navigator.language;
+  let formatter = new Intl.NumberFormat(browserLanguage);
+  let formattedNumber = formatter.format(parsedValue);
+
+  return formattedNumber;
 }
 
-export default helper(formatCurrency);
+export default helper(formatNumber);

--- a/app/templates/components/billing/auto-refill.hbs
+++ b/app/templates/components/billing/auto-refill.hbs
@@ -10,7 +10,7 @@
   </span>
   <p class="auto-refill-description">
   Enable this option to ensure you never run out of credits and prevent unexpected builds stops.
-  With this feature enabled, whenever your credit balance goes below {{this.autoRefillMinimumCredits}} credits, your account will be replenished with {{this.autoRefillCredits}} credits purchased at the cost of ${{this.autoRefillPrice}}.
+  With this feature enabled, whenever your credit balance goes below {{format-number this.autoRefillMinimumCredits}} credits, your account will be replenished with {{format-number this.autoRefillCredits}} credits purchased at the cost of ${{this.autoRefillPrice}}.
   Auto-refill works with debit/credit cards. Read the <ExternalLinkTo @href={{config-get 'urls.docs'}} @title="Travis CI Docs">documentation</ExternalLinkTo> for more information.
   </p>
   {{#if this.autoRefillEnabled}}
@@ -22,7 +22,7 @@
           onclick={{action (mut this.selectedThreshold) value}}
         >
           <p class='billing-refill__box--value'>
-            {{value}}
+            {{format-number value}}
           </p>
           <p class='billing-refill__box--description'>
             Credits
@@ -38,7 +38,7 @@
           onclick={{action (mut this.selectedAmount) value.amount}}
         >
           <p class='billing-refill__box--value'>
-            {{value.amount}}
+            {{format-number value.amount}}
           </p>
           <p class='billing-refill__box--description'>
             Credits - {{format-currency value.price floor="true"}}

--- a/app/templates/components/billing/credit-balance.hbs
+++ b/app/templates/components/billing/credit-balance.hbs
@@ -25,15 +25,15 @@
   <p class='avail-credits'>
     {{#if (eq this.creditsTab 1)}}
       {{#if (eq this.creditsAvailable 0)}}
-        {{this.creditsAvailable}} available credits
+        {{format-number this.creditsAvailable}} available credits
       {{else}}
-        {{this.creditsAvailable}} available credits (next replenish date: {{moment-format this.creditsPublicValidDate 'MMMM DD, YYYY'}})
+        {{format-number this.creditsAvailable}} available credits (next replenish date: {{moment-format this.creditsPublicValidDate 'MMMM DD, YYYY'}})
       {{/if}}
     {{else}}
       {{#if this.subscription.isCanceled}}
-        {{this.creditsAvailable}} available credits (expiry date: {{moment-format this.creditsValidityDate 'MMMM DD, YYYY'}})
+        {{format-number this.creditsAvailable}} available credits (expiry date: {{moment-format this.creditsValidityDate 'MMMM DD, YYYY'}})
       {{else}}
-        {{this.creditsAvailable}} available credits (purchase date: {{moment-format this.creditsPrivatePurchaseDate 'MMMM DD, YYYY'}}
+        {{format-number this.creditsAvailable}} available credits (purchase date: {{moment-format this.creditsPrivatePurchaseDate 'MMMM DD, YYYY'}}
       {{#if this.creditsPrivateValidDate}}
         , valid until: {{moment-format this.creditsPrivateValidDate 'MMMM DD, YYYY'}}
       {{/if}})
@@ -42,9 +42,9 @@
   </p>
   <p class='used-credits'>
     {{#if (eq this.creditsTab 1)}}
-      You have used {{this.creditsUsed}} of your {{this.creditsTotal}} monthly credits
+      You have used {{format-number this.creditsUsed}} of your {{format-number this.creditsTotal}} monthly credits
     {{else}}
-      You have used {{this.creditsUsed}} of {{this.creditsTotal}} credits
+      You have used {{format-number this.creditsUsed}} of {{format-number this.creditsTotal}} credits
     {{/if}}
   </p>
   <div class='credits-bar-bg'>
@@ -55,7 +55,7 @@
     {{/if}}
   </div>
   <p class='credits-bar-left'>
-    {{this.creditsAvailable}} available <span class='credits-bar-right'>{{this.creditsUsed}} used</span>
+    {{format-number this.creditsAvailable}} available <span class='credits-bar-right'>{{format-number this.creditsUsed}} used</span>
   </p>
   {{#if (not this.hideToggle)}}
     <Billing::OssCreditToggle @account={{this.account}} />

--- a/app/templates/components/billing/first-plan.hbs
+++ b/app/templates/components/billing/first-plan.hbs
@@ -177,18 +177,18 @@
 
           {{#if this.selectedPlan.hasOSSCreditAddons}}
           <p class='billing-plans__box-v2--desc' data-test-selected-plan-oss-credits="true">
-            <SvgImage @name="stage-passed" @class="icon icon-desc" /> {{this.selectedPlan.publicCredits}} OSS Credits<span
+            <SvgImage @name="stage-passed" @class="icon icon-desc" /> {{format-number  this.selectedPlan.publicCredits}} OSS Credits<span
               class='color-cement-grey'>/month</span>
           </p>
           {{/if}}
           {{#if this.selectedPlan.hasCreditAddons}}
           <p class='selected-plan__details--desc' data-test-selected-plan-credits>
-            {{this.selectedPlan.privateCreditsTotal}} Credits
+            {{format-number this.selectedPlan.privateCreditsTotal}} Credits
           </p>
           {{/if}}
           {{#if this.selectedPlan.hasOSSCreditAddons}}
           <p class='selected-plan__details--desc' data-test-selected-plan-oss-credits>
-            {{this.selectedPlan.publicCredits}} OSS Only Credits<span class='color-cement-grey'>/month</span>
+            {{format-number this.selectedPlan.publicCredits}} OSS Only Credits<span class='color-cement-grey'>/month</span>
           </p>
           {{/if}}
           {{#if this.selectedPlan.hasUserLicenseAddons}}
@@ -203,7 +203,7 @@
               Unlimited unique users.
               {{/if}}
             {{else}}
-            Up to {{this.selectedPlan.startingUsers}} unique users
+            Up to {{format-number this.selectedPlan.startingUsers}} unique users
           <div data-test-selected-plan-period='true' class='selected-plan__period'>
             Charged monthly per usage - check pricing
           </div>

--- a/app/templates/components/billing/select-addon.hbs
+++ b/app/templates/components/billing/select-addon.hbs
@@ -30,7 +30,7 @@
                 {{/if}}
               </p>
               <p class='billing-plans__addons_box--desc color-asphalt-grey' data-test-selected-addon-desc>
-                {{addon.quantity}}
+                {{format-number addon.quantity}}
                 {{#if (eq addon.type 'user_license')}}
                   user licenses
                 {{else}}

--- a/app/templates/components/billing/selected-plan.hbs
+++ b/app/templates/components/billing/selected-plan.hbs
@@ -5,12 +5,12 @@
     </p>
     {{#if this.selectedPlan.hasCreditAddons}}
       <p class='selected-plan__details--desc' data-test-selected-plan-credits>
-        {{this.selectedPlan.privateCreditsTotal}} Credits
+        {{format-number this.selectedPlan.privateCreditsTotal}} Credits
       </p>
     {{/if}}
     {{#if this.selectedPlan.hasOSSCreditAddons}}
       <p class='selected-plan__details--desc' data-test-selected-plan-oss-credits>
-        {{this.selectedPlan.publicCredits}} OSS Only Credits<span class='color-cement-grey'>/month</span>
+        {{format-number this.selectedPlan.publicCredits}} OSS Only Credits<span class='color-cement-grey'>/month</span>
       </p>
     {{/if}}
     {{#if this.selectedPlan.hasUserLicenseAddons}}
@@ -25,7 +25,7 @@
             Unlimited unique users.
           {{/if}}
         {{else}}
-          Up to {{this.selectedPlan.startingUsers}} unique users
+          Up to {{format-number this.selectedPlan.startingUsers}} unique users
           <div data-test-selected-plan-period='true' class='selected-plan__period'>
             Charged monthly per usage - check pricing
           </div>

--- a/tests/acceptance/profile/billing-test.js
+++ b/tests/acceptance/profile/billing-test.js
@@ -362,9 +362,9 @@ module('Acceptance | profile/billing', function (hooks) {
     await selectedPlan.subscribeButton.click();
 
     assert.equal(profilePage.billing.selectedPlanOverview.name.text, `${this.defaultV2Plan.name}`);
-    assert.equal(profilePage.billing.selectedPlanOverview.credits.text, `${this.defaultV2Plan.privateCredits * (this.defaultV2Plan.isAnnual ? 12 : 1)} Credits`);
+    assert.equal(profilePage.billing.selectedPlanOverview.credits.text, `${(this.defaultV2Plan.privateCredits * (this.defaultV2Plan.isAnnual ? 12 : 1)).toLocaleString()} Credits`);
     assert.equal(profilePage.billing.selectedPlanOverview.price.text, `$${this.defaultV2Plan.startingPrice / 100}`);
-    assert.equal(profilePage.billing.selectedPlanOverview.osscredits.text, `${this.defaultV2Plan.publicCredits} OSS Only Credits/month`);
+    assert.equal(profilePage.billing.selectedPlanOverview.osscredits.text, `${(this.defaultV2Plan.publicCredits).toLocaleString()} OSS Only Credits/month`);
     assert.equal(profilePage.billing.selectedPlanOverview.users.text, `Up to ${this.defaultV2Plan.startingUsers} unique users Charged monthly per usage - check pricing`);
     assert.equal(profilePage.billing.selectedPlanOverview.changePlan.text, 'Change plan');
 
@@ -979,9 +979,9 @@ module('Acceptance | profile/billing', function (hooks) {
 
 
     assert.equal(profilePage.billing.selectedPlanOverview.name.text, `${this.defaultV2Plan.name}`);
-    assert.equal(profilePage.billing.selectedPlanOverview.credits.text, `${this.defaultV2Plan.privateCredits * (this.defaultV2Plan.isAnnual ? 12 : 1)} Credits`);
+    assert.equal(profilePage.billing.selectedPlanOverview.credits.text, `${(this.defaultV2Plan.privateCredits * (this.defaultV2Plan.isAnnual ? 12 : 1)).toLocaleString()} Credits`);
     assert.equal(profilePage.billing.selectedPlanOverview.price.text, `$${this.defaultV2Plan.startingPrice / 100}`);
-    assert.equal(profilePage.billing.selectedPlanOverview.osscredits.text, `${this.defaultV2Plan.publicCredits} OSS Only Credits/month`);
+    assert.equal(profilePage.billing.selectedPlanOverview.osscredits.text, `${(this.defaultV2Plan.publicCredits).toLocaleString()} OSS Only Credits/month`);
     assert.equal(profilePage.billing.selectedPlanOverview.users.text, `Up to ${this.defaultV2Plan.startingUsers} unique users Charged monthly per usage - check pricing`);
     assert.equal(profilePage.billing.selectedPlanOverview.changePlan.text, 'Change plan');
 
@@ -1038,9 +1038,9 @@ module('Acceptance | profile/billing', function (hooks) {
     await profilePage.billing.selectedPlan.subscribeButton.click();
 
     assert.equal(profilePage.billing.selectedPlanOverview.name.text, `${this.defaultV2Plan.name}`);
-    assert.equal(profilePage.billing.selectedPlanOverview.credits.text, `${this.defaultV2Plan.privateCredits * (this.defaultV2Plan.isAnnual ? 12 : 1)} Credits`);
+    assert.equal(profilePage.billing.selectedPlanOverview.credits.text, `${(this.defaultV2Plan.privateCredits * (this.defaultV2Plan.isAnnual ? 12 : 1)).toLocaleString()} Credits`);
     assert.equal(profilePage.billing.selectedPlanOverview.price.text, `$${this.defaultV2Plan.startingPrice / 100}`);
-    assert.equal(profilePage.billing.selectedPlanOverview.osscredits.text, `${this.defaultV2Plan.publicCredits} OSS Only Credits/month`);
+    assert.equal(profilePage.billing.selectedPlanOverview.osscredits.text, `${(this.defaultV2Plan.publicCredits).toLocaleString()} OSS Only Credits/month`);
     assert.equal(profilePage.billing.selectedPlanOverview.users.text, `Up to ${this.defaultV2Plan.startingUsers} unique users Charged monthly per usage - check pricing`);
     assert.equal(profilePage.billing.selectedPlanOverview.changePlan.text, 'Change plan');
   });
@@ -1055,9 +1055,9 @@ module('Acceptance | profile/billing', function (hooks) {
     await profilePage.billing.selectedPlan.subscribeButton.click();
 
     assert.equal(profilePage.billing.selectedPlanOverview.name.text, `${this.defaultV2Plan.name}`);
-    assert.equal(profilePage.billing.selectedPlanOverview.credits.text, `${this.defaultV2Plan.privateCredits * (this.defaultV2Plan.isAnnual ? 12 : 1)} Credits`);
+    assert.equal(profilePage.billing.selectedPlanOverview.credits.text, `${(this.defaultV2Plan.privateCredits * (this.defaultV2Plan.isAnnual ? 12 : 1)).toLocaleString()} Credits`);
     assert.equal(profilePage.billing.selectedPlanOverview.price.text, `$${this.defaultV2Plan.startingPrice / 100}`);
-    assert.equal(profilePage.billing.selectedPlanOverview.osscredits.text, `${this.defaultV2Plan.publicCredits} OSS Only Credits/month`);
+    assert.equal(profilePage.billing.selectedPlanOverview.osscredits.text, `${(this.defaultV2Plan.publicCredits).toLocaleString()} OSS Only Credits/month`);
     assert.equal(profilePage.billing.selectedPlanOverview.users.text, `Up to ${this.defaultV2Plan.startingUsers} unique users Charged monthly per usage - check pricing`);
     assert.equal(profilePage.billing.selectedPlanOverview.changePlan.text, 'Change plan');
 
@@ -1324,9 +1324,9 @@ module('Acceptance | profile/billing', function (hooks) {
     await billingForm.proceedPayment.click();
 
     assert.equal(profilePage.billing.selectedPlanOverview.name.text, `${this.defaultV2Plan.name}`);
-    assert.equal(profilePage.billing.selectedPlanOverview.credits.text, `${this.defaultV2Plan.privateCredits * (this.defaultV2Plan.isAnnual ? 12 : 1)} Credits`);
+    assert.equal(profilePage.billing.selectedPlanOverview.credits.text, `${(this.defaultV2Plan.privateCredits * (this.defaultV2Plan.isAnnual ? 12 : 1)).toLocaleString()} Credits`);
     assert.equal(profilePage.billing.selectedPlanOverview.price.text, `$${this.defaultV2Plan.startingPrice / 100}`);
-    assert.equal(profilePage.billing.selectedPlanOverview.osscredits.text, `${this.defaultV2Plan.publicCredits} OSS Only Credits/month`);
+    assert.equal(profilePage.billing.selectedPlanOverview.osscredits.text, `${(this.defaultV2Plan.publicCredits).toLocaleString()} OSS Only Credits/month`);
     assert.equal(profilePage.billing.selectedPlanOverview.users.text, `Up to ${this.defaultV2Plan.startingUsers} unique users Charged monthly per usage - check pricing`);
     assert.equal(profilePage.billing.selectedPlanOverview.changePlan.text, 'Change plan');
 
@@ -1394,9 +1394,9 @@ module('Acceptance | profile/billing', function (hooks) {
     await billingForm.proceedPayment.click();
 
     assert.equal(profilePage.billing.selectedPlanOverview.name.text, `${this.defaultV2Plan.name}`);
-    assert.equal(profilePage.billing.selectedPlanOverview.credits.text, `${this.defaultV2Plan.privateCredits * (this.defaultV2Plan.isAnnual ? 12 : 1)} Credits`);
+    assert.equal(profilePage.billing.selectedPlanOverview.credits.text, `${(this.defaultV2Plan.privateCredits * (this.defaultV2Plan.isAnnual ? 12 : 1)).toLocaleString()} Credits`);
     assert.equal(profilePage.billing.selectedPlanOverview.price.text, `$${this.defaultV2Plan.startingPrice / 100}`);
-    assert.equal(profilePage.billing.selectedPlanOverview.osscredits.text, `${this.defaultV2Plan.publicCredits} OSS Only Credits/month`);
+    assert.equal(profilePage.billing.selectedPlanOverview.osscredits.text, `${(this.defaultV2Plan.publicCredits).toLocaleString()} OSS Only Credits/month`);
     assert.equal(profilePage.billing.selectedPlanOverview.users.text, `Up to ${this.defaultV2Plan.startingUsers} unique users Charged monthly per usage - check pricing`);
     assert.equal(profilePage.billing.selectedPlanOverview.changePlan.text, 'Change plan');
 
@@ -1473,9 +1473,9 @@ module('Acceptance | profile/billing', function (hooks) {
     await billingForm.proceedPayment.click();
 
     assert.equal(profilePage.billing.selectedPlanOverview.name.text, `${this.defaultV2Plan.name}`);
-    assert.equal(profilePage.billing.selectedPlanOverview.credits.text, `${this.defaultV2Plan.privateCredits * (this.defaultV2Plan.isAnnual ? 12 : 1)} Credits`);
+    assert.equal(profilePage.billing.selectedPlanOverview.credits.text, `${(this.defaultV2Plan.privateCredits * (this.defaultV2Plan.isAnnual ? 12 : 1)).toLocaleString()} Credits`);
     assert.equal(profilePage.billing.selectedPlanOverview.price.text, `$${this.defaultV2Plan.startingPrice / 100}`);
-    assert.equal(profilePage.billing.selectedPlanOverview.osscredits.text, `${this.defaultV2Plan.publicCredits} OSS Only Credits/month`);
+    assert.equal(profilePage.billing.selectedPlanOverview.osscredits.text, `${(this.defaultV2Plan.publicCredits).toLocaleString()} OSS Only Credits/month`);
     assert.equal(profilePage.billing.selectedPlanOverview.users.text, `Up to ${this.defaultV2Plan.startingUsers} unique users Charged monthly per usage - check pricing`);
     assert.equal(profilePage.billing.selectedPlanOverview.changePlan.text, 'Change plan');
 

--- a/tests/integration/components/billing/select-addon-test.js
+++ b/tests/integration/components/billing/select-addon-test.js
@@ -47,7 +47,7 @@ module('Integration | Component | billing-select-addon', function (hooks) {
     );
 
     assert.equal(profilePage.billing.selectedAddon.name.text, 'Additional credits');
-    assert.equal(profilePage.billing.selectedAddon.desc.text, `${this.addon1.quantity} credits`);
+    assert.equal(profilePage.billing.selectedAddon.desc.text, `${(this.addon1.quantity.toLocaleString())} credits`);
     assert.equal(profilePage.billing.selectedAddon.price.text, `$${this.addon1.price / 100}`);
   });
 });


### PR DESCRIPTION
Formatted number of credits to separate thousands parts, e.g. 30 000 (many EU countries, US too) or 30,000 (EU countries/accounting formats)

changes made in:
- plan selection
- after plan is selected
- when showing pool of credits vs used credits on plan page
- addons selection page
- auto-refill boxes