### PR TITLE
PDTQ161 - [Pricing] 10M users in plan page in travis-web instead of 'unlimited'

### DIFF
--- a/app/models/v2-plan-config.js
+++ b/app/models/v2-plan-config.js
@@ -1,6 +1,6 @@
 import Model, { attr } from '@ember-data/model';
 import { computed } from '@ember/object';
-import { equal, or } from '@ember/object/computed';
+import { equal, or, gte } from '@ember/object/computed';
 
 export default Model.extend({
   name: attr('string'),
@@ -23,7 +23,7 @@ export default Model.extend({
   isProTier: equal('id', 'standard_tier_plan'),
   isStandardTier: equal('id', 'pro_tier_plan'),
 
-  isUnlimitedUsers: equal('startingUsers', 999999),
+  isUnlimitedUsers: gte('startingUsers', 999999),
 
   isAnnual: equal('annual', true),
 


### PR DESCRIPTION
#[PDTQ-161](https://travisci.assembla.com/spaces/Product-and-Dev-Tickets-Queue/tickets/161--pricing--10m-users-in-plan-page-in-travis-web-instead-of---39-unlimited--39/details
) - [Pricing] 10M users in plan page in travis-web instead of 'unlimited'