### PR TITLE
[Hotfix] Sort available plans on first-plan and when plan is expired for more than a month

### DIFF
--- a/app/components/billing/select-plan.js
+++ b/app/components/billing/select-plan.js
@@ -51,11 +51,11 @@ export default Component.extend({
 
   displayedPlans: computed('availablePlans.[]', 'subscription.plan.startingPrice', function () {
     if (!this.subscription || !this.subscription.plan || this.subscription.plan.trialPlan) {
-      return this.availablePlans;
+      return this.sortedPlans;
     }
 
     if (this.isCancellationMoreThanOneMonthOld || this.isValidityMoreThanOneMonthOld) {
-      return this.availablePlans;
+      return this.sortedPlans;
     }
 
     let allowedHybridPlans = this.availablePlans.filter(plan => plan.planType.includes('hybrid'));


### PR DESCRIPTION
Continuation of https://github.com/travis-ci/travis-web/pull/2862
Missed sorting plans on these scenarios:
- first-plan: account_activation page > "Change Plan" modal
- when plan is expired for more than a month