### PR TITLE
[Readme] removed ember beta and canary deployments instruction from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,18 +144,6 @@ The Redis server is a modified version of `waiter/lib/travis/web/app.rb`. We wil
 that with [`travis-web-index`](https://github.com/travis-ci/travis-web-index) and move to using
 `ember-cli-deploy` for all deployments.
 
-### Ember beta and canary deployments
-
-Upon a merge to `master`, the application is built with the latest beta and canary versions
-of Ember, running against the production API. This uses the same infrastructure as the
-pull request deployments. You can visit these deployments at:
-* https://ember-beta.travis-ci.org
-* https://ember-beta.travis-ci.com
-* https://ember-canary.travis-ci.org
-* https://ember-canary.travis-ci.com
-
-These deployments are also performed with the weekly cron build.
-
 
 ### Ask Travis updates
 


### PR DESCRIPTION
removed ember beta and canary deployments instruction from readme