### PR TITLE
Fix validto computed property infinite calls problem

### DIFF
--- a/app/components/billing/summary-v2.js
+++ b/app/components/billing/summary-v2.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
+import { computed, observer } from '@ember/object';
 import { reads, or, not, and, bool } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import isCurrentTrial from 'travis/utils/computed-is-current-trial';
@@ -25,7 +25,12 @@ export default Component.extend({
   isSubscribed: computed('subscription.isSubscribed', function () {
     return this.subscription.isSubscribed;
   }),
-  validto: computed('subscription.validTo', function () {
+  validto: computed('subscription.validTo', 'subscription.validToFromAddon', function () {
+    return this.subscription.validToFromAddon || this.subscription.validTo;
+  }),
+
+  // Use an observer to fetch subscriptions if `subscription.validTo` is null
+  onValidToChange: observer('subscription.validTo', function () {
     try {
       if (this.subscription.validTo == null) {
         this.accounts.fetchV2Subscriptions.perform();
@@ -33,7 +38,6 @@ export default Component.extend({
     } catch (e) {
       console.log(e);
     }
-    return this.subscription.validToFromAddon || this.subscription.validTo;
   }),
   isCurrentTrial: isCurrentTrial(),
   isExpired: or('subscription.isExpired', 'subscription.subscriptionExpiredByDate'),


### PR DESCRIPTION
When subscription/v2-plan in DB has valid_to null, the /plan page make infinite calls to v_subscriptions and causing the page unresponsive.

The computed property is causing infinite calls because it depends on subscription.validTo, and within the computation, it makes a call to fetchV2Subscriptions.perform(), which likely modifies subscription.validTo. This causes the computed property to re-evaluate, leading to an infinite loop.


**Fixed Approach with an Observer:**
Ensure fetchV2Subscriptions doesn't modify subscription.validTo directly within the computed property, as this triggers recomputation.
Use computed properties for deriving state, and use observer to avoid side effect like fetching data.